### PR TITLE
fix for after-bolus crash

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -147,7 +147,6 @@ final class StatusTableViewController: UITableViewController, UIGestureRecognize
             charts.startDate = Calendar.current.nextDate(after: date, matching: components, matchingPolicy: .strict, direction: .backward) ?? date
 
             let reloadGroup = DispatchGroup()
-            let oldRecommendedTempBasal = self.recommendedTempBasal
             var newRecommendedTempBasal: LoopDataManager.TempBasalRecommendation?
 
             if let glucoseStore = dataManager.glucoseStore {
@@ -274,6 +273,7 @@ final class StatusTableViewController: UITableViewController, UIGestureRecognize
                 self.charts.prerender()
 
                 // Show/hide the recommended temp basal row
+                let oldRecommendedTempBasal = self.recommendedTempBasal
                 self.recommendedTempBasal = newRecommendedTempBasal
                 switch (oldRecommendedTempBasal, newRecommendedTempBasal) {
                 case (let old?, let new?) where old != new:


### PR DESCRIPTION
Fixes #233

Multiple updates have the potential to interleave, due to being managed by dispatch_groups. Therefore two updates first read the state of the temp basal (e.g. both read nil), then when their async completion runs, the first one sets the temp basal to non-nil and the UITableView is fine, but then the  second one also sets it to non-nil and attempts to insert an extra row in the table view.

