### PR TITLE
Properly support mmol/L in the status extension.

### DIFF
--- a/Loop Status Extension/HKUnit.swift
+++ b/Loop Status Extension/HKUnit.swift
@@ -8,10 +8,11 @@
 
 import HealthKit
 
+// Code in this extension is duplicated from:
+//   https://github.com/LoopKit/LoopKit/blob/master/LoopKit/HKUnit.swift
+// to avoid pulling in the LoopKit extension since it's not extension-API safe.
 public extension HKUnit {
     // A formatting helper for determining the preferred decimal style for a given unit
-    // This is similar to the LoopKit HKUnit extension, but copied here so that we can
-    // avoid a dependency on LoopKit from the Loop Status Extension.
     var preferredMinimumFractionDigits: Int {
         if self.unitString == "mg/dL" {
             return 0
@@ -19,4 +20,18 @@ public extension HKUnit {
             return 1
         }
     }
+    
+    static func millimolesPerLiterUnit() -> HKUnit {
+        return HKUnit.moleUnit(with: .milli, molarMass: HKUnitMolarMassBloodGlucose).unitDivided(by: HKUnit.liter())
+    }
+    
+    // A glucose-centric presentation helper for the localized unit string
+    var glucoseUnitDisplayString: String {
+        if self == HKUnit.millimolesPerLiterUnit() {
+            return NSLocalizedString("mmol/L", comment: "The unit display string for millimoles of glucose per liter")
+        } else {
+            return String(describing: self)
+        }
+    }
+
 }

--- a/Loop Status Extension/StatusExtensionContext.swift
+++ b/Loop Status Extension/StatusExtensionContext.swift
@@ -117,8 +117,8 @@ final class StatusExtensionContext: NSObject, RawRepresentable {
 
         raw["preferredUnitString"] = preferredUnitString
         
-        if let glucose = latestGlucose,
-           preferredUnitString != nil {
+        if preferredUnitString != nil,
+            let glucose = latestGlucose {
             raw["latestGlucose_value"] = glucose.quantity
             raw["latestGlucose_startDate"] = glucose.startDate
         }

--- a/Loop Status Extension/StatusExtensionContext.swift
+++ b/Loop Status Extension/StatusExtensionContext.swift
@@ -44,7 +44,7 @@ final class StatusExtensionContext: NSObject, RawRepresentable {
     typealias RawValue = [String: Any]
     private let version = 1
     
-    var preferredUnitDisplayString: String?
+    var preferredUnitString: String?
     var latestGlucose: GlucoseContext?
     var reservoir: ReservoirContext?
     var loop: LoopContext?
@@ -60,7 +60,7 @@ final class StatusExtensionContext: NSObject, RawRepresentable {
         super.init()
         let raw = rawValue
         
-        if let preferredString = raw["preferredUnitDisplayString"] as? String,
+        if let preferredString = raw["preferredUnitString"] as? String,
            let latestValue = raw["latestGlucose_value"] as? Double,
            let startDate = raw["latestGlucose_startDate"] as? Date {
  
@@ -81,7 +81,7 @@ final class StatusExtensionContext: NSObject, RawRepresentable {
                     isLocal: local)
             }
             
-            preferredUnitDisplayString = preferredString
+            preferredUnitString = preferredString
             latestGlucose = GlucoseContext(
                 quantity: latestValue,
                 startDate: startDate,
@@ -115,10 +115,10 @@ final class StatusExtensionContext: NSObject, RawRepresentable {
             "version": version
         ]
 
-        raw["preferredUnitDisplayString"] = preferredUnitDisplayString
+        raw["preferredUnitString"] = preferredUnitString
         
         if let glucose = latestGlucose,
-           preferredUnitDisplayString != nil {
+           preferredUnitString != nil {
             raw["latestGlucose_value"] = glucose.quantity
             raw["latestGlucose_startDate"] = glucose.startDate
         }

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -43,7 +43,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
         // the wrong units and that could be very harmful. So unless there's a preferred
         // unit, assume that none of the rest of the data is reliable.
         guard
-            let preferredUnitDisplayString = context.preferredUnitDisplayString
+            let preferredUnitString = context.preferredUnitString
         else {
             completionHandler(NCUpdateResult.failed)
             return
@@ -52,7 +52,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
         if let glucose = context.latestGlucose {
             glucoseHUD.set(glucoseQuantity: glucose.quantity,
                            at: glucose.startDate,
-                           unitDisplayString: preferredUnitDisplayString,
+                           unitString: preferredUnitString,
                            from: glucose.sensor)
         }
         
@@ -74,14 +74,16 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             loopCompletionHUD.lastLoopCompleted = loop.lastCompleted
         }
 
-        if let eventualGlucose = context.eventualGlucose {
-            let quantity = HKQuantity(unit: HKUnit(from: preferredUnitDisplayString),
-                                      doubleValue: eventualGlucose.rounded())
+        let preferredUnit = HKUnit(from: preferredUnitString)
+        let formatter = NumberFormatter.glucoseFormatter(for: preferredUnit)
+        if let eventualGlucose = context.eventualGlucose,
+           let eventualGlucoseNumberString = formatter.string(from: NSNumber(value: eventualGlucose)) {
             subtitleLabel.text = String(
                     format: NSLocalizedString(
-                        "Eventually %@",
-                        comment: "The subtitle format describing eventual glucose. (1: localized glucose value description)"),
-                    String(describing: quantity))
+                        "Eventually %1$@ %2$@",
+                        comment: "The subtitle format describing eventual glucose. (1: localized glucose value description) (2: localized glucose units description)"),
+                    eventualGlucoseNumberString,
+                    preferredUnit.glucoseUnitDisplayString)
             subtitleLabel.alpha = 1
         } else {
             subtitleLabel.alpha = 0

--- a/Loop/Managers/StatusExtensionDataManager.swift
+++ b/Loop/Managers/StatusExtensionDataManager.swift
@@ -57,10 +57,11 @@ final class StatusExtensionDataManager {
                 context.batteryPercentage = 0.25
                 context.reservoir = ReservoirContext(startDate: Date(), unitVolume: 42.5, capacity: 200)
                 context.netBasal = NetBasalContext(rate: 2.1, percentage: 0.6, startDate: Date() - TimeInterval(250))
-                context.eventualGlucose = 119.123
+                context.eventualGlucose = HKQuantity(unit: HKUnit.milligramsPerDeciliterUnit(), doubleValue: 119.123)
+                    .doubleValue(for: preferredUnit)
             #endif
 
-            context.preferredUnitDisplayString = preferredUnit.glucoseUnitDisplayString
+            context.preferredUnitString = preferredUnit.unitString
             context.loop = LoopContext(
                 dosingEnabled: dataManager.loopManager.dosingEnabled,
                 lastCompleted: lastLoopCompleted)

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -269,7 +269,7 @@ final class StatusTableViewController: UITableViewController, UIGestureRecognize
                 if let glucose = self.dataManager.glucoseStore?.latestGlucose {
                     self.glucoseHUD.set(glucoseQuantity: glucose.quantity.doubleValue(for: self.charts.glucoseUnit),
                                         at: glucose.startDate,
-                                        unitDisplayString: self.charts.glucoseUnit.glucoseUnitDisplayString,
+                                        unitString: self.charts.glucoseUnit.unitString,
                                         from: self.dataManager.sensorInfo)
                 }
 

--- a/Loop/Views/GlucoseHUDView.swift
+++ b/Loop/Views/GlucoseHUDView.swift
@@ -64,19 +64,20 @@ final class GlucoseHUDView: HUDView {
         }
     }
 
-    func set(glucoseQuantity: Double, at glucoseStartDate: Date, unitDisplayString: String, from sensor: SensorDisplayable?) {
+    func set(glucoseQuantity: Double, at glucoseStartDate: Date, unitString: String, from sensor: SensorDisplayable?) {
         var accessibilityStrings = [String]()
 
         let time = timeFormatter.string(from: glucoseStartDate)
         caption?.text = time
+        let unit = HKUnit(from: unitString)
 
-        let numberFormatter = NumberFormatter.glucoseFormatter(for: HKUnit(from: unitDisplayString))
+        let numberFormatter = NumberFormatter.glucoseFormatter(for: unit)
         if let valueString = numberFormatter.string(from: NSNumber(value: glucoseQuantity)) {
             glucoseLabel.text = valueString
             accessibilityStrings.append(String(format: NSLocalizedString("%1$@ at %2$@", comment: "Accessbility format value describing glucose: (1: glucose number)(2: glucose time)"), valueString, time))
         }
 
-        var unitStrings = [unitDisplayString]
+        var unitStrings = [unit.glucoseUnitDisplayString]
 
         if let trend = sensor?.trendType {
             unitStrings.append(trend.symbol)


### PR DESCRIPTION
Pass the raw HKUnit.unitString (eg. mmol<180.1558800000541>/L) through
the context, as opposed to the unitDisplayString which is uses the
glucose-centric version (eg. mmol/L). This way we can properly hydrate
the unit on the extension side and represent it in the extension.

Fixes #311.