### PR TITLE
Fix widget battery level for x22 pumps

### DIFF
--- a/Loop/Managers/StatusExtensionDataManager.swift
+++ b/Loop/Managers/StatusExtensionDataManager.swift
@@ -91,8 +91,8 @@ final class StatusExtensionDataManager {
                     capacity: capacity)
             }
             
-            if let batteryPercentage = dataManager.latestPumpStatusFromMySentry?.batteryRemainingPercent {
-                context.batteryPercentage = Double(batteryPercentage) / 100.0
+            if let batteryPercentage = dataManager.pumpBatteryChargeRemaining {
+                context.batteryPercentage = batteryPercentage
             }
         
             if let lastPoint = predictedGlucose?.last {


### PR DESCRIPTION
This change fixes the lock screen widget battery level to work with MiniMed x22 pumps, which do not send MySentry packets.  I believe that this covers issue #325.  The change just makes use of the work done for issue #141 - thanks to the team for that great work!  (Note that I have not been able to test this for regression against x23 model pumps as I do not have one.)