### PR TITLE
Fix broken build.

### DIFF
--- a/Loop/Extensions/NSBundle.swift
+++ b/Loop/Extensions/NSBundle.swift
@@ -22,6 +22,10 @@ extension Bundle {
         return String(format: NSLocalizedString("%1$@ v%2$@", comment: "The format string for the app name and version number. (1: bundle name)(2: bundle version)"), bundleDisplayName, shortVersionString)
     }
     
+    private var mainAppBundleIdentifier: String? {
+        return object(forInfoDictionaryKey: "MainAppBundleIdentifier") as? String
+    }
+
     var appGroupSuiteName: String {
         return object(forInfoDictionaryKey: "AppGroupIdentifier") as! String
     }


### PR DESCRIPTION
The merge of 73b7302 and 82dc3da resulted in an accidental deletion of
mainAppBundleIdentifier from the NSBundle extension.