### PR TITLE
X22 enlite cgm support

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		4F7528AA1DFE215100C322D6 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C8001DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift */; };
 		4FC8C8021DEB943800A1452E /* NSUserDefaults+StatusExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C8001DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift */; };
+		540DED971E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */; };
 		4FF4D0F81E1725B000846527 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F54561D287FDB002A9274 /* NibLoadable.swift */; };
 		4FF4D0F91E17268800846527 /* IdentifiableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434FF1E91CF26C29000DB779 /* IdentifiableClass.swift */; };
 		4FF4D1001E18374700846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
@@ -463,6 +464,7 @@
 		4F70C1FD1DE8E662006380B7 /* Loop Status Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Loop Status Extension.entitlements"; sourceTree = "<group>"; };
 		4F70C20F1DE8FAC5006380B7 /* StatusExtensionDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusExtensionDataManager.swift; sourceTree = "<group>"; };
 		4F70C2111DE900EA006380B7 /* StatusExtensionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusExtensionContext.swift; sourceTree = "<group>"; };
+		540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpGlucoseHistorySensorDisplayable.swift; sourceTree = "<group>"; };
 		4F75288B1DFE1DC600C322D6 /* LoopUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoopUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F75288D1DFE1DC600C322D6 /* LoopUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoopUI.h; sourceTree = "<group>"; };
 		4F75288E1DFE1DC600C322D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -593,6 +595,7 @@
 				438D42F81D7C88BC003244B0 /* PredictionInputEffect.swift */,
 				43C418B41CE0575200405B6A /* ShareGlucose+GlucoseKit.swift */,
 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
+				540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1355,6 +1358,7 @@
 				4328E0331CFC091100E199AA /* WatchContext+LoopKit.swift in Sources */,
 				4F526D611DF8D9A900A04910 /* NetBasal.swift in Sources */,
 				4398973B1CD2FC2000223065 /* NSDateFormatter.swift in Sources */,
+				540DED971E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift in Sources */,
 				436A0DA51D236A2A00104B24 /* LoopError.swift in Sources */,
 				43E2D8C61D204678004DA55F /* KeychainManager.swift in Sources */,
 				433EA4C21D9F39C900CD78FB /* PumpIDTableViewController.swift in Sources */,

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -173,11 +173,11 @@
 		4F7528AA1DFE215100C322D6 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C8001DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift */; };
 		4FC8C8021DEB943800A1452E /* NSUserDefaults+StatusExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C8001DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift */; };
-		540DED971E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */; };
 		4FF4D0F81E1725B000846527 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F54561D287FDB002A9274 /* NibLoadable.swift */; };
 		4FF4D0F91E17268800846527 /* IdentifiableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434FF1E91CF26C29000DB779 /* IdentifiableClass.swift */; };
 		4FF4D1001E18374700846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
 		4FF4D1011E18375000846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
+		540DED971E14C75F002B2491 /* EnliteSensorDisplayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540DED961E14C75F002B2491 /* EnliteSensorDisplayable.swift */; };
 		C10428971D17BAD400DD539A /* NightscoutUploadKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */; };
 		C12F21A71DFA79CB00748193 /* recommend_tamp_basal_very_low_end_in_range.json in Resources */ = {isa = PBXBuildFile; fileRef = C12F21A61DFA79CB00748193 /* recommend_tamp_basal_very_low_end_in_range.json */; };
 		C15713821DAC6983005BC4D2 /* MealBolusNightscoutTreatment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15713811DAC6983005BC4D2 /* MealBolusNightscoutTreatment.swift */; };
@@ -464,12 +464,12 @@
 		4F70C1FD1DE8E662006380B7 /* Loop Status Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Loop Status Extension.entitlements"; sourceTree = "<group>"; };
 		4F70C20F1DE8FAC5006380B7 /* StatusExtensionDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusExtensionDataManager.swift; sourceTree = "<group>"; };
 		4F70C2111DE900EA006380B7 /* StatusExtensionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusExtensionContext.swift; sourceTree = "<group>"; };
-		540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpGlucoseHistorySensorDisplayable.swift; sourceTree = "<group>"; };
 		4F75288B1DFE1DC600C322D6 /* LoopUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoopUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F75288D1DFE1DC600C322D6 /* LoopUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoopUI.h; sourceTree = "<group>"; };
 		4F75288E1DFE1DC600C322D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4FC8C8001DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSUserDefaults+StatusExtension.swift"; path = "Common/Extensions/NSUserDefaults+StatusExtension.swift"; sourceTree = "<group>"; };
 		4FF4D0FF1E18374700846527 /* WatchContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchContext.swift; sourceTree = "<group>"; };
+		540DED961E14C75F002B2491 /* EnliteSensorDisplayable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnliteSensorDisplayable.swift; sourceTree = "<group>"; };
 		C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NightscoutUploadKit.framework; path = Carthage/Build/iOS/NightscoutUploadKit.framework; sourceTree = "<group>"; };
 		C12F21A61DFA79CB00748193 /* recommend_tamp_basal_very_low_end_in_range.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = recommend_tamp_basal_very_low_end_in_range.json; sourceTree = "<group>"; };
 		C15713811DAC6983005BC4D2 /* MealBolusNightscoutTreatment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MealBolusNightscoutTreatment.swift; sourceTree = "<group>"; };
@@ -595,7 +595,7 @@
 				438D42F81D7C88BC003244B0 /* PredictionInputEffect.swift */,
 				43C418B41CE0575200405B6A /* ShareGlucose+GlucoseKit.swift */,
 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
-				540DED961E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift */,
+				540DED961E14C75F002B2491 /* EnliteSensorDisplayable.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1358,7 +1358,7 @@
 				4328E0331CFC091100E199AA /* WatchContext+LoopKit.swift in Sources */,
 				4F526D611DF8D9A900A04910 /* NetBasal.swift in Sources */,
 				4398973B1CD2FC2000223065 /* NSDateFormatter.swift in Sources */,
-				540DED971E14C75F002B2491 /* PumpGlucoseHistorySensorDisplayable.swift in Sources */,
+				540DED971E14C75F002B2491 /* EnliteSensorDisplayable.swift in Sources */,
 				436A0DA51D236A2A00104B24 /* LoopError.swift in Sources */,
 				43E2D8C61D204678004DA55F /* KeychainManager.swift in Sources */,
 				433EA4C21D9F39C900CD78FB /* PumpIDTableViewController.swift in Sources */,

--- a/Loop/Extensions/NSUserDefaults.swift
+++ b/Loop/Extensions/NSUserDefaults.swift
@@ -25,6 +25,7 @@ extension UserDefaults {
         case MaximumBasalRatePerHour = "com.loudnate.Naterade.MaximumBasalRatePerHour"
         case MaximumBolus = "com.loudnate.Naterade.MaximumBolus"
         case PreferredInsulinDataSource = "com.loudnate.Loop.PreferredInsulinDataSource"
+        case PumpFetchGlucoseEnabled = "com.loopkit.Loop.FetchPumpGlucoseEnabled"
         case PumpID = "com.loudnate.Naterade.PumpID"
         case PumpModelNumber = "com.loudnate.Naterade.PumpModelNumber"
         case PumpRegion = "com.loopkit.Loop.PumpRegion"
@@ -211,6 +212,15 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.G4ReceiverEnabled.rawValue)
+        }
+    }
+
+    var fetchPumpGlucoseEnabled: Bool {
+        get {
+            return bool(forKey: Key.PumpFetchGlucoseEnabled.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.PumpFetchGlucoseEnabled.rawValue)
         }
     }
 

--- a/Loop/Extensions/NSUserDefaults.swift
+++ b/Loop/Extensions/NSUserDefaults.swift
@@ -25,7 +25,7 @@ extension UserDefaults {
         case MaximumBasalRatePerHour = "com.loudnate.Naterade.MaximumBasalRatePerHour"
         case MaximumBolus = "com.loudnate.Naterade.MaximumBolus"
         case PreferredInsulinDataSource = "com.loudnate.Loop.PreferredInsulinDataSource"
-        case PumpFetchGlucoseEnabled = "com.loopkit.Loop.FetchPumpGlucoseEnabled"
+        case FetchEnliteDataEnabled = "com.loopkit.Loop.FetchEnliteDataEnabled"
         case PumpID = "com.loudnate.Naterade.PumpID"
         case PumpModelNumber = "com.loudnate.Naterade.PumpModelNumber"
         case PumpRegion = "com.loopkit.Loop.PumpRegion"
@@ -215,12 +215,12 @@ extension UserDefaults {
         }
     }
 
-    var fetchPumpGlucoseEnabled: Bool {
+    var fetchEnliteDataEnabled: Bool {
         get {
-            return bool(forKey: Key.PumpFetchGlucoseEnabled.rawValue)
+            return bool(forKey: Key.FetchEnliteDataEnabled.rawValue)
         }
         set {
-            set(newValue, forKey: Key.PumpFetchGlucoseEnabled.rawValue)
+            set(newValue, forKey: Key.FetchEnliteDataEnabled.rawValue)
         }
     }
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -54,6 +54,15 @@ final class DeviceDataManager: CarbStoreDelegate, CarbStoreSyncDelegate, DoseSto
         }
     }
 
+    var fetchPumpGlucoseEnabled: Bool {
+        get {
+            return UserDefaults.standard.fetchPumpGlucoseEnabled
+        }
+        set {
+            UserDefaults.standard.fetchPumpGlucoseEnabled = newValue
+        }
+    }
+
     var sensorInfo: SensorDisplayable? {
         return latestGlucoseG5 ?? latestGlucoseG4 ?? latestGlucoseFromShare ?? latestPumpStatusFromMySentry
     }
@@ -367,7 +376,9 @@ final class DeviceDataManager: CarbStoreDelegate, CarbStoreSyncDelegate, DoseSto
         device.assertIdleListening()
 
         assertCurrentPumpStatus(device: device) {
-            self.assertCurrentPumpCGMData(device: device);
+            if UserDefaults.standard.fetchPumpGlucoseEnabled {
+                self.assertCurrentPumpCGMData(device: device)
+            }
         }
     }
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -510,6 +510,10 @@ final class DeviceDataManager: CarbStoreDelegate, CarbStoreSyncDelegate, DoseSto
 
         let fetchGlucoseSince = glucoseStore?.latestGlucose?.startDate.addingTimeInterval(TimeInterval(minutes: 1)) ?? Date(timeIntervalSinceNow: TimeInterval(hours: -24))
 
+        guard fetchGlucoseSince.timeIntervalSinceNow <= TimeInterval(minutes: -4.5) else {
+            return
+        }
+
         device.ops?.getGlucoseHistoryEvents(since: fetchGlucoseSince, completion: { (result) in
             switch result {
             case .success(let glucoseEvents):

--- a/Loop/Models/EnliteSensorDisplayable.swift
+++ b/Loop/Models/EnliteSensorDisplayable.swift
@@ -1,5 +1,5 @@
 //
-//  PumpGlucoseHistorySensorDisplayable.swift
+//  EnliteSensorDisplayable.swift
 //  Loop
 //
 //  Created by Timothy Mecklem on 12/28/16.
@@ -10,7 +10,7 @@ import Foundation
 import LoopUI
 import MinimedKit
 
-struct PumpGlucoseHistorySensorDisplayable: SensorDisplayable {
+struct EnliteSensorDisplayable: SensorDisplayable {
     public let isStateValid: Bool
     public let trendType: LoopUI.GlucoseTrend? = nil
     public let isLocal = true

--- a/Loop/Models/PumpGlucoseHistorySensorDisplayable.swift
+++ b/Loop/Models/PumpGlucoseHistorySensorDisplayable.swift
@@ -1,0 +1,21 @@
+//
+//  PumpGlucoseHistorySensorDisplayable.swift
+//  Loop
+//
+//  Created by Timothy Mecklem on 12/28/16.
+//  Copyright © 2016 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopUI
+import MinimedKit
+
+struct PumpGlucoseHistorySensorDisplayable: SensorDisplayable {
+    public let isStateValid: Bool
+    public let trendType: LoopUI.GlucoseTrend? = nil
+    public let isLocal = true
+
+    public init?(_ e: RelativeTimestampedGlucoseEvent) {
+        isStateValid = e is SensorValueGlucoseEvent
+    }
+}

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -194,7 +194,7 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
                 let switchCell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
 
                 switchCell.`switch`?.isOn = dataManager.fetchPumpGlucoseEnabled
-                switchCell.titleLabel.text = NSLocalizedString("Fetch Pump Glucose", comment: "The title text for the fetch pump glocose enabled switch cell")
+                switchCell.titleLabel.text = NSLocalizedString("Fetch Enlite Data", comment: "The title text for the fetch enlite data enabled switch cell")
 
                 switchCell.`switch`?.addTarget(self, action: #selector(fetchPumpGlucoseEnabledChanged(_:)), for: .valueChanged)
 

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -97,6 +97,7 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
         case pumpID = 0
         case transmitterID
         case receiverEnabled
+        case fetchPumpGlucose
         case glucoseTargetRange
         case insulinActionDuration
         case basalRate
@@ -106,7 +107,7 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
         case maxBolus
         case batteryChemistry
 
-        static let count = 11
+        static let count = 12
     }
 
     fileprivate enum ServiceRow: Int {
@@ -189,6 +190,17 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
                 return switchCell
             }
 
+            if case .fetchPumpGlucose = ConfigurationRow(rawValue: indexPath.row)! {
+                let switchCell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
+
+                switchCell.`switch`?.isOn = dataManager.fetchPumpGlucoseEnabled
+                switchCell.titleLabel.text = NSLocalizedString("Fetch Pump Glucose", comment: "The title text for the fetch pump glocose enabled switch cell")
+
+                switchCell.`switch`?.addTarget(self, action: #selector(fetchPumpGlucoseEnabledChanged(_:)), for: .valueChanged)
+
+                return switchCell
+            }
+
             let configCell = tableView.dequeueReusableCell(withIdentifier: ConfigCellIdentifier, for: indexPath)
 
             switch ConfigurationRow(rawValue: indexPath.row)! {
@@ -199,6 +211,8 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
                 configCell.textLabel?.text = NSLocalizedString("G5 Transmitter ID", comment: "The title text for the Dexcom G5 transmitter ID config value")
                 configCell.detailTextLabel?.text = dataManager.transmitterID ?? TapToSetString
             case .receiverEnabled:
+                break
+            case .fetchPumpGlucose:
                 break
             case .basalRate:
                 configCell.textLabel?.text = NSLocalizedString("Basal Rates", comment: "The title text for the basal rate schedule")
@@ -466,6 +480,8 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
                 }
             case .receiverEnabled:
                 break
+            case .fetchPumpGlucose:
+                break
             case .batteryChemistry:
                 let vc = RadioSelectionTableViewController.batteryChemistryType(dataManager.batteryChemistry)
                 vc.title = sender?.textLabel?.text
@@ -572,6 +588,10 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
 
     func receiverEnabledChanged(_ sender: UISwitch) {
         dataManager.receiverEnabled = sender.isOn
+    }
+
+    func fetchPumpGlucoseEnabledChanged(_ sender: UISwitch) {
+        dataManager.fetchPumpGlucoseEnabled = sender.isOn
     }
 
     // MARK: - DailyValueScheduleTableViewControllerDelegate

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -193,7 +193,7 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
             if case .fetchPumpGlucose = ConfigurationRow(rawValue: indexPath.row)! {
                 let switchCell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
 
-                switchCell.`switch`?.isOn = dataManager.fetchPumpGlucoseEnabled
+                switchCell.`switch`?.isOn = dataManager.fetchEnliteDataEnabled
                 switchCell.titleLabel.text = NSLocalizedString("Fetch Enlite Data", comment: "The title text for the fetch enlite data enabled switch cell")
 
                 switchCell.`switch`?.addTarget(self, action: #selector(fetchPumpGlucoseEnabledChanged(_:)), for: .valueChanged)
@@ -591,7 +591,7 @@ final class SettingsTableViewController: UITableViewController, DailyValueSchedu
     }
 
     func fetchPumpGlucoseEnabledChanged(_ sender: UISwitch) {
-        dataManager.fetchPumpGlucoseEnabled = sender.isOn
+        dataManager.fetchEnliteDataEnabled = sender.isOn
     }
 
     // MARK: - DailyValueScheduleTableViewControllerDelegate

--- a/LoopUI/Models/SensorDisplayable.swift
+++ b/LoopUI/Models/SensorDisplayable.swift
@@ -19,6 +19,6 @@ public protocol SensorDisplayable {
     /// Enumerates the trend of the sensor values
     var trendType: GlucoseTrend? { get }
 
-    /// Returns wheter the data is from a locally-connected device
+    /// Returns whether the data is from a locally-connected device
     var isLocal: Bool { get }
 }


### PR DESCRIPTION
This PR adds initial Loop support for enlite cgm on pumps that do not support MySentry. https://github.com/LoopKit/Loop/issues/100

Overview:

1. Uses RileyLink MinimedKit support for fetching glucose history pages. Glucose fetching happens if needed after completion of assertCurrentPumpStatus.
2. Adds switch to activate pump cgm fetching
3. Adds sensor info to show "!" when sensor calibrations are required or a sensor error or weak signal happens

PR changes requested:
- [x] Rename functions to enlite for clarity
- [x] Group related enlite data and functions together
- [x] Remove tight coupling between pump status and enlite data fetching
