### PR TITLE
remove +ve momentum from bolus calculation

### DIFF
--- a/Loop/Managers/DiagnosticLogger+LoopKit.swift
+++ b/Loop/Managers/DiagnosticLogger+LoopKit.swift
@@ -26,7 +26,7 @@ extension DiagnosticLogger {
         addError(String(describing: message), fromSource: source)
     }
 
-    func addLoopStatus(startDate: Date, endDate: Date, glucose: GlucoseValue, effects: [String: [GlucoseEffect]], error: Error?, prediction: [GlucoseValue], predictionWithRetrospectiveEffect: Double, recommendedTempBasal: LoopDataManager.TempBasalRecommendation?) {
+    func addLoopStatus(startDate: Date, endDate: Date, glucose: GlucoseValue, effects: [String: [GlucoseEffect]], error: Error?, prediction: [GlucoseValue], predictionWithRetrospectiveEffect: Double, eventualBG: Double, eventualBGWithRetrospectiveEffect: Double, eventualBGWithoutMomentum: Double, recommendedTempBasal: LoopDataManager.TempBasalRecommendation?) {
 
         let dateFormatter = DateFormatter.ISO8601StrictDateFormatter()
         let unit = HKUnit.milligramsPerDeciliterUnit()
@@ -57,7 +57,10 @@ extension DiagnosticLogger {
                     "unit": unit.unitString
                 ]
             },
-            "prediction_retrospect_delta": predictionWithRetrospectiveEffect
+            "prediction_retrospect_delta": predictionWithRetrospectiveEffect,
+            "eventualBG": eventualBG,
+            "eventualBGWithRetrospectiveEffect": eventualBGWithRetrospectiveEffect,
+            "eventualBGWithoutMomentum": eventualBGWithoutMomentum
         ]
 
         if let error = error {


### PR DESCRIPTION
This PR is a attempt to address https://github.com/LoopKit/Loop/issues/370. The `recommendBolus` function calculates a bolus based on both a glucose prediction with momentum, and one without, and returns the smaller bolus of the two.

Note that currently the retrospective effect is not used in the bolus calculation without momentum. We will test over the next few days. Any comments welcome.