### PR TITLE
Do not show glucose in HUD view if older than 15 minutes

### DIFF
--- a/LoopUI/Views/GlucoseHUDView.swift
+++ b/LoopUI/Views/GlucoseHUDView.swift
@@ -95,7 +95,11 @@ public final class GlucoseHUDView: BaseHUDView {
 
         let numberFormatter = NumberFormatter.glucoseFormatter(for: unit)
         if let valueString = numberFormatter.string(from: NSNumber(value: glucoseQuantity)) {
-            glucoseLabel.text = valueString
+            if glucoseStartDate.timeIntervalSinceNow > -TimeInterval(minutes: 15) {
+                glucoseLabel.text = valueString
+            } else {
+                glucoseLabel.text = "-"
+            }
             accessibilityStrings.append(String(format: NSLocalizedString("%1$@ at %2$@", comment: "Accessbility format value describing glucose: (1: glucose number)(2: glucose time)"), valueString, time))
         }
 


### PR DESCRIPTION
 to not mislead people into wrong glucose levels.