### PR TITLE
Break the tie between two visual constraints.

### DIFF
--- a/Loop Status Extension/Base.lproj/MainInterface.storyboard
+++ b/Loop Status Extension/Base.lproj/MainInterface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="64E-I5-5c4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="64E-I5-5c4">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -54,7 +54,7 @@
                                         <rect key="frame" x="0.0" y="110" width="359" height="110"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="rLK-f9-lLl"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="750" constant="100" id="rLK-f9-lLl"/>
                                         </constraints>
                                     </view>
                                 </subviews>


### PR DESCRIPTION
"<NSLayoutConstraint:0x600000097430 LoopUI.ChartContentView:0x7f808c50aae0.height >= 100   (active)>",
"<NSLayoutConstraint:0x60000009c2f0 'UISV-hiding' LoopUI.ChartContentView:0x7f808c50aae0.height == 0   (active)>"

Lower the priority of the height >= 100 constraint.