### PR TITLE
Use standard forecast for bolus recommendations.

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -838,7 +838,7 @@ final class LoopDataManager {
             insulinActionDuration: insulinActionDuration
         )
 
-        return recommendation;
+        return recommendation
     }
 
     /// *This method should only be called from the `dataAccessQueue`*

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -838,22 +838,7 @@ final class LoopDataManager {
             insulinActionDuration: insulinActionDuration
         )
 
-        // TODO: This was added in https://github.com/LoopKit/Loop/issues/370, but concerns were raised
-        // that this contradicts users expectations in https://github.com/LoopKit/Loop/issues/435
-        let bolusSafetyEffects = settings.enabledEffects.subtracting([.retrospection, .momentum])
-
-        return min(recommendation,
-            DoseMath.recommendBolusFromPredictedGlucose(
-                try predictGlucoseFromCurrentData(using: bolusSafetyEffects),
-                maxBolus: maxBolus,
-                glucoseTargetRange: glucoseTargetRange,
-                insulinSensitivity: insulinSensitivity,
-                basalRateSchedule: basalRates,
-                pendingInsulin: pendingInsulin,
-                minimumBGGuard: minimumBGGuard,
-                insulinActionDuration: insulinActionDuration
-            )
-        )
+        return recommendation;
     }
 
     /// *This method should only be called from the `dataAccessQueue`*


### PR DESCRIPTION
This reverts behavior that added in #370.  That change caused confusion, because the forecast that drove bolusing was different from the forecast shown.  #435 is one example.

For those people that feel that Loop is being too aggressive in times of unexpected upward bg change, they should look into retrospective correction, and see what their forecast looks like with and without it enabled.  That may be a feature that you want to turn off.