### PR TITLE
Cancel temp basal when bolusing.

### DIFF
--- a/DoseMathTests/DoseMathTests.swift
+++ b/DoseMathTests/DoseMathTests.swift
@@ -509,7 +509,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -526,7 +526,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
 
@@ -544,7 +544,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
 
@@ -562,7 +562,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
 
@@ -580,7 +580,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
 
@@ -605,7 +605,7 @@ class RecommendBolusTests: XCTestCase {
                                                                glucoseTargetRange: glucoseTargetRange,
                                                                insulinSensitivity: insulinSensitivitySchedule,
                                                                basalRateSchedule: basalRateSchedule,
-                                                               pendingInsulin: 0,
+                                                               unconfirmedInsulin: 0,
                                                                minimumBGGuard: minimumBGGuard,
                                                                insulinActionDuration: insulinActionDuration
         )
@@ -615,7 +615,7 @@ class RecommendBolusTests: XCTestCase {
     }
 
 
-    func testStartLowEndHighWithPendingBolus() {
+    func testStartLowEndHighWithUnconfirmedBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_high")
         
         let dose = DoseMath.recommendBolusFromPredictedGlucose(glucose,
@@ -624,7 +624,7 @@ class RecommendBolusTests: XCTestCase {
                                                                glucoseTargetRange: glucoseTargetRange,
                                                                insulinSensitivity: insulinSensitivitySchedule,
                                                                basalRateSchedule: basalRateSchedule,
-                                                               pendingInsulin: 1,
+                                                               unconfirmedInsulin: 1,
                                                                minimumBGGuard: minimumBGGuard,
                                                                insulinActionDuration: insulinActionDuration
         )
@@ -641,7 +641,7 @@ class RecommendBolusTests: XCTestCase {
                                                                glucoseTargetRange: glucoseTargetRange,
                                                                insulinSensitivity: insulinSensitivitySchedule,
                                                                basalRateSchedule: basalRateSchedule,
-                                                               pendingInsulin: 0,
+                                                               unconfirmedInsulin: 0,
                                                                minimumBGGuard: minimumBGGuard,
                                                                insulinActionDuration: insulinActionDuration
         )
@@ -658,7 +658,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -675,7 +675,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -692,7 +692,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -707,7 +707,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0.8,
+            unconfirmedInsulin: 0.8,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -720,7 +720,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -737,7 +737,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: self.insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -753,7 +753,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration
         )
@@ -770,7 +770,7 @@ class RecommendBolusTests: XCTestCase {
                                                                glucoseTargetRange: glucoseTargetRange,
                                                                insulinSensitivity: self.insulinSensitivitySchedule,
                                                                basalRateSchedule: basalRateSchedule,
-                                                               pendingInsulin: 0,
+                                                               unconfirmedInsulin: 0,
                                                                minimumBGGuard: minimumBGGuard,
                                                                insulinActionDuration: insulinActionDuration
         )
@@ -785,7 +785,7 @@ class RecommendBolusTests: XCTestCase {
             glucoseTargetRange: glucoseTargetRange,
             insulinSensitivity: insulinSensitivitySchedule,
             basalRateSchedule: basalRateSchedule,
-            pendingInsulin: 0,
+            unconfirmedInsulin: 0,
             minimumBGGuard: minimumBGGuard,
             insulinActionDuration: insulinActionDuration)
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -386,7 +386,7 @@ final class DeviceDataManager {
         }
 
         let setBolus = {
-            ops.setNormalBolus(units: units) { (error) in
+            ops.setNormalBolus(units: units, cancelExistingTemp: true) { (error) in
                 if let error = error {
                     self.logger.addError(error, fromSource: "Bolus")
                     notify(error)

--- a/Loop/Models/BolusRecommendation.swift
+++ b/Loop/Models/BolusRecommendation.swift
@@ -65,12 +65,12 @@ enum BolusRecommendationNotice: CustomStringConvertible, Equatable {
 
 struct BolusRecommendation {
     let amount: Double
-    let pendingInsulin: Double
+    let unconfirmedInsulin: Double
     let notice: BolusRecommendationNotice?
 
-    init(amount: Double, pendingInsulin: Double, notice: BolusRecommendationNotice? = nil) {
+    init(amount: Double, unconfirmedInsulin: Double, notice: BolusRecommendationNotice? = nil) {
         self.amount = amount
-        self.pendingInsulin = pendingInsulin
+        self.unconfirmedInsulin = unconfirmedInsulin
         self.notice = notice
     }
 }

--- a/Loop/View Controllers/BolusViewController.swift
+++ b/Loop/View Controllers/BolusViewController.swift
@@ -42,7 +42,7 @@ final class BolusViewController: UITableViewController, IdentifiableClass, UITex
         AnalyticsManager.sharedManager.didDisplayBolusScreen()
     }
 
-    func generateActiveInsulinDescription(activeInsulin: Double?, pendingInsulin: Double?) -> String
+    func generateActiveInsulinDescription(activeInsulin: Double?, unconfirmedInsulin: Double?) -> String
     {
         let iobStr: String
         if let iob = activeInsulin, let valueStr = insulinFormatter.string(from: NSNumber(value: iob))
@@ -54,9 +54,9 @@ final class BolusViewController: UITableViewController, IdentifiableClass, UITex
 
         var rval = String(format: NSLocalizedString("Active Insulin: %@", comment: "The string format describing active insulin. (1: localized insulin value description)"), iobStr)
 
-        if let pending = pendingInsulin, pending > 0, let pendingStr = insulinFormatter.string(from: NSNumber(value: pending))
+        if let unconfirmed = unconfirmedInsulin, unconfirmed > 0, let unconfirmedStr = insulinFormatter.string(from: NSNumber(value: unconfirmed))
         {
-            rval += String(format: NSLocalizedString(" (pending: %@)", comment: "The string format appended to active insulin that describes pending insulin. (1: pending insulin)"), pendingStr + " U")
+            rval += String(format: NSLocalizedString(" (unconfirmed: %@)", comment: "The string format appended to active insulin that describes unconfirmed insulin. (1: unconfirmed insulin)"), unconfirmedStr + " U")
         }
         return rval
     }
@@ -70,8 +70,8 @@ final class BolusViewController: UITableViewController, IdentifiableClass, UITex
             let amount = bolusRecommendation?.amount ?? 0
             recommendedBolusAmountLabel?.text = bolusUnitsFormatter.string(from: NSNumber(value: amount))
             updateNotice()
-            if let pendingInsulin = bolusRecommendation?.pendingInsulin {
-                self.pendingInsulin = pendingInsulin
+            if let unconfirmedInsulin = bolusRecommendation?.unconfirmedInsulin {
+                self.unconfirmedInsulin = unconfirmedInsulin
             }
         }
     }
@@ -104,13 +104,13 @@ final class BolusViewController: UITableViewController, IdentifiableClass, UITex
 
     var activeInsulin: Double? = nil {
         didSet {
-            activeInsulinDescription = generateActiveInsulinDescription(activeInsulin: activeInsulin, pendingInsulin: pendingInsulin)
+            activeInsulinDescription = generateActiveInsulinDescription(activeInsulin: activeInsulin, unconfirmedInsulin: unconfirmedInsulin)
         }
     }
 
-    var pendingInsulin: Double? = nil {
+    var unconfirmedInsulin: Double? = nil {
         didSet {
-            activeInsulinDescription = generateActiveInsulinDescription(activeInsulin: activeInsulin, pendingInsulin: pendingInsulin)
+            activeInsulinDescription = generateActiveInsulinDescription(activeInsulin: activeInsulin, unconfirmedInsulin: unconfirmedInsulin)
         }
     }
 


### PR DESCRIPTION
- Cancel any existing temp basal when issuing bolus.
- Do not subtract pending insulin from temp basals in bolus recommendation calc.
