### PR TITLE
Dexcom share more agressive fetch

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -694,6 +694,8 @@ extension DeviceDataManager: CGMManagerDelegate {
             self.setLastError(error: error)
             self.assertCurrentPumpData()
         }
+
+        updateTimerTickPreference()
     }
 
     func startDateToFilterNewData(for manager: CGMManager) -> Date? {


### PR DESCRIPTION
 - No longer disable Share backfill after the first reading
 - Don't fetch from Share unless G4/G5 data is old
 - Report bad G5 calibration state as a CGM error so it surfaces to users