### PR TITLE
Fetch pump data if needed, even after .noData CGM updates.

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -691,6 +691,7 @@ extension DeviceDataManager: CGMManagerDelegate {
                 self.assertCurrentPumpData()
             }
         case .noData:
+            self.assertCurrentPumpData()
             break
         case .error(let error):
             self.setLastError(error: error)


### PR DESCRIPTION
If pump data fetch fails, subsequent timer events will now trigger another attempt.

This should help with general stability and can fix extreme cases where MySentry packets are arriving just after CGM updates, and routinely blocking pump data reads. 
