### PR TITLE
Refactor Bolus recommendation code

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -994,15 +994,6 @@ protocol LoopState {
     /// - Returns: An timeline of predicted glucose values
     /// - Throws: LoopError.missingDataError if prediction cannot be computed
     func predictGlucose(using inputs: PredictionInputEffect) throws -> [GlucoseValue]
-
-    /// Calculates a recommended bolus based on predicted glucose
-    ///
-    /// - Returns: A bolus recommendation
-    /// - Throws: An error describing why a bolus couldnʼt be computed
-    ///     - LoopError.configurationError
-    ///     - LoopError.glucoseTooOld
-    ///     - LoopError.missingDataError
-    func recommendBolus() throws -> BolusRecommendation
 }
 
 
@@ -1063,13 +1054,6 @@ extension LoopDataManager {
 
         func predictGlucose(using inputs: PredictionInputEffect) throws -> [GlucoseValue] {
             return try loopDataManager.predictGlucose(using: inputs)
-        }
-
-        func recommendBolus() throws -> BolusRecommendation {
-            if let bolus = loopDataManager.recommendedBolus {
-                return bolus.recommendation
-            }
-            throw LoopError.missingDataError(details: "Recommended Bolus data not available.", recovery: "Check you loop state.")
         }
     }
 

--- a/Loop/Managers/NightscoutDataManager.swift
+++ b/Loop/Managers/NightscoutDataManager.swift
@@ -43,15 +43,7 @@ final class NightscoutDataManager {
             var loopError = state.error
             let recommendedBolus: Double?
 
-            do {
-                recommendedBolus = try state.recommendBolus().amount
-            } catch let error {
-                recommendedBolus = nil
-
-                if loopError == nil {
-                    loopError = error
-                }
-            }
+            recommendedBolus = state.recommendedBolus?.recommendation.amount
 
             let carbsOnBoard = state.carbsOnBoard
             let predictedGlucose = state.predictedGlucose

--- a/Loop/Managers/WatchDataManager.swift
+++ b/Loop/Managers/WatchDataManager.swift
@@ -125,7 +125,7 @@ final class WatchDataManager: NSObject, WCSessionDelegate {
                 context.reservoir = reservoir?.unitVolume
 
                 context.loopLastRunDate = state.lastLoopCompleted
-                context.recommendedBolusDose = try? state.recommendBolus().amount
+                context.recommendedBolusDose = state.recommendedBolus?.recommendation.amount
                 context.maxBolus = manager.settings.maximumBolus
 
                 if let glucoseTargetRangeSchedule = manager.settings.glucoseTargetRangeSchedule {

--- a/Loop/View Controllers/BolusViewController+LoopDataManager.swift
+++ b/Loop/View Controllers/BolusViewController+LoopDataManager.swift
@@ -20,7 +20,7 @@ extension BolusViewController {
             if let recommendation = recommendation {
                 bolusRecommendation = recommendation
             } else {
-                bolusRecommendation = try? state.recommendBolus()
+                bolusRecommendation = state.recommendedBolus?.recommendation
             }
 
             manager.doseStore.insulinOnBoard(at: Date()) { (result) in


### PR DESCRIPTION
Essentially handle Bolus recommendation the same as Basal recommendations.  There is probably historic reasons why these are treated differently.  Given that update() is always called before recommendBolus it does not make a lot of functional sense though.

This is in preparation of being able to automatically do bolus' out of LoopDataManager.