### PR TITLE
Automatic Pump Time Synchronization

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -241,9 +241,19 @@ final class DeviceDataManager {
     // MARK: Pump data
 
     /// TODO: Isolate to queue
-    fileprivate var latestPumpStatusFromMySentry: MySentryPumpStatusMessageBody?
+    fileprivate var latestPumpStatusFromMySentry: MySentryPumpStatusMessageBody? {
+        didSet {
+            if let manager = cgmManager as? EnliteCGMManager {
+                manager.sensorState = latestPumpStatusFromMySentry
+            }
+        }
+    }
 
-    /** Check if pump date is current and otherwise update it. **/
+    /**
+     Check if pump date is current and otherwise update it.
+     
+     - parameter date: The last pump date
+    */
     private func assertPumpDate(_ date: Date) -> Bool {
         let dateDiff = abs(date.timeIntervalSinceNow)
         if dateDiff > TimeInterval(minutes: 1) {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -304,11 +304,11 @@ final class DeviceDataManager {
         guard status != latestPumpStatusFromMySentry, let pumpDate = pumpDateComponents.date else {
             return
         }
-        
+
         if !assertPumpDate(pumpDate) {
             return
         }
-        
+
         observeBatteryDuring {
             latestPumpStatusFromMySentry = status
         }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -243,9 +243,7 @@ final class DeviceDataManager {
     /// TODO: Isolate to queue
     fileprivate var latestPumpStatusFromMySentry: MySentryPumpStatusMessageBody?
 
-    /** Check if pump date is current and otherwise update it.
-     * TODO this should get a device name probably.
-     **/
+    /** Check if pump date is current and otherwise update it. **/
     private func assertPumpDate(_ date: Date) -> Bool {
         let dateDiff = abs(date.timeIntervalSinceNow)
         if dateDiff > TimeInterval(minutes: 1) {
@@ -256,18 +254,15 @@ final class DeviceDataManager {
                 guard let device = devices.firstConnected else {
                     return
                 }
-                // TODO use a session
                 pumpOps.runSession(withName: "Sync Pump Time", using: device) { (session) in
                     do {
                         try session.setTime { () -> DateComponents in
                             let calendar = Calendar(identifier: .gregorian)
                             return calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: Date())
                         }
-                        self.loopManager.addInternalNote("syncPumpTime success (difference \(dateDiff)).")
-
+                        NSLog("syncPumpTime success (difference \(dateDiff)).")
                     } catch let error {
-                
-                        self.loopManager.addInternalNote("syncPumpTime error \(String(describing: error)).")
+                        NSLog("syncPumpTime error \(String(describing: error)).")
                     }
                 }
             }


### PR DESCRIPTION
If an out of sync pump time is detected, automatically adjust the time and date of the pump, assuming that the mobile has a better idea of where we are. 

Potential corner case is traveling around the world, but for 99% of users this is probably what they want.  Given that the IOB calculation relies on accurate sync between the pump and mobile device, it seems prudent to make sure this is the case.

An alternative might be to refuse to loop if too big of a time difference is detected.