### PR TITLE
Reset recommendedBolus if we have a new prediction.

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -165,6 +165,7 @@ final class LoopDataManager {
     fileprivate var predictedGlucose: [GlucoseValue]? {
         didSet {
             recommendedTempBasal = nil
+            recommendedBolus = nil
         }
     }
     fileprivate var retrospectivePredictedGlucose: [GlucoseValue]? {


### PR DESCRIPTION
This technically isn't necessary as they are updated in the same
function but for consistency and not to forget during the next
refactoring this is protecting the user from getting a potentially
dangerous out of date recommendation.