### PR TITLE
WatchApp success haptic for carb, bolus sends

### DIFF
--- a/WatchApp Extension/Controllers/AddCarbsInterfaceController.swift
+++ b/WatchApp Extension/Controllers/AddCarbsInterfaceController.swift
@@ -163,6 +163,7 @@ final class AddCarbsInterfaceController: WKInterfaceController, IdentifiableClas
             do {
                 try WCSession.default.sendCarbEntryMessage(entry,
                     replyHandler: { (suggestion) in
+                        WKInterfaceDevice.current().play(.success)
                         DispatchQueue.main.async {
                             WKExtension.shared().rootInterfaceController?.presentController(withName: BolusInterfaceController.className, context: suggestion)
                         }

--- a/WatchApp Extension/Controllers/BolusInterfaceController.swift
+++ b/WatchApp Extension/Controllers/BolusInterfaceController.swift
@@ -135,11 +135,16 @@ final class BolusInterfaceController: WKInterfaceController, IdentifiableClass {
             let bolus = SetBolusUserInfo(value: bolusValue, startDate: Date())
 
             do {
-                try WCSession.default.sendBolusMessage(bolus) { (error) in
-                    DispatchQueue.main.async {
-                        ExtensionDelegate.shared().present(error)
+                try WCSession.default.sendBolusMessage(bolus,
+                    replyHandler: { _ in
+                        WKInterfaceDevice.current().play(.success)
+                    },
+                    errorHandler: { (error) in
+                        DispatchQueue.main.async {
+                            ExtensionDelegate.shared().present(error)
+                        }
                     }
-                }
+                )
             } catch {
                 presentAlert(
                     withTitle: NSLocalizedString("Bolus Failed", comment: "The title of the alert controller displayed after a bolus attempt fails"),

--- a/WatchApp Extension/Extensions/WCSession.swift
+++ b/WatchApp Extension/Extensions/WCSession.swift
@@ -40,7 +40,8 @@ extension WCSession {
         )
     }
 
-    func sendBolusMessage(_ userInfo: SetBolusUserInfo, errorHandler: @escaping (Error) -> Void) throws {
+    func sendBolusMessage(_ userInfo: SetBolusUserInfo, replyHandler: @escaping ([String: Any]) -> Void,
+        errorHandler: @escaping (Error) -> Void) throws {
         guard activationState == .activated else {
             throw MessageError.activationError
         }
@@ -50,7 +51,7 @@ extension WCSession {
         }
 
         sendMessage(userInfo.rawValue,
-            replyHandler: { reply in },
+            replyHandler: replyHandler,
             errorHandler: errorHandler
         )
     }


### PR DESCRIPTION
This change adds success haptic feedback to the WatchApp for carb and bolus entries that have been sent successfully. This small, but meaningful change allows for the user to know that it was sent successfully. 

Currently, a user could accidentally close / cancel the bolus or carb entry windows without any indication it wasn't sent. 

