### PR TITLE
Reconcile delivery above max basal rate as bolus on chart

### DIFF
--- a/Loop/Managers/StatusChartsManager+LoopKit.swift
+++ b/Loop/Managers/StatusChartsManager+LoopKit.swift
@@ -72,7 +72,7 @@ extension StatusChartsManager {
         }
     }
 
-    func setDoseEntries(_ doseEntries: [DoseEntry]) {
+    func setDoseEntries(_ doseEntries: [DoseEntry], _ maxBasalRateUnitsPerHour: Double?) {
         let dateFormatter = self.dateFormatter
         let doseFormatter = self.doseFormatter
 
@@ -83,7 +83,8 @@ extension StatusChartsManager {
         for entry in doseEntries {
             let time = entry.endDate.timeIntervalSince(entry.startDate)
 
-            if entry.type == .bolus && entry.netBasalUnits > 0 && time < .minutes(5) {
+            // Delivery rate above max basal indicates a bolus not yet present in event history: 
+            if (entry.type == .bolus && entry.netBasalUnits > 0 && time < .minutes(5)) || (entry.netBasalUnitsPerHour > maxBasalRateUnitsPerHour ?? Double.infinity) {
                 let x = ChartAxisValueDate(date: entry.startDate, formatter: dateFormatter)
                 let y = ChartAxisValueDoubleLog(actualDouble: entry.units, unitString: "U", formatter: doseFormatter)
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -391,7 +391,7 @@ final class StatusTableViewController: ChartsTableViewController {
 
             // Insulin Delivery
             if let doseEntries = doseEntries {
-                self.charts.setDoseEntries(doseEntries)
+                self.charts.setDoseEntries(doseEntries,  self.deviceManager.loopManager.settings.maximumBasalRatePerHour)
             }
             if let totalDelivery = totalDelivery {
                 self.totalDelivery = totalDelivery


### PR DESCRIPTION
This addresses issue #705 by interpreting delivery rate above the max basal rate (if it is set) as a bolus, and graphing it as such.  One part of the rendering that isn't perfectly accurate is that a bolus that is in progress at the time of a reservoir reading (i.e. whose delivery is partly reflected in two consecutive reservoir readings since it spans them) will initially be registered as two smaller boluses (see first screenshot below).  Eventually this will be rendered correctly as a single, larger bolus once event history is read, as shown in the second screenshot below.  In my view this initial inaccuracy (two boluses instead of one) is less confusing / alarming for a user than the current initial inaccuracy of showing it as an extremely high basal rate.  

Initial rendering based on high delivery rate in reservoir data: 
![img_2873](https://user-images.githubusercontent.com/2545845/43991830-c3df8f1c-9d42-11e8-8249-83086c6c144e.PNG)

Later rendering after event history is read: 
![img_2874](https://user-images.githubusercontent.com/2545845/43991832-cb614dfc-9d42-11e8-9019-c4766bc7e86b.PNG)
