### PR TITLE
Add Spike support to Loop

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -6,3 +6,4 @@ github "LoopKit/dexcom-share-client-swift" == 1.0
 github "LoopKit/G4ShareSpy" == 1.0
 github "ps2/rileylink_ios" == 2.1.0
 github "LoopKit/Amplitude-iOS" "decreepify"
+github "dabear/spike-client-swift" "master"

--- a/Cartfile
+++ b/Cartfile
@@ -6,4 +6,4 @@ github "LoopKit/dexcom-share-client-swift" == 1.0
 github "LoopKit/G4ShareSpy" == 1.0
 github "ps2/rileylink_ios" == 2.1.0
 github "LoopKit/Amplitude-iOS" "decreepify"
-github "dabear/spike-client-swift" "master"
+github "dabear/spike-client-swift" == 0.9.1

--- a/Cartfile
+++ b/Cartfile
@@ -6,4 +6,4 @@ github "LoopKit/dexcom-share-client-swift" == 1.0
 github "LoopKit/G4ShareSpy" == 1.0
 github "ps2/rileylink_ios" == 2.1.0
 github "LoopKit/Amplitude-iOS" "decreepify"
-github "dabear/spike-client-swift" == 0.9.1
+github "dabear/spike-client-swift" == 0.9.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -3,6 +3,6 @@ github "LoopKit/CGMBLEKit" "v3.0"
 github "LoopKit/G4ShareSpy" "v1.0"
 github "LoopKit/LoopKit" "v2.2.1"
 github "LoopKit/dexcom-share-client-swift" "v1.0"
-github "dabear/spike-client-swift" "v.0.9.2
+github "dabear/spike-client-swift" "0.9.2"
 github "i-schuetz/SwiftCharts" "0.6.2"
 github "ps2/rileylink_ios" "v2.1.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -3,5 +3,6 @@ github "LoopKit/CGMBLEKit" "v3.0"
 github "LoopKit/G4ShareSpy" "v1.0"
 github "LoopKit/LoopKit" "v2.2.1"
 github "LoopKit/dexcom-share-client-swift" "v1.0"
+github "dabear/spike-client-swift" "v.0.9.2
 github "i-schuetz/SwiftCharts" "0.6.2"
 github "ps2/rileylink_ios" "v2.1.0"

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		272AD3152168F56800E11366 /* SpikeClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 272AD3132168F56800E11366 /* SpikeClient.framework */; };
+		272AD3162168F56800E11366 /* SpikeClientUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 272AD3142168F56800E11366 /* SpikeClientUI.framework */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
 		4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */; };
@@ -446,6 +448,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		272AD3132168F56800E11366 /* SpikeClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SpikeClient.framework; path = Carthage/Build/iOS/SpikeClient.framework; sourceTree = "<group>"; };
+		272AD3142168F56800E11366 /* SpikeClientUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SpikeClientUI.framework; path = Carthage/Build/iOS/SpikeClientUI.framework; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
 		430B29892041F54A00BA9F93 /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
@@ -860,6 +864,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				272AD3152168F56800E11366 /* SpikeClient.framework in Frameworks */,
+				272AD3162168F56800E11366 /* SpikeClientUI.framework in Frameworks */,
 				4F7528941DFE1E9500C322D6 /* LoopUI.framework in Frameworks */,
 				434FB6461D68F1CD007B9C70 /* Amplitude.framework in Frameworks */,
 				43A8EC6F210E622700A81379 /* CGMBLEKitUI.framework in Frameworks */,
@@ -1400,6 +1406,8 @@
 		968DCD53F724DE56FFE51920 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				272AD3132168F56800E11366 /* SpikeClient.framework */,
+				272AD3142168F56800E11366 /* SpikeClientUI.framework */,
 				434FB6451D68F1CD007B9C70 /* Amplitude.framework */,
 				4344628420A7A3BE00C4BE6F /* CGMBLEKit.framework */,
 				438A95A71D8B9B24009D12E1 /* CGMBLEKit.framework */,
@@ -1842,6 +1850,8 @@
 				"$(SRCROOT)/Carthage/Build/iOS/MinimedKitUI.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/CGMBLEKitUI.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/ShareClientUI.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SpikeClientUI.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SpikeClient.framework",
 			);
 			name = "Copy Frameworks with Carthage";
 			outputPaths = (

--- a/Loop/Managers/CGMManager.swift
+++ b/Loop/Managers/CGMManager.swift
@@ -9,13 +9,14 @@ import LoopKit
 import CGMBLEKit
 import G4ShareSpy
 import ShareClient
-
+import SpikeClient
 
 let allCGMManagers: [CGMManager.Type] = [
     G6CGMManager.self,
     G5CGMManager.self,
     G4CGMManager.self,
     ShareClientManager.self,
+    SpikeClientManager.self,
 ]
 
 


### PR DESCRIPTION
This adds in my spike-client-swift which is a modified version of dexcom-share-client-swift. It allows loop to connect to the spike app running locally on port 1979 on the same device

![image](https://user-images.githubusercontent.com/442324/46633446-f057b400-cb4d-11e8-8940-468cb2458a63.png)
