### PR TITLE
More efficient use of complication user info transfers

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -290,6 +290,14 @@
 		7D7076631FE06EE4004AC8EA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D7076651FE06EE4004AC8EA /* Localizable.strings */; };
 		7D7076681FE0702F004AC8EA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D70766A1FE0702F004AC8EA /* InfoPlist.strings */; };
 		894F71E21FFEC4D8007D365C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 894F71E11FFEC4D8007D365C /* Assets.xcassets */; };
+		89732E79216A975B00069E29 /* WatchComplicationUpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E78216A975B00069E29 /* WatchComplicationUpdateManager.swift */; };
+		89732E7B216A981000069E29 /* DailyScheduleInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E7A216A981000069E29 /* DailyScheduleInterval.swift */; };
+		89732E7D216A981E00069E29 /* WatchSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E7C216A981E00069E29 /* WatchSettings.swift */; };
+		89732E7F216A983500069E29 /* DailyScheduleIntervalTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E7E216A983500069E29 /* DailyScheduleIntervalTableViewController.swift */; };
+		89732E83216A987900069E29 /* DateAndDurationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E80216A987900069E29 /* DateAndDurationTableViewCell.swift */; };
+		89732E84216A987900069E29 /* DateAndDurationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 89732E81216A987900069E29 /* DateAndDurationTableViewCell.xib */; };
+		89732E85216A987900069E29 /* DatePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E82216A987900069E29 /* DatePickerTableViewCell.swift */; };
+		89732E87216A988E00069E29 /* WakingHoursTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E86216A988D00069E29 /* WakingHoursTableViewController.swift */; };
 		C10428971D17BAD400DD539A /* NightscoutUploadKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */; };
 		C10B28461EA9BA5E006EA1FC /* far_future_high_bg_forecast.json in Resources */ = {isa = PBXBuildFile; fileRef = C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */; };
 		C11C87DE1E21EAAD00BB71D3 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
@@ -824,6 +832,14 @@
 		7DD382781F8DBFC60071272B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/MainInterface.strings; sourceTree = "<group>"; };
 		7DD382791F8DBFC60071272B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Interface.strings; sourceTree = "<group>"; };
 		894F71E11FFEC4D8007D365C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		89732E78216A975B00069E29 /* WatchComplicationUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchComplicationUpdateManager.swift; sourceTree = "<group>"; };
+		89732E7A216A981000069E29 /* DailyScheduleInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyScheduleInterval.swift; sourceTree = "<group>"; };
+		89732E7C216A981E00069E29 /* WatchSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettings.swift; sourceTree = "<group>"; };
+		89732E7E216A983500069E29 /* DailyScheduleIntervalTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyScheduleIntervalTableViewController.swift; sourceTree = "<group>"; };
+		89732E80216A987900069E29 /* DateAndDurationTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateAndDurationTableViewCell.swift; sourceTree = "<group>"; };
+		89732E81216A987900069E29 /* DateAndDurationTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DateAndDurationTableViewCell.xib; sourceTree = "<group>"; };
+		89732E82216A987900069E29 /* DatePickerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatePickerTableViewCell.swift; sourceTree = "<group>"; };
+		89732E86216A988D00069E29 /* WakingHoursTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakingHoursTableViewController.swift; sourceTree = "<group>"; };
 		C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NightscoutUploadKit.framework; path = Carthage/Build/iOS/NightscoutUploadKit.framework; sourceTree = SOURCE_ROOT; };
 		C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = far_future_high_bg_forecast.json; sourceTree = "<group>"; };
 		C12F21A61DFA79CB00748193 /* recommend_temp_basal_very_low_end_in_range.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = recommend_temp_basal_very_low_end_in_range.json; sourceTree = "<group>"; };
@@ -975,6 +991,8 @@
 				43D848AF1E7DCBE100DADCBC /* Result.swift */,
 				43441A9B1EDB34810087958C /* StatusExtensionContext+LoopKit.swift */,
 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
+				89732E7A216A981000069E29 /* DailyScheduleInterval.swift */,
+				89732E7C216A981E00069E29 /* WatchSettings.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1156,6 +1174,8 @@
 				43F5C2DA1B92A5E1003EB13D /* SettingsTableViewController.swift */,
 				43E3449E1B9D68E900C85C07 /* StatusTableViewController.swift */,
 				4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */,
+				89732E7E216A983500069E29 /* DailyScheduleIntervalTableViewController.swift */,
+				89732E86216A988D00069E29 /* WakingHoursTableViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -1166,6 +1186,9 @@
 				43B260481ED248FB008CAA77 /* CarbEntryTableViewCell.swift */,
 				4346D1E61C77F5FE00ABAFE3 /* ChartTableViewCell.swift */,
 				431A8C3F1EC6E8AB00823B9C /* CircleMaskView.swift */,
+				89732E80216A987900069E29 /* DateAndDurationTableViewCell.swift */,
+				89732E81216A987900069E29 /* DateAndDurationTableViewCell.xib */,
+				89732E82216A987900069E29 /* DatePickerTableViewCell.swift */,
 				43D381611EBD9759007F8C8F /* HeaderValuesTableViewCell.swift */,
 				430D85881F44037000AF2D4F /* HUDViewTableViewCell.swift */,
 				438D42FA1D7D11A4003244B0 /* PredictionInputEffectTableViewCell.swift */,
@@ -1194,6 +1217,7 @@
 				432E73CA1D24B3D6009AD15D /* RemoteDataManager.swift */,
 				430C1ABC1E5568A80067F1AE /* StatusChartsManager+LoopKit.swift */,
 				4F70C20F1DE8FAC5006380B7 /* StatusExtensionDataManager.swift */,
+				89732E78216A975B00069E29 /* WatchComplicationUpdateManager.swift */,
 				4328E0341CFC0AE100E199AA /* WatchDataManager.swift */,
 			);
 			path = Managers;
@@ -1688,6 +1712,7 @@
 				7D7076631FE06EE4004AC8EA /* Localizable.strings in Resources */,
 				43776F971B8022E90074EA36 /* Main.storyboard in Resources */,
 				C9886AE51E5B2FAD00473BB8 /* gallery.ckcomplication in Resources */,
+				89732E84216A987900069E29 /* DateAndDurationTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1862,6 +1887,7 @@
 				430B298A2041F54A00BA9F93 /* NSUserDefaults.swift in Sources */,
 				4315D28A1CA5F45E00589052 /* DiagnosticLogger+LoopKit.swift in Sources */,
 				4F2C15821E074FC600E160D4 /* NSTimeInterval.swift in Sources */,
+				89732E7D216A981E00069E29 /* WatchSettings.swift in Sources */,
 				4311FB9B1F37FE1B00D4C0A7 /* TitleSubtitleTextFieldTableViewCell.swift in Sources */,
 				430DA58E1D4AEC230097D1CA /* NSBundle.swift in Sources */,
 				43C513191E864C4E001547C7 /* GlucoseRangeSchedule.swift in Sources */,
@@ -1869,6 +1895,7 @@
 				43776F901B8022E90074EA36 /* AppDelegate.swift in Sources */,
 				4372E48B213CB5F00068E043 /* Double.swift in Sources */,
 				430B29932041F5B300BA9F93 /* UserDefaults+Loop.swift in Sources */,
+				89732E7B216A981000069E29 /* DailyScheduleInterval.swift in Sources */,
 				4341F4EB1EDB92AC001C936B /* LogglyService.swift in Sources */,
 				43CE7CDE1CA8B63E003CC1B0 /* Data.swift in Sources */,
 				43BFF0CB1E466C0900FF19A9 /* StateColorPalette.swift in Sources */,
@@ -1893,10 +1920,12 @@
 				4372E487213C86240068E043 /* SampleValue.swift in Sources */,
 				4346D1E71C77F5FE00ABAFE3 /* ChartTableViewCell.swift in Sources */,
 				437CEEE41CDE5C0A003C8C80 /* UIImage.swift in Sources */,
+				89732E7F216A983500069E29 /* DailyScheduleIntervalTableViewController.swift in Sources */,
 				43DBF0591C93F73800B3C386 /* CarbEntryTableViewController.swift in Sources */,
 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
 				43BFF0BC1E45C80600FF19A9 /* UIColor+Loop.swift in Sources */,
 				43C0944A1CACCC73001F6403 /* NotificationManager.swift in Sources */,
+				89732E87216A988E00069E29 /* WakingHoursTableViewController.swift in Sources */,
 				4F08DE9D1E81D0E9006741EA /* StatusChartsManager+LoopKit.swift in Sources */,
 				434FF1EE1CF27EEF000DB779 /* UITableViewCell.swift in Sources */,
 				439BED2A1E76093C00B0AED5 /* CGMManager.swift in Sources */,
@@ -1917,8 +1946,10 @@
 				4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */,
 				4374B5F4209D89A900D17AA8 /* TextFieldTableViewCell.swift in Sources */,
 				4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,
+				89732E79216A975B00069E29 /* WatchComplicationUpdateManager.swift in Sources */,
 				43DAD00020A2736F000F8529 /* PersistedPumpEvent.swift in Sources */,
 				438849EC1D29EC34003B3F23 /* AmplitudeService.swift in Sources */,
+				89732E85216A987900069E29 /* DatePickerTableViewCell.swift in Sources */,
 				43E93FB61E469A4000EAB8DB /* NumberFormatter.swift in Sources */,
 				4F08DE8F1E7BB871006741EA /* CollectionType+Loop.swift in Sources */,
 				435400341C9F878D00D5819C /* SetBolusUserInfo.swift in Sources */,
@@ -1938,6 +1969,7 @@
 				436A0DA51D236A2A00104B24 /* LoopError.swift in Sources */,
 				4F11D3C220DD80B3006E072C /* WatchHistoricalGlucose.swift in Sources */,
 				435CB6231F37967800C320C7 /* InsulinModelSettingsViewController.swift in Sources */,
+				89732E83216A987900069E29 /* DateAndDurationTableViewCell.swift in Sources */,
 				431E73481FF95A900069B5F7 /* PersistenceController.swift in Sources */,
 				4372E490213CFCE70068E043 /* LoopSettingsUserInfo.swift in Sources */,
 				43F78D261C8FC000002152D1 /* DoseMath.swift in Sources */,
@@ -2619,7 +2651,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Loop/Loop.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				INFOPLIST_FILE = Loop/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				"OTHER_SWIFT_FLAGS[sdk=iphonesimulator*]" = "-D IOS_SIMULATOR";
@@ -2636,7 +2668,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Loop/Loop.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				INFOPLIST_FILE = Loop/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_IDENTIFIER)";
@@ -2652,7 +2684,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WatchApp Extension/WatchApp Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -2672,7 +2704,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WatchApp Extension/WatchApp Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -2692,7 +2724,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				FRAMEWORK_SEARCH_PATHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
@@ -2713,7 +2745,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				FRAMEWORK_SEARCH_PATHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
@@ -2792,7 +2824,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Loop Status Extension/Loop Status Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_IDENTIFIER).statuswidget";
@@ -2811,7 +2843,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Loop Status Extension/Loop Status Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5Q5Q8W9ATZ;
 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MAIN_APP_BUNDLE_IDENTIFIER).statuswidget";

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		89732E84216A987900069E29 /* DateAndDurationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 89732E81216A987900069E29 /* DateAndDurationTableViewCell.xib */; };
 		89732E85216A987900069E29 /* DatePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E82216A987900069E29 /* DatePickerTableViewCell.swift */; };
 		89732E87216A988E00069E29 /* WakingHoursTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89732E86216A988D00069E29 /* WakingHoursTableViewController.swift */; };
+		8981B31D217179280078BC68 /* DailyScheduleTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8981B31C217179280078BC68 /* DailyScheduleTime.swift */; };
 		C10428971D17BAD400DD539A /* NightscoutUploadKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */; };
 		C10B28461EA9BA5E006EA1FC /* far_future_high_bg_forecast.json in Resources */ = {isa = PBXBuildFile; fileRef = C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */; };
 		C11C87DE1E21EAAD00BB71D3 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
@@ -840,6 +841,7 @@
 		89732E81216A987900069E29 /* DateAndDurationTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DateAndDurationTableViewCell.xib; sourceTree = "<group>"; };
 		89732E82216A987900069E29 /* DatePickerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatePickerTableViewCell.swift; sourceTree = "<group>"; };
 		89732E86216A988D00069E29 /* WakingHoursTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakingHoursTableViewController.swift; sourceTree = "<group>"; };
+		8981B31C217179280078BC68 /* DailyScheduleTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyScheduleTime.swift; sourceTree = "<group>"; };
 		C10428961D17BAD400DD539A /* NightscoutUploadKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NightscoutUploadKit.framework; path = Carthage/Build/iOS/NightscoutUploadKit.framework; sourceTree = SOURCE_ROOT; };
 		C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = far_future_high_bg_forecast.json; sourceTree = "<group>"; };
 		C12F21A61DFA79CB00748193 /* recommend_temp_basal_very_low_end_in_range.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = recommend_temp_basal_very_low_end_in_range.json; sourceTree = "<group>"; };
@@ -982,6 +984,8 @@
 				43880F961D9D8052009061A8 /* ServiceAuthentication */,
 				43DE92601C555C26001FFDE1 /* AbsorptionTimeType+CarbKit.swift */,
 				C17824A41E1AD4D100D9D25C /* BolusRecommendation.swift */,
+				89732E7A216A981000069E29 /* DailyScheduleInterval.swift */,
+				8981B31C217179280078BC68 /* DailyScheduleTime.swift */,
 				43C2FAE01EB656A500364AFF /* GlucoseEffectVelocity.swift */,
 				4374B5F1209D897600D17AA8 /* Locked.swift */,
 				436A0DA41D236A2A00104B24 /* LoopError.swift */,
@@ -991,7 +995,6 @@
 				43D848AF1E7DCBE100DADCBC /* Result.swift */,
 				43441A9B1EDB34810087958C /* StatusExtensionContext+LoopKit.swift */,
 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
-				89732E7A216A981000069E29 /* DailyScheduleInterval.swift */,
 				89732E7C216A981E00069E29 /* WatchSettings.swift */,
 			);
 			path = Models;
@@ -1944,6 +1947,7 @@
 				43BFF0C51E465A2D00FF19A9 /* UIColor+HIG.swift in Sources */,
 				43785E982120E7060057DED1 /* Intents.intentdefinition in Sources */,
 				4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */,
+				8981B31D217179280078BC68 /* DailyScheduleTime.swift in Sources */,
 				4374B5F4209D89A900D17AA8 /* TextFieldTableViewCell.swift in Sources */,
 				4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,
 				89732E79216A975B00069E29 /* WatchComplicationUpdateManager.swift in Sources */,

--- a/Loop/Extensions/UserDefaults+Loop.swift
+++ b/Loop/Extensions/UserDefaults+Loop.swift
@@ -39,6 +39,7 @@ extension UserDefaults {
 extension UserDefaults {
     private enum Key: String {
         case pumpManagerState = "com.loopkit.Loop.PumpManagerState"
+        case watchSettings = "com.loopkit.Loop.WatchSettings"
     }
 
     var pumpManager: PumpManager? {
@@ -72,6 +73,19 @@ extension UserDefaults {
         }
         set {
             cgmManagerState = newValue?.rawValue
+        }
+    }
+
+    var watchSettings: WatchSettings? {
+        get {
+            if let rawValue = dictionary(forKey: Key.watchSettings.rawValue) {
+                return WatchSettings(rawValue: rawValue)
+            } else {
+                return nil
+            }
+        }
+        set {
+            set(newValue?.rawValue, forKey: Key.watchSettings.rawValue)
         }
     }
 }

--- a/Loop/Managers/AnalyticsManager.swift
+++ b/Loop/Managers/AnalyticsManager.swift
@@ -130,6 +130,11 @@ final class AnalyticsManager: IdentifiableClass {
         }
     }
 
+    func didChangeWatchSettings(from oldValue: WatchSettings, to newValue: WatchSettings) {
+        if newValue.wakingHours != oldValue.wakingHours {
+            logEvent("Waking hours change")
+        }
+    }
 
     // MARK: - Loop Events
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -79,11 +79,11 @@ final class DeviceDataManager {
 
     // MARK: - WatchKit
 
-    fileprivate var watchManager: WatchDataManager!
+    private(set) var watchManager: WatchDataManager!
 
     // MARK: - Status Extension
 
-    fileprivate var statusExtensionManager: StatusExtensionDataManager!
+    private var statusExtensionManager: StatusExtensionDataManager!
 
     // MARK: - Initialization
 

--- a/Loop/Managers/WatchComplicationUpdateManager.swift
+++ b/Loop/Managers/WatchComplicationUpdateManager.swift
@@ -56,7 +56,7 @@ final class WatchComplicationUpdateManager {
             return remainingTimeInWakingHours / Double(WCSession.default.remainingComplicationUserInfoTransfers + 1)
         } else {
             // Sleeping hours now; send next complication user info transfer at beginning of waking hours.
-            return wakingHours.nextStartDate(after: now).timeIntervalSince(now)
+            return wakingHours.nextStartDate(after: now)?.timeIntervalSince(now) ?? .hours(24)
         }
     }
 

--- a/Loop/Managers/WatchComplicationUpdateManager.swift
+++ b/Loop/Managers/WatchComplicationUpdateManager.swift
@@ -1,0 +1,121 @@
+//
+//  WatchComplicationUpdateManager.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 9/23/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import WatchConnectivity
+
+
+final class WatchComplicationUpdateManager {
+    private unowned let watchManager: WatchDataManager
+    private let log: CategoryLogger
+
+    init(watchManager: WatchDataManager) {
+        self.watchManager = watchManager
+        self.log = watchManager.deviceManager.logger.forCategory("WatchComplicationUpdateManager")
+        configureBudgetUpdateObservation()
+    }
+
+    var lastComplicationContext: WatchContext?
+
+    func shouldUpdateComplicationImmediately(with context: WatchContext) -> Bool {
+        if let lastComplicationContextGlucoseDate = lastComplicationContext?.glucoseDate,
+            let newContextGlucoseDate = context.glucoseDate {
+            // Ensure a new glucose value has been received.
+            guard lastComplicationContextGlucoseDate != newContextGlucoseDate else {
+                return false
+            }
+        }
+
+        if watchManager.settings.wakingHours.isInProgress() {
+            return enoughTimePassedToUpdate(with: context) || enoughTrendDriftToUpdate(with: context)
+        } else {
+            // Ignore trend drift during sleeping hours.
+            return enoughTimePassedToUpdate(with: context)
+        }
+    }
+
+    private func enoughTimePassedToUpdate(with context: WatchContext) -> Bool {
+        guard let lastComplicationContext = lastComplicationContext else {
+            // No complication update sent yet.
+            return true
+        }
+        return context.creationDate.timeIntervalSince(lastComplicationContext.creationDate) >= complicationUserInfoTransferInterval
+    }
+
+    private var complicationUserInfoTransferInterval: TimeInterval {
+        let wakingHours = watchManager.settings.wakingHours
+        let now = Date()
+        if wakingHours.isInProgress(at: now) {
+            let nowUntilBudgetReset = DateInterval(start: now, end: WCSession.expectedComplicationUserInfoTransferBudgetResetDate)
+            let remainingTimeInWakingHours = wakingHours.durationInProgress(in: nowUntilBudgetReset)
+            return remainingTimeInWakingHours / Double(WCSession.default.remainingComplicationUserInfoTransfers + 1)
+        } else {
+            // Sleeping hours now; send next complication user info transfer at beginning of waking hours.
+            return wakingHours.nextStartDate(after: now).timeIntervalSince(now)
+        }
+    }
+
+    private let minTrendDriftToUpdate = (amount: 20 as Double, unit: HKUnit.milligramsPerDeciliter)
+
+    private func enoughTrendDriftToUpdate(with context: WatchContext) -> Bool {
+        guard let lastComplicationUpdateContext = lastComplicationContext else {
+            // No complication update sent yet.
+            return true
+        }
+
+        guard let lastGlucose = lastComplicationUpdateContext.glucose, let newGlucose = context.glucose else {
+            // Glucose values unavailable to compare.
+            return false
+        }
+
+        let normalized = { (glucose: HKQuantity) in glucose.doubleValue(for: self.minTrendDriftToUpdate.unit) }
+        let trendDrift = abs(normalized(newGlucose) - normalized(lastGlucose))
+        return trendDrift >= minTrendDriftToUpdate.amount
+    }
+
+    // MARK: - Logging
+
+    private var budgetUpdateObservationToken: NSKeyValueObservation?
+
+    private var lastLoggedRemainingUpdates: Int?
+
+    deinit {
+        budgetUpdateObservationToken?.invalidate()
+    }
+
+    private func configureBudgetUpdateObservation() {
+        budgetUpdateObservationToken = WCSession.default.observe(\.remainingComplicationUserInfoTransfers, options: [.initial, .new]) { [weak self] session, change in
+            guard let self = self else { return }
+            if let newValue = change.newValue, newValue != self.lastLoggedRemainingUpdates {
+                self.log.debug(["remainingComplicationUserInfoTransfers": newValue])
+                self.lastLoggedRemainingUpdates = newValue
+            }
+        }
+    }
+}
+
+private extension WCSession {
+    static var expectedComplicationUserInfoTransferBudgetResetDate: Date {
+        let now = Date()
+        if let fiveAM = Calendar.current.nextDate(after: now, matching: DateComponents(hour: 5), matchingPolicy: .nextTime) {
+            return fiveAM
+        } else {
+            return now.addingTimeInterval(.hours(24))
+        }
+    }
+}
+
+extension WatchComplicationUpdateManager: CustomDebugStringConvertible {
+    var debugDescription: String {
+        return """
+        ### WatchComplicationUpdateManager
+        * lastComplicationContext: \(String(reflecting: lastComplicationContext))
+        * complicationUserInfoTransferInterval: \(String(format: "%.1f", complicationUserInfoTransferInterval.minutes))min
+        """
+    }
+}

--- a/Loop/Models/DailyScheduleInterval.swift
+++ b/Loop/Models/DailyScheduleInterval.swift
@@ -1,0 +1,269 @@
+//
+//  DailyScheduleInterval.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 9/24/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+/// Represents a time on a daily schedule as an offset from midnight.
+/// Only values in seconds between 0 and 24 hours are valid.
+typealias DailyScheduleTime = TimeInterval
+
+private extension DailyScheduleTime {
+    var isValid: Bool {
+        let validRange = 0..<TimeInterval(hours: 24)
+        return validRange.contains(self)
+    }
+
+    func relative(to date: Date, calendar: Calendar = .current) -> Date {
+        let startOfDay = calendar.startOfDay(for: date)
+        return startOfDay.addingTimeInterval(self)
+    }
+}
+
+private func assertValid(_ time: DailyScheduleTime) {
+    assert(time.isValid, "DailyScheduleTime values must represent a number of seconds between 0 and 24 hours.")
+}
+
+/// Represents a daily schedule interval relative to a specific date.
+enum DateRelativeDailyScheduleInterval {
+    case closed(DateInterval)
+    case disjoint(morning: DateInterval, evening: DateInterval)
+
+    func contains(_ date: Date) -> Bool {
+        switch self {
+        case .closed(let interval):
+            return interval.contains(date)
+        case .disjoint(morning: let morning, evening: let evening):
+            return morning.contains(date) || evening.contains(date)
+        }
+    }
+
+    var duration: TimeInterval {
+        switch self {
+        case .closed(let interval):
+            return interval.duration
+        case .disjoint(morning: let morning, evening: let evening):
+            return morning.duration + evening.duration
+        }
+    }
+}
+
+/// Represents a continuous interval of time in a daily schedule.
+/// The interval may cross midnight, in which case the value models the combination of
+/// an interval in the morning and an interval in the evening.
+///
+/// The following diagram demonstrates the two types of intervals
+/// that can be modeled by `DailySchedulePeriod`:
+/// ```
+/// 1) Closed interval within the day
+///       ●────────────────●
+///            6am-10pm
+///
+/// 2) Disjoint intervals overlapping days
+///  ─────●                ●──
+///            10pm-6am
+///
+///  ◆───────────◆───────────◆
+/// 12am        12pm       12am
+/// ```
+enum DailyScheduleInterval {
+    case closed(ClosedRange<DailyScheduleTime>)
+    case disjoint(morning: PartialRangeThrough<DailyScheduleTime>, evening: PartialRangeFrom<DailyScheduleTime>)
+
+    var startTime: DailyScheduleTime {
+        get {
+            switch self {
+            case .closed(let range):
+                return range.lowerBound
+            case .disjoint(morning: _, evening: let evening):
+                return evening.lowerBound
+            }
+        }
+        set {
+            self = DailyScheduleInterval(startTime: newValue, endTime: endTime)
+        }
+    }
+
+    var endTime: DailyScheduleTime {
+        get {
+            switch self {
+            case .closed(let range):
+                return range.upperBound
+            case .disjoint(morning: let morning, evening: _):
+                return morning.upperBound
+            }
+        }
+        set {
+            self = DailyScheduleInterval(startTime: startTime, endTime: newValue)
+        }
+    }
+
+    init(startTime: DailyScheduleTime, endTime: DailyScheduleTime) {
+        assertValid(startTime); assertValid(endTime)
+        if startTime > endTime {
+            self = .disjoint(morning: ...endTime, evening: startTime...)
+        } else {
+            self = .closed(startTime...endTime)
+        }
+    }
+
+    func contains(_ time: DailyScheduleTime) -> Bool {
+        assertValid(time)
+        switch self {
+        case .closed(let range):
+            return range.contains(time)
+        case .disjoint(morning: let morning, evening: let evening):
+            return morning.contains(time) || evening.contains(time)
+        }
+    }
+
+    /// Returns the date interval(s) corresponding to the daily schedule interval
+    /// on the given date.
+    /// ```
+    /// 1) Closed interval
+    ///       ●────────────────●
+    ///            6am-10pm
+    ///
+    /// 2) Disjoint intervals
+    ///  ●────●                ●─●
+    ///            10pm-6am
+    ///
+    ///  ◆───────────◆───────────◆
+    /// 12am        12pm       12am
+    /// ```
+    func relative(to date: Date, calendar: Calendar = .current) -> DateRelativeDailyScheduleInterval {
+        switch self {
+        case .closed(let range):
+            return .closed(DateInterval(start: range.lowerBound.relative(to: date, calendar: calendar), end: range.upperBound.relative(to: date, calendar: calendar)))
+        case .disjoint(morning: let morning, evening: let evening):
+            guard let dayInterval = calendar.dateInterval(of: .day, for: date) else {
+                preconditionFailure("Unable to get day interval for \(date)")
+            }
+            return .disjoint(
+                morning: DateInterval(start: dayInterval.start, end: morning.upperBound.relative(to: date, calendar: calendar)),
+                evening: DateInterval(start: evening.lowerBound.relative(to: date, calendar: calendar), end: dayInterval.end)
+            )
+        }
+    }
+
+    var duration: TimeInterval {
+        return relative(to: Date(timeIntervalSince1970: 0)).duration
+    }
+
+    func isInProgress(at date: Date = Date(), calendar: Calendar = .current) -> Bool {
+        return relative(to: date, calendar: calendar).contains(date)
+    }
+
+    /// Returns a single date interval corresponding to the daily schedule interval
+    /// beginning on the given date.
+    /// ```
+    /// 1) Closed interval within the day
+    ///       ●────────────────●
+    ///            6am-10pm
+    ///
+    /// 2) Interval overlapping days
+    ///                        ●───────●
+    ///                        10pm-6am
+    ///
+    ///  ◆───────────◆───────────◆───────────◆
+    /// 12am        12pm       12am         12pm
+    /// ```
+    func dateInterval(beginningOnDayOf date: Date, calendar: Calendar = .current) -> DateInterval {
+        switch relative(to: date) {
+        case .closed(let interval):
+            return interval
+        case .disjoint(morning: let morning, evening: let evening):
+            guard let nextMorning = calendar.date(byAdding: .day, value: 1, to: morning.end) else {
+                preconditionFailure("Unable to compute the day after \(morning.end)")
+            }
+            return DateInterval(start: evening.start, end: nextMorning)
+        }
+    }
+
+    /// Returns the next date after the given date on which the daily schedule interval begins.
+    func nextStartDate(after date: Date, calendar: Calendar = .current) -> Date {
+        let startDateOnDayOf = { self.dateInterval(beginningOnDayOf: $0, calendar: calendar).start }
+        if case let startDate = startDateOnDayOf(date), startDate > date {
+            return startDate
+        } else {
+            guard let nextDay = calendar.date(byAdding: .day, value: 1, to: date) else {
+                preconditionFailure("Unable to compute the day after \(date)")
+            }
+            return startDateOnDayOf(nextDay)
+        }
+    }
+
+    /// Returns the duration for which the daily schedule is in progress
+    /// in the given date interval.
+    /// - Precondition: The given interval must span no more than one day.
+    func durationInProgress(in interval: DateInterval, calendar: Calendar = .current) -> TimeInterval {
+        let oneDayAfterStart = calendar.date(byAdding: .day, value: 1, to: interval.start)!
+        precondition(interval.end <= oneDayAfterStart, "End date must be within a day after start date.")
+        let startDayInterval = dateInterval(beginningOnDayOf: interval.start)
+        let endDayInterval = dateInterval(beginningOnDayOf: interval.end)
+        let intersectionDuration = { interval.intersection(with: $0)?.duration ?? 0 }
+        if startDayInterval == endDayInterval {
+            // `interval` starts and ends on the same day; avoid double-counting intersection
+            return intersectionDuration(startDayInterval)
+        } else {
+            return intersectionDuration(startDayInterval) + intersectionDuration(endDayInterval)
+        }
+    }
+
+    /// Returns a pair of dates with times matching the interval start and end times.
+    /// Do not rely on any property of these dates other than their offsets from midnight.
+    func dayInsensitiveDates() -> (start: Date, end: Date) {
+        let referenceDate = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 0))
+        return (start: referenceDate + startTime, end: referenceDate + endTime)
+    }
+
+    /// Returns the complementary daily schedule interval for this interval.
+    ///
+    /// For example, 6am-10pm and 10pm-6am are complements.
+    /// ```
+    ///       ●────────────────●
+    ///            6am-10pm
+    ///
+    ///  ─────●                ●──
+    ///            10pm-6am
+    ///
+    ///  ◆───────────◆───────────◆
+    /// 12am        12pm       12am
+    /// ```
+    func complement() -> DailyScheduleInterval {
+        return DailyScheduleInterval(startTime: endTime, endTime: startTime)
+    }
+}
+
+extension DailyScheduleInterval: CustomStringConvertible {
+    var description: String {
+        let descriptionFormat = NSLocalizedString("%1$@ – %2$@", comment: "Format string for daily schedule period. (1: Start time)(2: End time)")
+        let formatDate = { DateFormatter.localizedString(from: $0, dateStyle: .none, timeStyle: .short) }
+        let dates = dayInsensitiveDates()
+        return String(format: descriptionFormat, formatDate(dates.start), formatDate(dates.end))
+    }
+}
+
+extension DailyScheduleInterval: RawRepresentable {
+    typealias RawValue = [DailyScheduleTime]
+
+    init?(rawValue: RawValue) {
+        guard
+            rawValue.count == 2,
+            rawValue.allSatisfy({ $0.isValid })
+        else {
+            return nil
+        }
+
+        self.init(startTime: rawValue[0], endTime: rawValue[1])
+    }
+
+    var rawValue: RawValue {
+        return [startTime, endTime]
+    }
+}

--- a/Loop/Models/DailyScheduleTime.swift
+++ b/Loop/Models/DailyScheduleTime.swift
@@ -1,0 +1,82 @@
+//
+//  DailyScheduleTime.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 10/12/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+private func isValidHour(_ hour: Int) -> Bool {
+    return (0..<24).contains(hour)
+}
+
+private func isValidMinute(_ minute: Int) -> Bool {
+    return (0..<60).contains(minute)
+}
+
+/// Represents a time on a daily schedule.
+struct DailyScheduleTime: Hashable {
+    let hour: Int
+    let minute: Int
+
+    init(hour: Int, minute: Int = 0) {
+        precondition(isValidHour(hour), "The hour component of a daily schedule time must fall in the range 0..<24")
+        precondition(isValidMinute(minute), "The minute component of a daily schedule time must fall in the range 0..<60")
+        self.hour = hour
+        self.minute = minute
+    }
+
+    init(of date: Date, calendar: Calendar = .current) {
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        self.init(dateComponents: components)!
+    }
+
+    init?(dateComponents: DateComponents) {
+        guard let hour = dateComponents.hour, let minute = dateComponents.minute else {
+            return nil
+        }
+        self.init(hour: hour, minute: minute)
+    }
+
+    static func hour(_ hour: Int) -> DailyScheduleTime {
+        return self.init(hour: hour)
+    }
+
+    var dateComponents: DateComponents {
+        return DateComponents(hour: hour, minute: minute)
+    }
+
+    func relative(toDayOf date: Date, calendar: Calendar = .current) -> Date? {
+        let startOfDay = calendar.startOfDay(for: date)
+        return calendar.nextDate(after: startOfDay, matching: dateComponents, matchingPolicy: .nextTime)
+    }
+}
+
+extension DailyScheduleTime: Comparable {
+    static func < (lhs: DailyScheduleTime, rhs: DailyScheduleTime) -> Bool {
+        return (lhs.hour, lhs.minute) < (rhs.hour, rhs.minute)
+    }
+}
+
+extension DailyScheduleTime: RawRepresentable {
+    typealias RawValue = [Int]
+
+    init?(rawValue: RawValue) {
+        guard
+            rawValue.count == 2,
+            case let (hour, minute) = (rawValue[0], rawValue[1]),
+            isValidHour(hour), isValidMinute(minute)
+        else {
+            return nil
+        }
+
+        self.init(hour: hour, minute: minute)
+    }
+
+    var rawValue: [Int] {
+        return [hour, minute]
+    }
+}

--- a/Loop/Models/WatchSettings.swift
+++ b/Loop/Models/WatchSettings.swift
@@ -1,0 +1,54 @@
+//
+//  WatchSettings.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 9/24/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+struct WatchSettings {
+    var wakingHours: DailyScheduleInterval
+}
+
+extension WatchSettings {
+    static var `default`: WatchSettings {
+        return WatchSettings(wakingHours: DailyScheduleInterval(startTime: .hours(6), endTime: .hours(22)))
+    }
+
+    var sleepingHours: DailyScheduleInterval {
+        return wakingHours.complement()
+    }
+}
+
+extension WatchSettings: RawRepresentable {
+    typealias RawValue = [String: Any]
+    private static let version = 1
+
+    private enum Key: String {
+        case version = "version"
+        case wakingHours = "wakingHours"
+    }
+
+    init?(rawValue: RawValue) {
+        guard
+            let version = rawValue[Key.version.rawValue] as? Int,
+            version == WatchSettings.version,
+            let wakingHoursRawValue = rawValue[Key.wakingHours.rawValue] as? DailyScheduleInterval.RawValue,
+            let wakingHours = DailyScheduleInterval(rawValue: wakingHoursRawValue)
+            else {
+                return nil
+        }
+
+        self.init(wakingHours: wakingHours)
+    }
+
+    var rawValue: RawValue {
+        return [
+            Key.version.rawValue: WatchSettings.version,
+            Key.wakingHours.rawValue: wakingHours.rawValue
+        ]
+    }
+}

--- a/Loop/Models/WatchSettings.swift
+++ b/Loop/Models/WatchSettings.swift
@@ -15,7 +15,7 @@ struct WatchSettings {
 
 extension WatchSettings {
     static var `default`: WatchSettings {
-        return WatchSettings(wakingHours: DailyScheduleInterval(startTime: .hours(6), endTime: .hours(22)))
+        return WatchSettings(wakingHours: DailyScheduleInterval(startTime: .hour(6), endTime: .hour(22)))
     }
 
     var sleepingHours: DailyScheduleInterval {

--- a/Loop/View Controllers/DailyScheduleIntervalTableViewController.swift
+++ b/Loop/View Controllers/DailyScheduleIntervalTableViewController.swift
@@ -1,0 +1,113 @@
+//
+//  DailyScheduleIntervalTableViewController.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 9/24/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+
+protocol DailyScheduleIntervalTableViewControllerDelegate: AnyObject {
+    func dailyScheduleIntervalTableViewController(_ controller: DailyScheduleIntervalTableViewController, dailyScheduleIntervalDidChangeTo dailyScheduleInterval: DailyScheduleInterval)
+}
+
+class DailyScheduleIntervalTableViewController: UITableViewController {
+    var dailyScheduleInterval: DailyScheduleInterval
+
+    weak var delegate: DailyScheduleIntervalTableViewControllerDelegate?
+
+    init(dailyScheduleInterval: DailyScheduleInterval) {
+        self.dailyScheduleInterval = dailyScheduleInterval
+        super.init(style: .grouped)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.register(DateAndDurationTableViewCell.nib(), forCellReuseIdentifier: DateAndDurationTableViewCell.className)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    enum Row: Int, CaseIterable {
+        case startTime
+        case endTime
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Row.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: DateAndDurationTableViewCell.className, for: indexPath) as! DateAndDurationTableViewCell
+        cell.datePicker.datePickerMode = .time
+        let row = Row(rawValue: indexPath.row)!
+        cell.titleLabel.text = title(for: row)
+        cell.date = {
+            let dayInsensitiveDates = dailyScheduleInterval.dayInsensitiveDates()
+            switch row {
+            case .startTime:
+                return dayInsensitiveDates.start
+            case .endTime:
+                return dayInsensitiveDates.end
+            }
+        }()
+        cell.delegate = self
+
+        return cell
+    }
+
+    func title(for row: Row) -> String {
+        switch row {
+        case .startTime:
+            return NSLocalizedString("Start Time", comment: "The title text for the daily schedule interval picker start time cell")
+        case .endTime:
+            return NSLocalizedString("End Time", comment: "The title text for the daily schedule interval picker end time cell")
+        }
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        tableView.endEditing(false)
+        tableView.beginUpdates()
+        hideDatePickerCells(excluding: indexPath)
+        return indexPath
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.endUpdates()
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+extension DailyScheduleIntervalTableViewController: DatePickerTableViewCellDelegate {
+    func datePickerTableViewCellDidUpdateDate(_ cell: DatePickerTableViewCell) {
+        guard let indexPath = tableView.indexPath(for: cell) else { return }
+        switch Row(rawValue: indexPath.row)! {
+        case .startTime:
+            dailyScheduleInterval.startTime = cell.date.timeIntervalSinceMidnight
+        case .endTime:
+            dailyScheduleInterval.endTime = cell.date.timeIntervalSinceMidnight
+        }
+
+        delegate?.dailyScheduleIntervalTableViewController(self, dailyScheduleIntervalDidChangeTo: dailyScheduleInterval)
+    }
+}
+
+private extension Date {
+    var timeIntervalSinceMidnight: DailyScheduleTime {
+        let midnight = Calendar.current.startOfDay(for: self)
+        return timeIntervalSince(midnight)
+    }
+}

--- a/Loop/View Controllers/DailyScheduleIntervalTableViewController.swift
+++ b/Loop/View Controllers/DailyScheduleIntervalTableViewController.swift
@@ -96,18 +96,11 @@ extension DailyScheduleIntervalTableViewController: DatePickerTableViewCellDeleg
         guard let indexPath = tableView.indexPath(for: cell) else { return }
         switch Row(rawValue: indexPath.row)! {
         case .startTime:
-            dailyScheduleInterval.startTime = cell.date.timeIntervalSinceMidnight
+            dailyScheduleInterval.startTime = DailyScheduleTime(of: cell.date)
         case .endTime:
-            dailyScheduleInterval.endTime = cell.date.timeIntervalSinceMidnight
+            dailyScheduleInterval.endTime = DailyScheduleTime(of: cell.date)
         }
 
         delegate?.dailyScheduleIntervalTableViewController(self, dailyScheduleIntervalDidChangeTo: dailyScheduleInterval)
-    }
-}
-
-private extension Date {
-    var timeIntervalSinceMidnight: DailyScheduleTime {
-        let midnight = Calendar.current.startOfDay(for: self)
-        return timeIntervalSince(midnight)
     }
 }

--- a/Loop/View Controllers/WakingHoursTableViewController.swift
+++ b/Loop/View Controllers/WakingHoursTableViewController.swift
@@ -1,0 +1,33 @@
+//
+//  WakingHoursTableViewController.swift
+//  Loop
+//
+//  Created by Michael Pangburn on 9/25/18.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+
+final class WakingHoursTableViewController: DailyScheduleIntervalTableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = NSLocalizedString("Waking Hours", comment: "The title of the waking hours configuration screen")
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func title(for row: Row) -> String {
+        switch row {
+        case .startTime:
+            return NSLocalizedString("Wake Time", comment: "The title text for the Apple Watch wake time setting cell")
+        case .endTime:
+            return NSLocalizedString("Bed Time", comment: "The title text for the Apple Watch bed time setting cell")
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return NSLocalizedString("Loop uses your waking hours to better keep your Apple Watch complication up to date.", comment: "The footer text for the waking hours selection screen")
+    }
+}

--- a/Loop/Views/DateAndDurationTableViewCell.swift
+++ b/Loop/Views/DateAndDurationTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  DateAndDurationTableViewCell.swift
+//  LoopKitUI
+//
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+class DateAndDurationTableViewCell: DatePickerTableViewCell, NibLoadable {
+
+    weak var delegate: DatePickerTableViewCellDelegate?
+
+    @IBOutlet weak var titleLabel: UILabel!
+
+    @IBOutlet weak var dateLabel: UILabel!
+
+    private lazy var durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .short
+
+        return formatter
+    }()
+
+    override func updateDateLabel() {
+        switch datePicker.datePickerMode {
+        case .countDownTimer:
+            dateLabel.text = durationFormatter.string(from: duration)
+        case .date, .dateAndTime:
+            dateLabel.text = DateFormatter.localizedString(from: date, dateStyle: .short, timeStyle: .short)
+        case .time:
+            dateLabel.text = DateFormatter.localizedString(from: date, dateStyle: .none, timeStyle: .short)
+        }
+    }
+
+    override func dateChanged(_ sender: UIDatePicker) {
+        super.dateChanged(sender)
+
+        delegate?.datePickerTableViewCellDidUpdateDate(self)
+    }
+}

--- a/Loop/Views/DateAndDurationTableViewCell.xib
+++ b/Loop/Views/DateAndDurationTableViewCell.xib
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="244" id="g8V-eF-Mfe" customClass="DateAndDurationTableViewCell" customModule="LoopKitUI" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="244"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="g8V-eF-Mfe" id="5ZV-xx-TUU">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="243.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R2S-Ub-M7W">
+                        <rect key="frame" x="16" y="11" width="343" height="28"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lrl-hk-6Uj">
+                                <rect key="frame" x="0.0" y="0.0" width="36" height="28"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AQf-Rb-UwO">
+                                <rect key="frame" x="301" y="0.0" width="42" height="28"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="lrl-hk-6Uj" firstAttribute="top" secondItem="R2S-Ub-M7W" secondAttribute="top" id="3uk-QP-JjL"/>
+                            <constraint firstAttribute="trailing" secondItem="AQf-Rb-UwO" secondAttribute="trailing" id="5a8-7D-t3d"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="7Jq-HV-uMc"/>
+                            <constraint firstItem="AQf-Rb-UwO" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="lrl-hk-6Uj" secondAttribute="trailing" constant="8" symbolic="YES" id="855-2i-Bjg"/>
+                            <constraint firstAttribute="bottom" secondItem="AQf-Rb-UwO" secondAttribute="bottom" id="dca-Sb-3xJ"/>
+                            <constraint firstItem="lrl-hk-6Uj" firstAttribute="leading" secondItem="R2S-Ub-M7W" secondAttribute="leading" id="dhX-4T-BRJ"/>
+                            <constraint firstItem="AQf-Rb-UwO" firstAttribute="top" secondItem="R2S-Ub-M7W" secondAttribute="top" id="gZJ-Ic-zYx"/>
+                            <constraint firstAttribute="bottom" secondItem="lrl-hk-6Uj" secondAttribute="bottom" id="y2J-K7-2r6"/>
+                        </constraints>
+                    </view>
+                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="uHg-qt-dX0">
+                        <rect key="frame" x="0.0" y="47" width="375" height="194"/>
+                        <constraints>
+                            <constraint firstAttribute="height" priority="750" constant="200" id="V2S-yZ-Wpl"/>
+                        </constraints>
+                        <date key="date" timeIntervalSinceReferenceDate="474584803.36239803">
+                            <!--2016-01-15 21:06:43 +0000-->
+                        </date>
+                        <connections>
+                            <action selector="dateChanged:" destination="g8V-eF-Mfe" eventType="valueChanged" id="eHp-Or-G7k"/>
+                        </connections>
+                    </datePicker>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="uHg-qt-dX0" firstAttribute="leading" secondItem="5ZV-xx-TUU" secondAttribute="leading" id="8mt-Np-dQX"/>
+                    <constraint firstAttribute="trailing" secondItem="uHg-qt-dX0" secondAttribute="trailing" id="DIU-Dd-v1R"/>
+                    <constraint firstItem="uHg-qt-dX0" firstAttribute="top" secondItem="R2S-Ub-M7W" secondAttribute="bottom" constant="8" id="Fb5-66-uiW"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="uHg-qt-dX0" secondAttribute="bottom" priority="750" constant="-8" id="U4P-Ys-AuD"/>
+                    <constraint firstItem="R2S-Ub-M7W" firstAttribute="leading" secondItem="5ZV-xx-TUU" secondAttribute="leadingMargin" id="VSV-R2-CjN"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="R2S-Ub-M7W" secondAttribute="trailing" id="fmT-fS-Gar"/>
+                    <constraint firstItem="R2S-Ub-M7W" firstAttribute="top" secondItem="5ZV-xx-TUU" secondAttribute="topMargin" id="kfl-01-9t8"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="dateLabel" destination="AQf-Rb-UwO" id="2Zm-Dx-YYA"/>
+                <outlet property="datePicker" destination="uHg-qt-dX0" id="Ejf-tw-dz0"/>
+                <outlet property="datePickerHeightConstraint" destination="V2S-yZ-Wpl" id="8lN-gu-CDh"/>
+                <outlet property="titleLabel" destination="lrl-hk-6Uj" id="aBm-pc-R9W"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Loop/Views/DatePickerTableViewCell.swift
+++ b/Loop/Views/DatePickerTableViewCell.swift
@@ -1,0 +1,109 @@
+//
+//  DatePickerTableViewCell.swift
+//  CarbKit
+//
+//  Created by Nathan Racklyeft on 1/15/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import UIKit
+
+protocol DatePickerTableViewCellDelegate: class {
+    func datePickerTableViewCellDidUpdateDate(_ cell: DatePickerTableViewCell)
+}
+
+
+class DatePickerTableViewCell: UITableViewCell {
+
+    var date: Date {
+        get {
+            return datePicker.date
+        }
+        set {
+            datePicker.setDate(newValue, animated: true)
+            updateDateLabel()
+        }
+    }
+
+    var duration: TimeInterval {
+        get {
+            return datePicker.countDownDuration
+        }
+        set {
+            datePicker.countDownDuration = newValue
+            updateDateLabel()
+        }
+    }
+
+    var maximumDuration = TimeInterval(hours: 8) {
+        didSet {
+            if duration > maximumDuration {
+                duration = maximumDuration
+            }
+        }
+    }
+
+    @IBOutlet weak var datePicker: UIDatePicker!
+
+    @IBOutlet private weak var datePickerHeightConstraint: NSLayoutConstraint!
+
+    private var datePickerExpandedHeight: CGFloat = 0
+
+    var isDatePickerHidden: Bool {
+        get {
+            return datePicker.isHidden || !datePicker.isEnabled
+        }
+        set {
+            if datePicker.isEnabled {
+                datePicker.isHidden = newValue
+                datePickerHeightConstraint.constant = newValue ? 0 : datePickerExpandedHeight
+
+                if !newValue, case .countDownTimer = datePicker.datePickerMode {
+                    // Workaround for target-action change notifications not firing if initial value is set while view is hidden
+                    DispatchQueue.main.async {
+                        self.datePicker.date = self.datePicker.date
+                        self.datePicker.countDownDuration = self.datePicker.countDownDuration
+                    }
+                }
+            }
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        datePickerExpandedHeight = datePickerHeightConstraint.constant
+
+        setSelected(true, animated: false)
+        updateDateLabel()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        if selected {
+            isDatePickerHidden = !isDatePickerHidden
+        }
+    }
+
+    func updateDateLabel() {
+    }
+
+    @IBAction func dateChanged(_ sender: UIDatePicker) {
+        if case .countDownTimer = sender.datePickerMode, duration > maximumDuration {
+            duration = maximumDuration
+        } else {
+            updateDateLabel()
+        }
+    }
+}
+
+
+/// UITableViewController extensions to aid working with DatePickerTableViewCell
+extension DatePickerTableViewCellDelegate where Self: UITableViewController {
+    func hideDatePickerCells(excluding indexPath: IndexPath? = nil) {
+        for case let cell as DatePickerTableViewCell in tableView.visibleCells where tableView.indexPath(for: cell) != indexPath && cell.isDatePickerHidden == false {
+            cell.isDatePickerHidden = true
+        }
+    }
+}

--- a/WatchApp Extension/ExtensionDelegate.swift
+++ b/WatchApp Extension/ExtensionDelegate.swift
@@ -208,7 +208,9 @@ extension ExtensionDelegate: WCSessionDelegate {
 
     // This method is called on a background thread of your app
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any] = [:]) {
-        let name = userInfo["name"] as? String ?? "WatchContext"
+        guard let name = userInfo["name"] as? String else {
+            return
+        }
 
         log.default("didReceiveUserInfo: %{public}@", name)
 
@@ -221,8 +223,7 @@ extension ExtensionDelegate: WCSessionDelegate {
             } else {
                 log.error("Could not decode LoopSettingsUserInfo: %{public}@", userInfo)
             }
-        case "WatchContext":
-            // WatchContext is the only userInfo type without a "name" key. This isn't a great heuristic.
+        case WatchContext.name:
             updateContext(userInfo)
         default:
             break


### PR DESCRIPTION
Relevant discussion in #816.
Summary of changes:
- Create a new class, `WatchComplicationUpdateManager`, whose sole purpose is to answer the question "should a complication user info transfer be used now?"
- Create a new struct, `WatchSettings`, which includes user preferences for Watch app and complication behavior. These settings are stored in `WatchDataManager`.
- Create a conditionally-visible section in the Settings screen for configuring the Watch settings. Right now, the only customization is the user's waking hours, which are used to restrict the time frame in which complication user info transfers are used. Waking hours are modeled by a new struct, `DailyScheduleInterval`, which describes a continuous period of time in a daily schedule.

Gardening:
- `WatchContext` is given a `name` field to avoid the "nil name field means context" dance we've been doing.

Points for discussion:
- I'm not _thrilled_ with exposing the waking hours as a user-configurable setting, but the impact on the user info transfer interval is significant. Hiding this setting and assuming a default range would alienate users whose sleeping schedules are non-traditional.
- `DatePickerTableViewCell` is ripped directly from LoopKit. `DateAndDurationTableViewCell` is also ripped from LoopKit, with one small to specialize behavior for the picker configuration in `updateDateLabel()`. I've copied them over to contain this PR to Loop, but exposing these classes publicly in LoopKit is probably a cleaner solution.
- I've left in logging of user info transfer update counts, at least for testing purposes. These logs make it easy to track usage patterns in Loggly.