### PR TITLE
Display boluses with a duration longer than 5 minutes

### DIFF
--- a/Loop/Managers/StatusChartsManager+LoopKit.swift
+++ b/Loop/Managers/StatusChartsManager+LoopKit.swift
@@ -83,7 +83,7 @@ extension StatusChartsManager {
         for entry in doseEntries {
             let time = entry.endDate.timeIntervalSince(entry.startDate)
 
-            if entry.type == .bolus && entry.netBasalUnits > 0 && time < .minutes(5) {
+            if entry.type == .bolus && entry.netBasalUnits > 0 && time < .minutes(10) {
                 let x = ChartAxisValueDate(date: entry.startDate, formatter: dateFormatter)
                 let y = ChartAxisValueDoubleLog(actualDouble: entry.units, unitString: "U", formatter: doseFormatter)
 


### PR DESCRIPTION
This only affects pump managers that do not report boluses as instantaneous.