### PR TITLE
Fix Loop crashing on startup on Apple Watch Series 0

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		C1C6591C1E1B1FDA0025CC58 /* recommend_temp_basal_dropping_then_rising.json in Resources */ = {isa = PBXBuildFile; fileRef = C1C6591B1E1B1FDA0025CC58 /* recommend_temp_basal_dropping_then_rising.json */; };
 		C1C73F0D1DE3D0270022FC89 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C1C73F0F1DE3D0270022FC89 /* InfoPlist.strings */; };
 		C9886AE51E5B2FAD00473BB8 /* gallery.ckcomplication in Resources */ = {isa = PBXBuildFile; fileRef = C9886AE41E5B2FAD00473BB8 /* gallery.ckcomplication */; };
+		E9D431C622173DE000E148E7 /* ClockKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9D431C522173DE000E148E7 /* ClockKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -646,6 +647,7 @@
 		C1C6591B1E1B1FDA0025CC58 /* recommend_temp_basal_dropping_then_rising.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = recommend_temp_basal_dropping_then_rising.json; sourceTree = "<group>"; };
 		C1C73F0E1DE3D0270022FC89 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C9886AE41E5B2FAD00473BB8 /* gallery.ckcomplication */ = {isa = PBXFileReference; lastKnownFileType = folder; path = gallery.ckcomplication; sourceTree = "<group>"; };
+		E9D431C522173DE000E148E7 /* ClockKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ClockKit.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS5.1.sdk/System/Library/Frameworks/ClockKit.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -684,6 +686,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9D431C622173DE000E148E7 /* ClockKit.framework in Frameworks */,
 				4353D178203D4DDA007B4ECD /* CoreBluetooth.framework in Frameworks */,
 				4353D176203D4D3C007B4ECD /* HealthKit.framework in Frameworks */,
 			);
@@ -1171,6 +1174,7 @@
 		968DCD53F724DE56FFE51920 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E9D431C522173DE000E148E7 /* ClockKit.framework */,
 				C18852E12082AB1A00BECC8C /* RileyLinkKitUI.framework */,
 				4353D177203D4DDA007B4ECD /* CoreBluetooth.framework */,
 				4353D175203D4D3C007B4ECD /* HealthKit.framework */,


### PR DESCRIPTION
There was a symbol not found in the WatchApp Extension during startup, causing Loop to crash on a Series 0 Watch.
```
dyld: Symbol not found: _OBJC_CLASS_$_CLKComplicationTemplateGraphicCircular
  Referenced from: /private/var/containers/Bundle/Application/34DBD240-07EE-44E8-852F-BD08CB1B459D/WatchApp.app/PlugIns/WatchApp Extension.appex/WatchApp Extension
  Expected in: dyld shared cache
 in /private/var/containers/Bundle/Application/34DBD240-07EE-44E8-852F-BD08CB1B459D/WatchApp.app/PlugIns/WatchApp Extension.appex/WatchApp Extension
```