### PR TITLE
Success haptic in BolusInterfaceController#deliver

### DIFF
--- a/WatchApp Extension/Controllers/BolusInterfaceController.swift
+++ b/WatchApp Extension/Controllers/BolusInterfaceController.swift
@@ -148,6 +148,7 @@ final class BolusInterfaceController: WKInterfaceController, IdentifiableClass {
                         if let error = error {
                             ExtensionDelegate.shared().present(error)
                         } else {
+                            WKInterfaceDevice.current().play(.success)
                             ExtensionDelegate.shared().loopManager.addConfirmedBolus(bolus)
                         }
                     }


### PR DESCRIPTION
Plays a success haptic when sending a bolus from the WatchApp. We already a play a success haptic when adding a carb entry, so it seems both logical and consistent to do the same for the bolus entry.