### PR TITLE
Only present non-zero bolus suggestion on watch after carb entry

### DIFF
--- a/WatchApp Extension/Controllers/AddCarbsInterfaceController.swift
+++ b/WatchApp Extension/Controllers/AddCarbsInterfaceController.swift
@@ -184,7 +184,9 @@ final class AddCarbsInterfaceController: WKInterfaceController, IdentifiableClas
 
                             ExtensionDelegate.shared().loopManager.addConfirmedCarbEntry(entry)
 
-                            WKExtension.shared().rootInterfaceController?.presentController(withName: BolusInterfaceController.className, context: suggestion)
+                            if let recommendedBolus = suggestion.recommendedBolus?.rawValue, recommendedBolus > 0.0 {
+                                WKExtension.shared().rootInterfaceController?.presentController(withName: BolusInterfaceController.className, context: suggestion)
+                            }
                         }
                     },
                     errorHandler: { (error) in


### PR DESCRIPTION
Small change to present the bolus controller after a carb entry on the watch only in cases where the bolus recommendation is non-zero.   Always presenting the bolus interface even for zero recommended bolus could be considered as a form of carb entry confirmation, but it doesn't seem necessary with the success haptic now in place, and also doesn't seem consistent with the behavior in the phone app and the overall "assume success but alert on failure" approach of the rest of the UI. 