### PR TITLE
Fix target range charting unit mismatch

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "LoopKit/Amplitude-iOS" "2137d5fd44bf630ed33e1e72d7af6d8f8612f270"
 github "LoopKit/CGMBLEKit" "ea1267791c66e884f1013fffd36faf4555cc6eaf"
 github "LoopKit/G4ShareSpy" "fed5a389e3e47e3a1953878dd21852aa5f44b360"
-github "LoopKit/LoopKit" "c6e9f9200deec9a401ab1725e888451b17dee98a"
+github "LoopKit/LoopKit" "643026a2adbb1011f195c8d9bb5a16cd9fb576e4"
 github "LoopKit/dexcom-share-client-swift" "b0419edf55c7f389b36cb47dd5c376bbd3d03d69"
 github "i-schuetz/SwiftCharts" "0.6.2"
 github "ps2/rileylink_ios" "8418b57c1983bdefaec7ccb456c86d5efacf40e7"

--- a/Common/Extensions/GlucoseRangeSchedule.swift
+++ b/Common/Extensions/GlucoseRangeSchedule.swift
@@ -35,16 +35,6 @@ extension GlucoseRangeSchedule {
         return activeOverride?.context
     }
 
-    var activeOverrideQuantityRange: Range<HKQuantity>? {
-        guard let activeOverride = activeOverride else {
-            return nil
-        }
-
-        let lowerBound = HKQuantity(unit: unit, doubleValue: activeOverride.value.minValue)
-        let upperBound = HKQuantity(unit: unit, doubleValue: activeOverride.value.maxValue)
-        return lowerBound..<upperBound
-    }
-
     var configuredOverrideContexts: [GlucoseRangeSchedule.Override.Context] {
         var contexts: [GlucoseRangeSchedule.Override.Context] = []
         for (context, range) in overrideRanges where !range.isZero {
@@ -53,15 +43,13 @@ extension GlucoseRangeSchedule {
 
         return contexts
     }
-
-    func minQuantity(at date: Date) -> HKQuantity {
-        return HKQuantity(unit: unit, doubleValue: value(at: date).minValue)
-    }
 }
 
 
-extension DoubleRange {
-    var averageValue: Double {
+extension Range where Bound == HKQuantity {
+    func averageValue(for unit: HKUnit) -> Double {
+        let minValue = lowerBound.doubleValue(for: unit)
+        let maxValue = upperBound.doubleValue(for: unit)
         return (maxValue + minValue) / 2
     }
 }

--- a/LoopUI/Managers/StatusChartsManager.swift
+++ b/LoopUI/Managers/StatusChartsManager.swift
@@ -952,16 +952,9 @@ public final class StatusChartsManager {
             let xAxisValues = xAxisValues, xAxisValues.count > 1,
             let schedule = targetGlucoseSchedule
         {
-            targetGlucosePoints = ChartPoint.pointsForGlucoseRangeSchedule(schedule, xAxisValues: xAxisValues)
-
-            if let override = schedule.override {
-                targetOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: schedule.unit, xAxisValues: xAxisValues, extendEndDateToChart: true)
-
-                targetOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: schedule.unit, xAxisValues: xAxisValues)
-            } else {
-                targetOverridePoints = []
-                targetOverrideDurationPoints = []
-            }
+            targetGlucosePoints = ChartPoint.pointsForGlucoseRangeSchedule(schedule, unit: glucoseUnit, xAxisValues: xAxisValues)
+            targetOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(schedule, unit: glucoseUnit, xAxisValues: xAxisValues, extendEndDateToChart: true)
+            targetOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(schedule, unit: glucoseUnit, xAxisValues: xAxisValues)
         }
     }
 }

--- a/WatchApp Extension/Models/GlucoseChartData.swift
+++ b/WatchApp Extension/Models/GlucoseChartData.swift
@@ -53,7 +53,7 @@ struct GlucoseChartData {
             max = Swift.max(max, correction.value.upperBound.doubleValue(for: unit))
         }
 
-        if let override = correctionRange?.activeOverrideQuantityRange {
+        if let override = correctionRange?.activeOverride?.quantityRange {
             min = Swift.min(min, override.lowerBound.doubleValue(for: unit))
             max = Swift.max(max, override.upperBound.doubleValue(for: unit))
         }

--- a/WatchApp Extension/Scenes/GlucoseChartScene.swift
+++ b/WatchApp Extension/Scenes/GlucoseChartScene.swift
@@ -258,7 +258,7 @@ class GlucoseChartScene: SKScene {
             inactiveNodes.removeValue(forKey: range.chartHashValue)
 
             if range.end < spannedInterval.end {
-                let extendedRange = GlucoseRangeSchedule.Override(context: range.context, start: range.start, end: spannedInterval.end, value: range.value)
+                let extendedRange = GlucoseRangeSchedule.Override(context: range.context, start: range.start, end: spannedInterval.end, unit: range.unit, value: range.value)
                 let (sprite2, created) = getSprite(forHash: extendedRange.chartHashValue)
                 sprite2.color = UIColor.glucose.withAlphaComponent(0.25)
                 sprite2.zPosition = NodePlane.overrideRanges.zPosition

--- a/WatchApp Extension/Scenes/GlucoseChartValueHashable.swift
+++ b/WatchApp Extension/Scenes/GlucoseChartValueHashable.swift
@@ -78,10 +78,10 @@ extension AbsoluteScheduleValue: GlucoseChartValueHashable where T == Range<HKQu
 
 extension GlucoseRangeSchedule.Override: GlucoseChartValueHashable {
     var min: Double {
-        return value.minValue
+        return quantityRange.lowerBound.doubleValue(for: .milligramsPerDeciliter)
     }
 
     var max: Double {
-        return value.maxValue
+        return quantityRange.upperBound.doubleValue(for: .milligramsPerDeciliter)
     }
 }


### PR DESCRIPTION
This fixes a bug where users whose graphs are broken when their target range unit doesn't match the HealthKit preferred unit