### PR TITLE
include pump manufacturer and model in the pump status

### DIFF
--- a/Loop/Managers/NightscoutDataManager.swift
+++ b/Loop/Managers/NightscoutDataManager.swift
@@ -152,6 +152,13 @@ final class NightscoutDataManager {
                 bolusing = false
             }
             
+            let currentReservoirUnits: Double?
+            if let lastReservoirValue = deviceManager.loopManager.doseStore.lastReservoirValue, lastReservoirValue.startDate > Date().addingTimeInterval(.minutes(-15)) {
+                currentReservoirUnits = lastReservoirValue.unitVolume
+            } else {
+                currentReservoirUnits = nil
+            }
+
             pumpStatus = NightscoutUploadKit.PumpStatus(
                 clock: Date(),
                 pumpID: pumpManagerStatus.device.localIdentifier ?? "Unknown",
@@ -161,7 +168,7 @@ final class NightscoutDataManager {
                 battery: battery,
                 suspended: pumpManagerStatus.basalDeliveryState == .suspended,
                 bolusing: bolusing,
-                reservoir: deviceManager.loopManager.doseStore.lastReservoirValue?.unitVolume,
+                reservoir: currentReservoirUnits,
                 secondsFromGMT: pumpManagerStatus.timeZone.secondsFromGMT())
         } else {
             pumpStatus = nil

--- a/Loop/Managers/NightscoutDataManager.swift
+++ b/Loop/Managers/NightscoutDataManager.swift
@@ -155,6 +155,8 @@ final class NightscoutDataManager {
             pumpStatus = NightscoutUploadKit.PumpStatus(
                 clock: Date(),
                 pumpID: pumpManagerStatus.device.localIdentifier ?? "Unknown",
+                manufacturer: pumpManagerStatus.device.manufacturer,
+                model: pumpManagerStatus.device.model,
                 iob: nil,
                 battery: battery,
                 suspended: pumpManagerStatus.basalDeliveryState == .suspended,


### PR DESCRIPTION
depends on https://github.com/ps2/rileylink_ios/pull/522

this will let us display 50+ U on the pump pill in Nightscout

uploaded device status looks like this:

```
"pump": {
  "bolusing": false,
  "suspended": false,
  "secondsFromGMT": -25200,
  "model": "Eros",
  "pumpID": "1F01ACAB",
  "clock": "2019-05-04T19:19:35Z",
  "manufacturer": "Insulet"
}
```

```
"pump": {
    "suspended": false,
    "pumpID": "999999",
    "manufacturer": "Medtronic",
    "model": "522",
    "battery": {
      "percent": 100
    },
    "reservoir": 90.6,
    "bolusing": false,
    "clock": "2019-05-04T05:13:58Z",
    "secondsFromGMT": -25200
  }
```
