### PR TITLE
Blured StatusBar

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -34,9 +34,14 @@ private extension RefreshContext {
 final class StatusTableViewController: ChartsTableViewController {
 
     private let log = OSLog(category: "StatusTableViewController")
+    private let visualEffectStatusBar = UIVisualEffectView(effect: UIBlurEffect(style: .light))
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Adding a visualEffect view to prevent the StatusBar from overlaying the UITableView
+        visualEffectStatusBar.frame = UIApplication.shared.statusBarFrame
+        view.addSubview(visualEffectStatusBar)
 
         charts.glucoseDisplayRange = (
             min: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 100),
@@ -139,7 +144,16 @@ final class StatusTableViewController: ChartsTableViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         refreshContext.update(with: .size(size))
 
+        // Only show the visualEffectStatusBar if the device is in landscape
+        visualEffectStatusBar.isHidden = UIDevice.current.orientation.isLandscape
+
         super.viewWillTransition(to: size, with: coordinator)
+    }
+
+    // MARK: - TableView
+
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        visualEffectStatusBar.transform = CGAffineTransform(translationX: 0, y: self.tableView.contentOffset.y)
     }
 
     // MARK: - State


### PR DESCRIPTION
This PR blurs the StatusBar to prevent the Statusbar from overlapping the existing UI Elements when scrolling
![BluredStatusBar](https://user-images.githubusercontent.com/6825153/57580325-5ae81e00-74a8-11e9-864d-9f50ff14f829.png)
