### PR TITLE
update Nightscout URL placeholder to Heroku

### DIFF
--- a/Loop/Base.lproj/Localizable.strings
+++ b/Loop/Base.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Glucose Momentum";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Indefinitely";

--- a/Loop/Models/ServiceAuthentication/NightscoutService.swift
+++ b/Loop/Models/ServiceAuthentication/NightscoutService.swift
@@ -29,7 +29,7 @@ class NightscoutService: ServiceAuthenticationUI {
         credentialFormFields = [
             ServiceCredential(
                 title: NSLocalizedString("Site URL", comment: "The title of the nightscout site URL credential"),
-                placeholder: NSLocalizedString("https://mysite.azurewebsites.net", comment: "The placeholder text for the nightscout site URL credential"),
+                placeholder: NSLocalizedString("https://mysite.herokuapp.com", comment: "The placeholder text for the nightscout site URL credential"),
                 isSecret: false,
                 keyboardType: .URL
             ),

--- a/Loop/de.lproj/Localizable.strings
+++ b/Loop/de.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Blutzucker-Momentum";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Unendlich";

--- a/Loop/es.lproj/Localizable.strings
+++ b/Loop/es.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Momento de Glucosa";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Indefinidamente";

--- a/Loop/fr.lproj/Localizable.strings
+++ b/Loop/fr.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Momentum de glucose";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Indéfiniment";

--- a/Loop/it.lproj/Localizable.strings
+++ b/Loop/it.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Effetto Glicemico";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Per sempre";

--- a/Loop/nb.lproj/Localizable.strings
+++ b/Loop/nb.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Glukosemomentum";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Uendelig";

--- a/Loop/nl.lproj/Localizable.strings
+++ b/Loop/nl.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Glucose momentum";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mijnsite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mijnsite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Oneindig";

--- a/Loop/pl.lproj/Localizable.strings
+++ b/Loop/pl.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Pęd glukozy";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "Niemożliwy do określenia";

--- a/Loop/ru.lproj/Localizable.strings
+++ b/Loop/ru.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "Динамика гликемии";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://мойсайт. azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://мойсайт. herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "На неопределенное время";

--- a/Loop/zh-Hans.lproj/Localizable.strings
+++ b/Loop/zh-Hans.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Glucose Momentum" = "葡萄糖增量预测算法";
 
 /* The placeholder text for the nightscout site URL credential */
-"https://mysite.azurewebsites.net" = "https://mysite.azurewebsites.net";
+"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
 
 /* The title of a target alert action specifying an indefinitely long workout targets duration */
 "Indefinitely" = "永久";

--- a/LoopTests/KeychainManagerTests.swift
+++ b/LoopTests/KeychainManagerTests.swift
@@ -47,14 +47,14 @@ class KeychainManagerTests: XCTestCase {
         try manager.setUsernamePasswordURLForLabel(nil, password: nil, url: nil)
         XCTAssertNil(manager.getUsernamePasswordURLForLabel())
 
-        manager.setNightscoutURL(URL(string: "http://mysite.azurewebsites.net")!, secret: "ABCDEFG")
+        manager.setNightscoutURL(URL(string: "http://mysite.herokuapp.com")!, secret: "ABCDEFG")
         var nightscoutCredentials = manager.getNightscoutCredentials()!
-        XCTAssertEqual(URL(string: "http://mysite.azurewebsites.net")!, nightscoutCredentials.url)
+        XCTAssertEqual(URL(string: "http://mysite.herokuapp.com")!, nightscoutCredentials.url)
         XCTAssertEqual("ABCDEFG", nightscoutCredentials.secret)
 
-        manager.setNightscoutURL(URL(string: "http://mysite.azurewebsites.net:4443")!, secret: "ABCDEFG")
+        manager.setNightscoutURL(URL(string: "http://mysite.herokuapp.com:4443")!, secret: "ABCDEFG")
         nightscoutCredentials = manager.getNightscoutCredentials()!
-        XCTAssertEqual(URL(string: "http://mysite.azurewebsites.net:4443")!, nightscoutCredentials.url)
+        XCTAssertEqual(URL(string: "http://mysite.herokuapp.com:4443")!, nightscoutCredentials.url)
         XCTAssertEqual("ABCDEFG", nightscoutCredentials.secret)
 
         manager.setNightscoutURL(nil, secret: nil)


### PR DESCRIPTION
Little tweak: the Nightscout project recommends using Heroku and NOT using Azure to host the project. 