### PR TITLE
Fix display of correction range override

### DIFF
--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -79,8 +79,8 @@ extension PredictedGlucoseChart {
             targetGlucosePoints = ChartPoint.pointsForGlucoseRangeSchedule(schedule, unit: glucoseUnit, xAxisValues: xAxisValues)
 
             if let override = scheduleOverride, override.isActive() || override.startDate > Date() {
-                targetOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: schedule.unit, xAxisValues: xAxisValues, extendEndDateToChart: true)
-                targetOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: schedule.unit, xAxisValues: xAxisValues)
+                targetOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: glucoseUnit, xAxisValues: xAxisValues, extendEndDateToChart: true)
+                targetOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: glucoseUnit, xAxisValues: xAxisValues)
             } else {
                 targetOverridePoints = []
                 targetOverrideDurationPoints = []


### PR DESCRIPTION
Fixes overrides being drawn incorrectly (wrong units) when schedule has different units than currently being displayed.