### PR TITLE
Use default insets for labels below Watch glucose graph

### DIFF
--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -414,7 +414,6 @@
                                             </separator>
                                         </items>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <edgeInsets key="margins" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                                     </group>
                                     <connections>
                                         <outlet property="bottomSeparator" destination="VV1-lG-fC0" id="T5d-VF-GlT"/>


### PR DESCRIPTION
This prevents clipping of the text on the rounded corners of 40mm and 44mm Series 4 Watches.