### PR TITLE
Store min and max for overrides in mg/dl on Watch

### DIFF
--- a/WatchApp Extension/Scenes/GlucoseChartValueHashable.swift
+++ b/WatchApp Extension/Scenes/GlucoseChartValueHashable.swift
@@ -96,10 +96,10 @@ struct TemporaryScheduleOverrideHashable: GlucoseChartValueHashable {
     }
 
     var min: Double {
-        return override.settings.targetRange!.lowerBound.doubleValue(for: unit)
+        return override.settings.targetRange!.lowerBound.doubleValue(for: .milligramsPerDeciliter)
     }
 
     var max: Double {
-        return override.settings.targetRange!.upperBound.doubleValue(for: unit)
+        return override.settings.targetRange!.upperBound.doubleValue(for: .milligramsPerDeciliter)
     }
 }


### PR DESCRIPTION
This aligns the override data structure with how target ranges are stored on the Watch, so both can be graphed with the same code assumptions. This fixes plotting of override ranges in mmol/L on the Watch graph. 