### PR TITLE
Update copy-frameworks for TestFlight

### DIFF
--- a/Scripts/copy-frameworks.sh
+++ b/Scripts/copy-frameworks.sh
@@ -18,23 +18,26 @@ else
 fi
 
 for COUNTER in $(seq 0 $(($SCRIPT_INPUT_FILE_COUNT - 1))); do
-    SCRIPT_INPUT_FILE="SCRIPT_INPUT_FILE_${COUNTER}"
-    CARTHAGE_BUILD_FILE="${!SCRIPT_INPUT_FILE/${BUILT_PRODUCTS_DIR}/${CARTHAGE_BUILD_DIR}}"
+    SCRIPT_INPUT_VAR="SCRIPT_INPUT_FILE_${COUNTER}"
+    CARTHAGE_BUILD_FILE="${!SCRIPT_INPUT_VAR/${BUILT_PRODUCTS_DIR}/${CARTHAGE_BUILD_DIR}}"
     if [ -e "${CARTHAGE_BUILD_FILE}" ]; then
-        if [ -e "${SCRIPT_INPUT_FILE}" ]; then
+        if [ -e "${!SCRIPT_INPUT_VAR}" ]; then
             echo "ERROR: Duplicate frameworks found at:"
-            echo "  ${SCRIPT_INPUT_FILE}"
+            echo "  ${!SCRIPT_INPUT_VAR}"
             echo "  ${CARTHAGE_BUILD_FILE}"
             exit 1
         fi
-        echo "Substituting \"${CARTHAGE_BUILD_FILE}\" for \"${!SCRIPT_INPUT_FILE}\""
-        export ${SCRIPT_INPUT_FILE}="${CARTHAGE_BUILD_FILE}"
-    elif [ -e "${!SCRIPT_INPUT_FILE}" ]; then
-        echo "Using original path: \"${!SCRIPT_INPUT_FILE}\""
+        echo "Substituting \"${CARTHAGE_BUILD_FILE}\" for \"${!SCRIPT_INPUT_VAR}\""
+        export ${SCRIPT_INPUT_VAR}="${CARTHAGE_BUILD_FILE}"
+    elif [ -e "${!SCRIPT_INPUT_VAR}" ]; then
+        echo "Using original path: \"${!SCRIPT_INPUT_VAR}\""
     else
         echo "ERROR: Input file not found at \"${!SCRIPT_INPUT_FILE}\""
         exit 1
     fi
+    # Resolve any symlinks
+    export ${SCRIPT_INPUT_VAR}="$(readlink "${!SCRIPT_INPUT_VAR}" || echo "${!SCRIPT_INPUT_VAR}")"
+    echo "copy-frameworks resolved path: ${!SCRIPT_INPUT_VAR}"
 done
 
 echo "Copy Frameworks with Carthage"


### PR DESCRIPTION
This fixes the check for duplicate versions of Carthage and workspace built frameworks existing, and follows symlinks to avoid installing frameworks as symlinks in an archive build. 