### PR TITLE
Multiple cycles triggered in short window.

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -33,7 +33,7 @@ final class DeviceDataManager {
     /// Should be accessed only on the main queue
     private(set) var lastError: (date: Date, error: Error)?
 
-    /// The last time a BLE heartbeat was received by the pump manager
+    /// The last time a BLE heartbeat was received and acted upon.
     private var lastBLEDrivenUpdate = Date.distantPast
 
     // MARK: - CGM
@@ -155,6 +155,40 @@ final class DeviceDataManager {
 
         return Manager.init(rawState: rawState) as? PumpManagerUI
     }
+    
+    private func processCGMResult(_ manager: CGMManager, result: CGMResult) {
+        switch result {
+        case .newData(let values):
+            log.default("CGMManager:\(type(of: manager)) did update with \(values.count) values")
+            
+            loopManager.addGlucose(values) { result in
+                if manager.shouldSyncToRemoteService {
+                    switch result {
+                    case .success(let values):
+                        self.nightscoutDataManager.uploadGlucose(values, sensorState: manager.sensorState)
+                    case .failure:
+                        break
+                    }
+                }
+                
+                self.log.default("Asserting current pump data")
+                self.pumpManager?.assertCurrentPumpData()
+            }
+        case .noData:
+            log.default("CGMManager:\(type(of: manager)) did update with no data")
+            
+            pumpManager?.assertCurrentPumpData()
+        case .error(let error):
+            log.default("CGMManager:\(type(of: manager)) did update with error: \(error)")
+            
+            self.setLastError(error: error)
+            log.default("Asserting current pump data")
+            pumpManager?.assertCurrentPumpData()
+        }
+        
+        updatePumpManagerBLEHeartbeatPreference()
+    }
+
 
 }
 
@@ -269,36 +303,8 @@ extension DeviceDataManager: CGMManagerDelegate {
 
     func cgmManager(_ manager: CGMManager, didUpdateWith result: CGMResult) {
         dispatchPrecondition(condition: .onQueue(queue))
-        switch result {
-        case .newData(let values):
-            log.default("CGMManager:\(type(of: manager)) did update with \(values.count) values")
-
-            loopManager.addGlucose(values) { result in
-                if manager.shouldSyncToRemoteService {
-                    switch result {
-                    case .success(let values):
-                        self.nightscoutDataManager.uploadGlucose(values, sensorState: manager.sensorState)
-                    case .failure:
-                        break
-                    }
-                }
-
-                self.log.default("Asserting current pump data")
-                self.pumpManager?.assertCurrentPumpData()
-            }
-        case .noData:
-            log.default("CGMManager:\(type(of: manager)) did update with no data")
-
-            pumpManager?.assertCurrentPumpData()
-        case .error(let error):
-            log.default("CGMManager:\(type(of: manager)) did update with error: \(error)")
-
-            self.setLastError(error: error)
-            log.default("Asserting current pump data")
-            pumpManager?.assertCurrentPumpData()
-        }
-
-        updatePumpManagerBLEHeartbeatPreference()
+        lastBLEDrivenUpdate = Date()
+        processCGMResult(manager, result: result);
     }
 
     func startDateToFilterNewData(for manager: CGMManager) -> Date? {
@@ -346,12 +352,12 @@ extension DeviceDataManager: PumpManagerDelegate {
             bleHeartbeatUpdateInterval = .minutes(1)
         case let interval?:
             // If we looped successfully less than 5 minutes ago, ignore the heartbeat.
-            log.default("PumpManager:\(type(of: pumpManager)) ignoring heartbeat. Last loop completed \(interval.minutes) minutes ago")
+            log.default("PumpManager:\(type(of: pumpManager)) ignoring pumpManager heartbeat. Last loop completed \(-interval.minutes) minutes ago")
             return
         }
 
         guard lastBLEDrivenUpdate.timeIntervalSinceNow <= -bleHeartbeatUpdateInterval else {
-            log.default("PumpManager:\(type(of: pumpManager)) ignoring heartbeat. Last update \(lastBLEDrivenUpdate)")
+            log.default("PumpManager:\(type(of: pumpManager)) ignoring pumpManager heartbeat. Last ble update \(lastBLEDrivenUpdate)")
             return
         }
         lastBLEDrivenUpdate = Date()
@@ -363,7 +369,7 @@ extension DeviceDataManager: PumpManagerDelegate {
 
             if let manager = self.cgmManager {
                 self.queue.async {
-                    self.cgmManager(manager, didUpdateWith: result)
+                    self.processCGMResult(manager, result: result)
                 }
             }
         }


### PR DESCRIPTION
Fix issue with PumpManager ble update coming in right after cgm update arrives, causing two loops to be run in rapid succession.