### PR TITLE
watch app install in build settings turned on

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -3468,7 +3468,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -3489,7 +3489,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;


### PR DESCRIPTION
The watch app not installing seems to be a common issue. Users have installed Loop, paired watch keeps failing to install despite being listed in the available apps for installation. Some work-arounds have been changing the deployment targets, but that is not a fix that works for everyone (nor gets at whatever the underlying issue is apparently). This fix has worked for myself and another as reported on Zulipchat.

My previous attempts (and @elnjensen too) to get around the install failure have been pretty labor intensive and involve repairing the phone from scratch. That seems excessive now if this solution works.