### PR TITLE
Adding checks for Bash profile & rc

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -2350,7 +2350,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -f $PROJECT_DIR/.gitmodules ]; then\n    echo \"Skipping checkout due to presence of .gitmodules file\"\n    if [ $ACTION = \"install\" ]; then\n        echo \"You're installing: Make sure to keep all submodules up-to-date and run carthage build after changes.\"\n    fi\nelse\n    echo \"Bootstrapping carthage dependencies\"\n    unset LLVM_TARGET_TRIPLE_SUFFIX\n    /usr/local/bin/carthage bootstrap --project-directory \"$SRCROOT\" --cache-builds\nfi\n";
+			shellScript = "if [ -s $HOME/.bash_profile ]; then\n    echo \"Found bash profile\"\n    source $HOME/.bash_profile\nelif [ -s $HOME/.bashrc ]; then\n    echo \"Found bashrc\"\n    source $HOME/.bashrc\nfi\n\nif [ -f $PROJECT_DIR/.gitmodules ]; then\n    echo \"Skipping checkout due to presence of .gitmodules file\"\n    if [ $ACTION = \"install\" ]; then\n        echo \"You're installing: Make sure to keep all submodules up-to-date and run carthage build after changes.\"\n    fi\nelse\n    echo \"Bootstrapping carthage dependencies\"\n    unset LLVM_TARGET_TRIPLE_SUFFIX\n    if [ $(which carthage) ]; then\n        carthage bootstrap --project-directory \"$SRCROOT\" --cache-builds\n    else\n        /usr/local/bin/carthage bootstrap --project-directory \"$SRCROOT\" --cache-builds\n    fi\nfi\n";
 		};
 		432CF88220D8BCD90066B889 /* Homebrew & Carthage Setup */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2364,7 +2364,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if ! [ -x \"$(command -v brew)\" ]; then\n    # Install Homebrew\n    ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"\nfi\n\nif brew ls carthage > /dev/null; then\n    brew upgrade carthage || echo \"Continuing…\"\nelse\n    brew install carthage\nfi\n";
+			shellScript = "if [ -s $HOME/.bash_profile ]; then\n    echo \"Found bash profile\"\n    source $HOME/.bash_profile\nelif [ -s $HOME/.bashrc ]; then\n    echo \"Found bashrc\"\n    source $HOME/.bashrc\nfi\n\nif ! [ -x \"$(command -v brew)\" ]; then\n    # Install Homebrew\n    ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"\nfi\n\nif brew ls carthage > /dev/null; then\n    brew upgrade carthage || echo \"Continuing…\"\nelse\n    brew install carthage\nfi\n";
 		};
 		43D9FFE221EAE40600AF44BF /* Copy Frameworks with Carthage */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Scripts/copy-frameworks.sh
+++ b/Scripts/copy-frameworks.sh
@@ -7,6 +7,14 @@
 
 date
 
+if [ -s $HOME/.bash_profile ]; then
+    echo "Found bash profile"
+    source $HOME/.bash_profile
+elif [ -s $HOME/.bashrc ]; then
+    echo "Found bashrc"
+    source $HOME/.bashrc
+fi
+
 CARTHAGE_BUILD_DIR="${SRCROOT}/Carthage/Build"
 if [ -n "${IPHONEOS_DEPLOYMENT_TARGET}" ]; then
     CARTHAGE_BUILD_DIR="${CARTHAGE_BUILD_DIR}/iOS"


### PR DESCRIPTION
For policy reasons users may not be able to install Homebrew in the default location, so could use a profile to add this location into the user's path.

The current project assumes the default location. This PR removes this hardcoding of location.