### PR TITLE
hide the saved API secret by default in NS services display

### DIFF
--- a/Loop/Models/ServiceAuthentication/NightscoutService.swift
+++ b/Loop/Models/ServiceAuthentication/NightscoutService.swift
@@ -36,7 +36,7 @@ class NightscoutService: ServiceAuthenticationUI {
             ServiceCredential(
                 title: NSLocalizedString("API Secret", comment: "The title of the nightscout API secret credential"),
                 placeholder: nil,
-                isSecret: false,
+                isSecret: true,
                 keyboardType: .asciiCapable
             )
         ]


### PR DESCRIPTION
since remote-overrides are coming, this might be an easy safety hide.