### PR TITLE
iOS 13 Dark Mode UI Reset

### DIFF
--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -90,6 +90,8 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
There is a bug with the UI where a user setting dark mode in iOS 13 will cause the background to go black and cause grey text to become illegible and UI to generally not be good. This change is to add a key to info.plist to force light mode within the app until dark mode can be supported. 