### PR TITLE
Set carb cache length to 24 hours.

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -65,6 +65,7 @@ final class LoopDataManager {
         carbStore = CarbStore(
             healthStore: healthStore,
             cacheStore: cacheStore,
+            cacheLength: .hours(24),
             defaultAbsorptionTimes: LoopSettings.defaultCarbAbsorptionTimes,
             carbRatioSchedule: carbRatioSchedule,
             insulinSensitivitySchedule: insulinSensitivitySchedule,


### PR DESCRIPTION
Investigations into delayed display and dosing availability have shown significant cache misses in CarbStore, which results in a HealthKit query.  When the phone has been locked for a significant amount of time, HealthKit queries can perform very slowly, as HealthKit is processing journaled data and doing other housekeeping. This fix increases the cache length to a longer value that should eliminate most cache misses.