### PR TITLE
Include current bg for suspend threshold and dosing thresholds

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -993,6 +993,7 @@ extension LoopDataManager {
         
         let tempBasal = predictedGlucose.recommendedTempBasal(
             to: glucoseTargetRange,
+            at: predictedGlucose[0].startDate,
             suspendThreshold: settings.suspendThreshold?.quantity,
             sensitivity: insulinSensitivity,
             model: model,
@@ -1019,6 +1020,7 @@ extension LoopDataManager {
 
         let recommendation = predictedGlucose.recommendedBolus(
             to: glucoseTargetRange,
+            at: predictedGlucose[0].startDate,
             suspendThreshold: settings.suspendThreshold?.quantity,
             sensitivity: insulinSensitivity,
             model: model,


### PR DESCRIPTION
Suspend threshold evaluation (when basal should be cut off), and dosing threshold (when any dosing above basal should be prevented), were not including current bg in the evaluation. This moves the window of consideration (DIA duration) back to the point of the most recent bg, rather than the current time.