### PR TITLE
Include insulin model delay in computation of dose

### DIFF
--- a/DoseMathTests/DoseMathTests.swift
+++ b/DoseMathTests/DoseMathTests.swift
@@ -347,7 +347,7 @@ class RecommendTempBasalTests: XCTestCase {
             lastTempBasal: nil
         )
 
-        XCTAssertEqual(1.425, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(1.450, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
         XCTAssertEqual(TimeInterval(minutes: 30), dose!.duration)
     }
 
@@ -588,7 +588,7 @@ class RecommendBolusTests: XCTestCase {
             volumeRounder: fortyIncrementsPerUnitRounder
         )
 
-        XCTAssertEqual(1.575, dose.amount)
+        XCTAssertEqual(1.625, dose.amount)
 
         if case BolusRecommendationNotice.currentGlucoseBelowTarget(let glucose) = dose.notice! {
             XCTAssertEqual(glucose.quantity.doubleValue(for: .milligramsPerDeciliter), 60)
@@ -657,7 +657,7 @@ class RecommendBolusTests: XCTestCase {
             volumeRounder: fortyIncrementsPerUnitRounder
         )
         
-        XCTAssertEqual(1.4, dose.amount)
+        XCTAssertEqual(1.575, dose.amount)
         XCTAssertEqual(BolusRecommendationNotice.predictedGlucoseBelowTarget(minGlucose: glucose[1]), dose.notice!)
     }
 
@@ -676,7 +676,7 @@ class RecommendBolusTests: XCTestCase {
             volumeRounder: fortyIncrementsPerUnitRounder
         )
         
-        XCTAssertEqual(0.575, dose.amount)
+        XCTAssertEqual(0.625, dose.amount)
     }
 
     func testStartVeryLowEndHigh() {
@@ -708,7 +708,7 @@ class RecommendBolusTests: XCTestCase {
             maxBolus: maxBolus
         )
 
-        XCTAssertEqual(1.575, dose.amount, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(1.625, dose.amount, accuracy: 1.0 / 40.0)
     }
 
     func testHighAndFalling() {
@@ -787,7 +787,7 @@ class RecommendBolusTests: XCTestCase {
             maxBolus: maxBolus
         )
 
-        XCTAssertEqual(1.25, dose.amount)
+        XCTAssertEqual(1.30, dose.amount, accuracy: 1.0 / 40.0)
 
         // Use mmol sensitivity value
         let insulinSensitivitySchedule = InsulinSensitivitySchedule(unit: HKUnit.millimolesPerLiter, dailyItems: [RepeatingScheduleValue(startTime: 0.0, value: 10.0 / 3)])!
@@ -802,7 +802,7 @@ class RecommendBolusTests: XCTestCase {
             maxBolus: maxBolus
         )
 
-        XCTAssertEqual(1.25, dose.amount, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(1.30, dose.amount, accuracy: 1.0 / 40.0)
     }
 
     func testRiseAfterDIA() {

--- a/Loop/Managers/DoseMath.swift
+++ b/Loop/Managers/DoseMath.swift
@@ -236,6 +236,7 @@ extension Collection where Element: GlucoseValue {
         let unit = correctionRange.unit
         let sensitivityValue = sensitivity.doubleValue(for: unit)
         let suspendThresholdValue = suspendThreshold.doubleValue(for: unit)
+        let delay = TimeInterval(minutes: 10)
 
         // For each prediction above target, determine the amount of insulin necessary to correct glucose based on the modeled effectiveness of the insulin at that time
         for prediction in self {
@@ -267,7 +268,8 @@ extension Collection where Element: GlucoseValue {
             // Compute the dose required to bring this prediction to target:
             // dose = (Glucose Δ) / (% effect × sensitivity)
 
-            let percentEffected = 1 - model.percentEffectRemaining(at: time)
+            // For 0 <= time <= delay, assume a small amount effected. This will result in large unit recommendation rather than no recommendation at all.
+            let percentEffected = Swift.max(.ulpOfOne, 1 - model.percentEffectRemaining(at: time - delay))
             let effectedSensitivity = percentEffected * sensitivityValue
             guard let correctionUnits = insulinCorrectionUnits(
                 fromValue: predictedGlucoseValue,
@@ -299,8 +301,8 @@ extension Collection where Element: GlucoseValue {
             eventual.quantity < eventualGlucoseTargets.lowerBound
         {
             let time = min.startDate.timeIntervalSince(date)
-            // For time = 0, assume a small amount effected. This will result in large (negative) unit recommendation rather than no recommendation at all.
-            let percentEffected = Swift.max(.ulpOfOne, 1 - model.percentEffectRemaining(at: time))
+            // For 0 <= time <= delay, assume a small amount effected. This will result in large (negative) unit recommendation rather than no recommendation at all.
+            let percentEffected = Swift.max(.ulpOfOne, 1 - model.percentEffectRemaining(at: time - delay))
 
             guard let units = insulinCorrectionUnits(
                 fromValue: min.quantity.doubleValue(for: unit),


### PR DESCRIPTION
A 10-min delay is included in calculation of effected insulin so that the insulin model used in dose calculations becomes consistent with the insulin model used for prediction calculations. 

This addresses an issue brought up in the [Partial Bolus Recommendation](https://loop.zulipchat.com/#narrow/stream/148543-Loop/topic/Partial.20Bolus.20Recommendations) topic on Loop Zulip where a nonzero bolus recommendation is observed immediately after a bolus recommendation has been accepted.  DoseMathTests have been updated accordingly. 