### PR TITLE
Fix bolus screen memory leak

### DIFF
--- a/Loop/View Controllers/BolusViewController.swift
+++ b/Loop/View Controllers/BolusViewController.swift
@@ -473,7 +473,9 @@ final class BolusViewController: ChartsTableViewController, IdentifiableClass, U
         updateDeliverButtonState()
 
         predictionRecomputation?.cancel()
-        let predictionRecomputation = DispatchWorkItem(block: recomputePrediction)
+        let predictionRecomputation = DispatchWorkItem { [weak self] in
+             self?.recomputePrediction()
+         }
         self.predictionRecomputation = predictionRecomputation
         let recomputeDelayMS = 300
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(recomputeDelayMS), execute: predictionRecomputation)


### PR DESCRIPTION
The old 'Swift doesn't warn you about implicit self when passing a member function point-free' gotcha.

https://github.com/tidepool-org/Loop/pull/57