### PR TITLE
Fix nightscout uploading trend arrow inconsistency

### DIFF
--- a/Loop/Managers/NightscoutDataManager.swift
+++ b/Loop/Managers/NightscoutDataManager.swift
@@ -417,15 +417,20 @@ final class NightscoutDataManager {
         } else {
             deviceStr = "loop://unknowndevice"
         }
+
         let direction: String? = {
             switch sensorState?.trendType {
             case .up?:
+                return "FortyFiveUp"
+            case .upUp?:
                 return "SingleUp"
-            case .upUp?, .upUpUp?:
+            case .upUpUp?:
                 return "DoubleUp"
             case .down?:
+                return "FortyFiveDown"
+            case .downDown?:
                 return "SingleDown"
-            case .downDown?, .downDownDown?:
+            case .downDownDown?:
                 return "DoubleDown"
             case .flat?:
                 return "Flat"


### PR DESCRIPTION
Issue reported on zulipchat: https://loop.zulipchat.com/#narrow/stream/144182-development/topic/trend.20arrow.20inconsistency

The code for uploading to nightscout has been inside Loop for a very long time, but has up to now only been used by the medtronic enlite cgmmanager. Now that the Dexcom cgmmanager also can upload to loop, more users have started using this feature. 

I've detected that the loop trend arrow doesn't always match the trend arrow displayed in nightscout. This fixes that by uploading the correct trend arrow names, adding those that were lacking from the original implementation. 

(My guess is that Loop's code for uploading glucose trend arrows predates nightscout's support for granular trend arrows. This code should be safe because Nightscout users generally update fast and because nightscout has supported granular trend arrows for a long time now, meaning the risk here is quite low.)