### PR TITLE
Add warning when user attempts to edit basal schedule without a configured pump

### DIFF
--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -521,7 +521,6 @@ final class SettingsTableViewController: UITableViewController {
             case .basalRate:
                 guard let pumpManager = dataManager.pumpManager else {
                     // Not allowing basal schedule entry without a configured pump.
-                    tableView.deselectRow(at: indexPath, animated: true)
                     let alert = UIAlertController(
                         title: NSLocalizedString("Unconfigured Pump", comment: "Alert title for unconfigured pump"),
                         message: NSLocalizedString("Please configure a pump to view or edit scheduled basal rates.", comment: "Alert message for attempting to change basal rates before pump was configured."),
@@ -532,6 +531,7 @@ final class SettingsTableViewController: UITableViewController {
                     alert.addAction(acknowledgeChange)
 
                     present(alert, animated: true)
+                    tableView.deselectRow(at: indexPath, animated: true)
                     return
                 }
                 let vc = BasalScheduleTableViewController(allowedBasalRates: pumpManager.supportedBasalRates, maximumScheduleItemCount: pumpManager.maximumBasalScheduleEntryCount, minimumTimeInterval: pumpManager.minimumBasalScheduleEntryDuration)

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -522,6 +522,16 @@ final class SettingsTableViewController: UITableViewController {
                 guard let pumpManager = dataManager.pumpManager else {
                     // Not allowing basal schedule entry without a configured pump.
                     tableView.deselectRow(at: indexPath, animated: true)
+                    let alert = UIAlertController(
+                        title: NSLocalizedString("Unconfigured Pump", comment: "Alert title for unconfigured pump"),
+                        message: NSLocalizedString("Please configure a pump to view or edit scheduled basal rates.", comment: "Alert message for attempting to change basal rates before pump was configured."),
+                        preferredStyle: .alert
+                    )
+
+                    let acknowledgeChange = UIAlertAction(title: NSLocalizedString("OK", comment: "Button text to dismiss unconfigured pump alert."), style: .default) { _ in }
+                    alert.addAction(acknowledgeChange)
+
+                    present(alert, animated: true)
                     return
                 }
                 let vc = BasalScheduleTableViewController(allowedBasalRates: pumpManager.supportedBasalRates, maximumScheduleItemCount: pumpManager.maximumBasalScheduleEntryCount, minimumTimeInterval: pumpManager.minimumBasalScheduleEntryDuration)


### PR DESCRIPTION
Currently, Loop doesn't display any message when the user attempts to edit the basal schedule without a configured pump, which can be confusing to new users. This is just a simple UIAlert that displays when the row is tapped without a configured pump; completely open to changing the wording to make it better.

<img width="325" alt="Screen Shot 2020-03-31 at 10 49 37 AM" src="https://user-images.githubusercontent.com/31571514/78058904-de6b6180-733d-11ea-88f2-997d3328ca32.png">