### PR TITLE
Fix glucose unit on bolus VC when editing carb entry

### DIFF
--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -507,6 +507,7 @@ final class CarbAbsorptionViewController: ChartsTableViewController, Identifiabl
             vc.deviceManager = deviceManager
             vc.defaultAbsorptionTimes = deviceManager.loopManager.carbStore.defaultAbsorptionTimes
             vc.preferredUnit = deviceManager.loopManager.carbStore.preferredUnit
+            vc.glucoseUnit = deviceManager.loopManager.glucoseStore.preferredUnit ?? .milligramsPerDeciliter
         default:
             break
         }


### PR DESCRIPTION
When tapping to edit a carb entry, `glucoseUnit` was not set when preparing to present `CarbEntryViewController`. `CarbEntryViewController` in turn calls `BolusViewController` (`bolusVC`) with the default value of its property `glucoseUnit`, which is `milligramsPerDeciliter`.

Consequentially, on the Bolus screen when editing a carb entry, notifications regarding glucose predictions were shown in mg/dl even to mmol/l users. Charts were not affected as (as far as I was able to determine), `ChartsTableViewController` (which `BolusViewController` extends) sets the glucoseUnit for charts directly.

Screenshot is attached.
![IMG_3730](https://user-images.githubusercontent.com/788904/78719924-0736bc80-7925-11ea-9cc6-2a061c1fead4.png)
