### PR TITLE
Red loop retry should refresh device data

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1282,7 +1282,7 @@ final class StatusTableViewController: ChartsTableViewController {
         if error != nil {
             let alertController = UIAlertController(with: error!)
             let manualLoopAction = UIAlertAction(title: NSLocalizedString("Retry", comment: "The button text for attempting a manual loop"), style: .default, handler: { _ in
-                self.deviceManager.loopManager.loop()
+                self.deviceManager.refreshDeviceData()
             })
             alertController.addAction(manualLoopAction)
             present(alertController, animated: true)


### PR DESCRIPTION
When Loop is failing to loop and displays a red or yellow loop, the user can tap on the red loop and see the last error, and have an option to Retry. The Retry option was just trying to loop again, without triggering a device data refresh. This changes the retry button to attempt to refresh pump and CGM data, so if any comms issues have been resolved by the user (bringing the RL/phone back in range, etc), but Loop hasn't tried comms with the devices, this will trigger a check, and will let the user resume automatic dosing more quickly.