### PR TITLE
Fix date picker appearance for carb entry in iOS 14

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -219,9 +219,11 @@ final class CarbEntryViewController: ChartsTableViewController, IdentifiableClas
             cell.titleLabel.text = NSLocalizedString("Date", comment: "Title of the carb entry date picker cell")
             cell.datePicker.isEnabled = isSampleEditable
             cell.datePicker.datePickerMode = .dateAndTime
-            if #available(iOS 14.0, *) {
-                cell.datePicker.preferredDatePickerStyle = .wheels
-            }
+            #if swift(>=5.2)
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+            #endif
             cell.datePicker.maximumDate = Date(timeIntervalSinceNow: maximumDateFutureInterval)
             cell.datePicker.minuteInterval = 1
             cell.date = date

--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -219,6 +219,9 @@ final class CarbEntryViewController: ChartsTableViewController, IdentifiableClas
             cell.titleLabel.text = NSLocalizedString("Date", comment: "Title of the carb entry date picker cell")
             cell.datePicker.isEnabled = isSampleEditable
             cell.datePicker.datePickerMode = .dateAndTime
+            if #available(iOS 14.0, *) {
+                cell.datePicker.preferredDatePickerStyle = .wheels
+            }
             cell.datePicker.maximumDate = Date(timeIntervalSinceNow: maximumDateFutureInterval)
             cell.datePicker.minuteInterval = 1
             cell.date = date


### PR DESCRIPTION
This is a small fix to address the date picker UI change that was made in iOS 14; I added a change to force the picker to show up in the .wheels style that it had before.

![simulator_screenshot_D617ED2C-30D0-4418-A295-E2F35434989B](https://user-images.githubusercontent.com/31571514/94377308-47594980-00d5-11eb-99c8-a4abb94d9077.png)
