### PR TITLE
Improve accessibility when using VoiceOver

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -347,6 +347,11 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
                 cell.titleLabel.text = NSLocalizedString("Date", comment: "Title of the carb entry date picker cell")
                 cell.datePicker.isEnabled = isSampleEditable
                 cell.datePicker.datePickerMode = .dateAndTime
+                #if swift(>=5.2)
+                    if #available(iOS 14.0, *) {
+                        cell.datePicker.preferredDatePickerStyle = .wheels
+                    }
+                #endif
                 cell.datePicker.maximumDate = date.addingTimeInterval(.hours(1))
                 cell.datePicker.minimumDate = date.addingTimeInterval(.hours(-12))
                 cell.datePicker.minuteInterval = 1

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -262,6 +262,7 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                 bolusUnitsLabel
             }
         }
+        .accessibilityElement(children: .combine)
     }
 
     private var recommendedBolusString: String {
@@ -285,10 +286,10 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                     keyboardType: .decimalPad,
                     shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder
                 )
-                
                 bolusUnitsLabel
             }
         }
+        .accessibilityElement(children: .combine)
     }
 
     private var bolusUnitsLabel: some View {

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -452,6 +452,7 @@ struct LabeledQuantity: View {
                 .foregroundColor(Color(.secondaryLabel))
                 .fixedSize(horizontal: true, vertical: false)
         }
+        .accessibilityElement(children: .combine)
         .font(.subheadline)
         .modifier(LabelBackground())
     }


### PR DESCRIPTION
There are a few groupings in Loop right now that don't get read correctly by VoiceOver, so I added the appropriate logic. I also snuck in a fix for the date picker style for the carb entry screen.