### PR TITLE
Removes x86_64 and i386 architectures from plugin frameworks

### DIFF
--- a/Scripts/copy-plugins.sh
+++ b/Scripts/copy-plugins.sh
@@ -16,8 +16,14 @@ function copy_plugins {
       echo Copying device plugin: $plugin to frameworks directory in app
       plugin_path="$(readlink "$f" || echo "$f")"
       plugin_as_framework_path="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/${plugin%.*}.framework"
+      
+      #Rename .plugin to .framework
       rsync -va --exclude=Frameworks "$plugin_path/." "${plugin_as_framework_path}"
-      # Rename .plugin to .framework
+      
+      #Remove sim architectures (for IPA distribution)
+      removeSimArchitectures "$plugin_as_framework_path"
+      
+      #Codesign
       if [ "$EXPANDED_CODE_SIGN_IDENTITY" != "-" ] && [ "$EXPANDED_CODE_SIGN_IDENTITY" != "" ]; then
         export CODESIGN_ALLOCATE=${DT_TOOLCHAIN_DIR}/usr/bin/codesign_allocate
         echo "Signing ${plugin} with ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
@@ -25,11 +31,15 @@ function copy_plugins {
       else
         echo "Skipping signing, no identity set"
       fi
+      
       for framework_path in "${f}"/Frameworks/*.framework; do
         framework=$(basename "$framework_path")
+        
+        #Copy nested framework
         echo "Copying plugin's framework $framework_path to ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
         cp -a "$framework_path" "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
-        plugin_path="$(readlink "$f" || echo "$f")"
+        
+        #Codesign nested framework
         if [ "$EXPANDED_CODE_SIGN_IDENTITY" != "-" ] && [ "$EXPANDED_CODE_SIGN_IDENTITY" != "" ]; then
           echo "Signing $framework for $plugin with $EXPANDED_CODE_SIGN_IDENTITY_NAME"
           /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --timestamp=none --preserve-metadata=identifier,entitlements,flags "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/${framework}"
@@ -38,8 +48,36 @@ function copy_plugins {
     done
 }
 
-copy_plugins "$BUILT_PRODUCTS_DIR"
+function removeSimArchitectures {
 
+    FRAMEWORK="$1"
+    echo "Check for sim architectures to remove in framework: $FRAMEWORK"
+
+    FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$FRAMEWORK/Info.plist" CFBundleExecutable)
+    FRAMEWORK_EXECUTABLE_PATH="$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME"
+
+    if [ ! -f "${FRAMEWORK_EXECUTABLE_PATH}" ]; then
+        return
+    fi
+
+    if xcrun lipo -info "${FRAMEWORK_EXECUTABLE_PATH}" | grep --silent "Non-fat"; then
+        echo "   $FRAMEWORK_EXECUTABLE_NAME non-fat, skipping"
+        return
+    fi
+
+    ARCHS=$(lipo -archs "$FRAMEWORK_EXECUTABLE_PATH")
+
+    for ARCH in $ARCHS
+    do
+        if [ "$ARCH" == "x86_64" ] || [ "$ARCH" == "i386" ]; then
+        echo "   Removing $ARCH from $FRAMEWORK_EXECUTABLE_NAME"
+        xcrun lipo -remove "$ARCH" "$FRAMEWORK_EXECUTABLE_PATH" -o "$FRAMEWORK_EXECUTABLE_PATH"
+        fi
+    done
+}
+
+
+copy_plugins "$BUILT_PRODUCTS_DIR"
 CARTHAGE_BUILD_DIR="${SRCROOT}/Carthage/Build"
 if [ -n "${IPHONEOS_DEPLOYMENT_TARGET}" ]; then
 CARTHAGE_BUILD_DIR="${CARTHAGE_BUILD_DIR}/iOS"


### PR DESCRIPTION
This is based off the work of PR [1324](https://github.com/LoopKit/Loop/pull/1324) which addresses the issue reported in [#1117](https://github.com/LoopKit/Loop/issues/1117). This PR change targets the master branch though. I also was not able to get PR [1324](https://github.com/LoopKit/Loop/pull/1324) to build IPAs without errors so opted for a smaller change in this PR that seems to work well.

The fix here resides in the copy-plugins.sh script, as I believe that is most closely the source of the issue. Extra architectures for frameworks (i386 and x86) are stripped in the copy-frameworks.sh script, via the call to `"${SRCROOT}/bin/carthage" copy-frameworks`. That script does not process plugin frameworks though, which are instead copied/installed via the copy-plugins.sh script. This PR will add a stripping mechanism for the plugin script as well for added parity between plugin frameworks vs non-plugin frameworks.

In terms of testing, I used Xcode 12.4 and checked the following. 

-Build directly to an iPhone 14.4.
-Simulator Builds
-Distribute an ad-hoc IPA.