### PR TITLE
Store device token to LoopSettings

### DIFF
--- a/LoopCore/LoopSettings.swift
+++ b/LoopCore/LoopSettings.swift
@@ -295,6 +295,8 @@ extension LoopSettings: RawRepresentable {
             let dosingStrategy = DosingStrategy(rawValue: rawDosingStrategy) {
             self.dosingStrategy = dosingStrategy
         }
+        
+        self.deviceToken = rawValue["deviceToken"] as? Data
     }
 
     public var rawValue: RawValue {
@@ -314,6 +316,7 @@ extension LoopSettings: RawRepresentable {
         raw["maximumBolus"] = maximumBolus
         raw["minimumBGGuard"] = suspendThreshold?.rawValue
         raw["dosingStrategy"] = dosingStrategy.rawValue
+        raw["deviceToken"] = deviceToken
 
         return raw
     }


### PR DESCRIPTION
I was getting an error "Could not find deviceToken in loopSettings." error while trying to send push notifications. It appears the token gets set to LoopSettings.deviceToken but that value isn't stored to LoopSettings.

I'm not very familiar with this area of code or how it interacts with `StoredSettings`, which also includes a device token. So this may not be the appropriate fix.