### PR TITLE
Fix outside doses not being uploaded to Nightscout

### DIFF
--- a/Loop/Managers/RemoteDataServicesManager.swift
+++ b/Loop/Managers/RemoteDataServicesManager.swift
@@ -167,7 +167,7 @@ extension RemoteDataServicesManager {
             let semaphore = DispatchSemaphore(value: 0)
             let queryAnchor = UserDefaults.appGroup?.getQueryAnchor(for: remoteDataService, withRemoteDataType: .dose) ?? DoseStore.QueryAnchor()
 
-            self.doseStore.executeDoseQuery(fromQueryAnchor: queryAnchor, limit: remoteDataService.doseDataLimit ?? Int.max) { result in
+            self.doseStore.executeDoseQuery(fromQueryAnchor: queryAnchor, pumpEventLimit: remoteDataService.doseDataLimit ?? Int.max / 2, doseEventsLimit: remoteDataService.doseDataLimit ?? Int.max / 2) { result in
                 switch result {
                 case .failure(let error):
                     self.log.error("Error querying dose data: %{public}@", String(describing: error))

--- a/Loop/Managers/Store Protocols/DoseStoreProtocol.swift
+++ b/Loop/Managers/Store Protocols/DoseStoreProtocol.swift
@@ -52,7 +52,7 @@ protocol DoseStoreProtocol: AnyObject {
     
     func executePumpEventQuery(fromQueryAnchor queryAnchor: DoseStore.QueryAnchor?, limit: Int, completion: @escaping (DoseStore.PumpEventQueryResult) -> Void)
     
-    func executeDoseQuery(fromQueryAnchor queryAnchor: DoseStore.QueryAnchor?, limit: Int, completion: @escaping (DoseStore.DoseQueryResult) -> Void)
+    func executeDoseQuery(fromQueryAnchor queryAnchor: DoseStore.QueryAnchor?, pumpEventLimit: Int, doseEventsLimit: Int, completion: @escaping (DoseStore.DoseQueryResult) -> Void)
     
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void)
     

--- a/LoopTests/Mock Stores/MockDoseStore.swift
+++ b/LoopTests/Mock Stores/MockDoseStore.swift
@@ -87,7 +87,7 @@ class MockDoseStore: DoseStoreProtocol {
         completion(.failure(DoseStore.DoseStoreError.configurationError))
     }
     
-    func executeDoseQuery(fromQueryAnchor queryAnchor: DoseStore.QueryAnchor?, limit: Int, completion: @escaping (DoseStore.DoseQueryResult) -> Void) {
+    func executeDoseQuery(fromQueryAnchor queryAnchor: DoseStore.QueryAnchor?, pumpEventLimit: Int, doseEventsLimit: Int, completion: @escaping (DoseStore.DoseQueryResult) -> Void) {
         completion(.failure(DoseStore.DoseStoreError.configurationError))
     }
     


### PR DESCRIPTION
This PR update store protocols based on LoopKit changes to upload outside doses to Nightscout (https://github.com/LoopKit/LoopKit/pull/369). To ensure the uploaded doses between the pump events & the insulin delivery objects don't exceed the limit for the service, I chose to split the limit in half for each (would love feedback on this, since the number of uploaded insulin delivery objects should be pretty small)