### PR TITLE
Zero out the recommended dose when user starts to edit bolus

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -301,6 +301,9 @@ struct BolusEntryView: View {
                 )
                 bolusUnitsLabel
             }
+            .onTapGesture {
+                typedBolusEntry.wrappedValue = ""
+            }
         }
         .accessibilityElement(children: .combine)
     }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -302,7 +302,9 @@ struct BolusEntryView: View {
                 bolusUnitsLabel
             }
             .onTapGesture {
-                typedBolusEntry.wrappedValue = ""
+                if typedBolusEntry.wrappedValue == recommendedBolusString {
+                    typedBolusEntry.wrappedValue = ""
+                }
             }
         }
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
Currently, when a user decides to edit the recommended bolus, they have to delete the entry first, which adds more taps to this common interaction. This PR zeros out the bolus entry field if the user taps to edit the bolus and the currently-entered dose matches the recommended amount.

![IMG_54DC4D28C48A-1](https://user-images.githubusercontent.com/31571514/129496093-3b3553d4-b17b-465b-8a0b-930c0e0952ef.jpeg)
