### PR TITLE
fix Retrospective Correction subtitle

### DIFF
--- a/Loop/Base.lproj/Localizable.strings
+++ b/Loop/Base.lproj/Localizable.strings
@@ -267,6 +267,9 @@
 /* The title text for the issue report cell */
 "Issue Report" = "Issue Report";
 
+/* Format string describing retrospective glucose prediction comparison. (1: Predicted glucose)(2: Actual glucose)(3: difference) */
+"prediction-description-retrospective-correction" = "Predicted: %1$@\nActual: %2$@ (%3$@)";
+
 /* Glucose HUD accessibility hint */
 "Launches CGM app" = "Launches CGM app";
 


### PR DESCRIPTION
This adds back the format string describing retrospective glucose prediction comparison, which fixes the Retrospective Correction subtitle on the Predicted Glucose screen.