### PR TITLE
increase log duration, add markdown header mark

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -606,7 +606,7 @@ final class DeviceDataManager {
                         "",
                         String(reflecting: self.statusExtensionManager!),
                         "",
-                        // loopReport,
+                        loopReport,
                         alertReport
                         ].joined(separator: "\n")
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -577,7 +577,7 @@ final class DeviceDataManager {
                     }
 
                     let report = [
-                        "## Version",
+                        "## Build Details",
                         "* appNameAndVersion: \(Bundle.main.localizedNameAndVersion)",
                         "* profileExpiration: \(Bundle.main.profileExpirationString)",
                         "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -578,7 +578,7 @@ final class DeviceDataManager {
 
                     let report = [
                         "## Version",
-                        "* codeVersion: \(Bundle.main.localizedNameAndVersion)",
+                        "* appNameAndVersion: \(Bundle.main.localizedNameAndVersion)",
                         "* profileExpiration: \(Bundle.main.profileExpirationString)",
                         "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
                         "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
@@ -602,10 +602,10 @@ final class DeviceDataManager {
                         "## Device Communication Log",
                         deviceLogReport,
                         "",
-                        // String(reflecting: self.watchManager!),
-                        // "",
-                        // String(reflecting: self.statusExtensionManager!),
-                        // "",
+                        String(reflecting: self.watchManager!),
+                        "",
+                        String(reflecting: self.statusExtensionManager!),
+                        "",
                         // loopReport,
                         alertReport
                         ].joined(separator: "\n")

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -564,9 +564,10 @@ final class DeviceDataManager {
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
 
-            self.alertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+            let logDurationHours = 84.0
 
-                self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
+            self.alertManager.getStoredEntries(startDate: Date() - .hours(logDurationHours)) { (alertReport) in
+                self.deviceLog.getLogEntries(startDate: Date() - .hours(logDurationHours)) { (result) in
                     let deviceLogReport: String
                     switch result {
                     case .failure(let error):
@@ -576,7 +577,8 @@ final class DeviceDataManager {
                     }
 
                     let report = [
-                        Bundle.main.localizedNameAndVersion,
+                        "## Version",
+                        "* codeVersion: \(Bundle.main.localizedNameAndVersion)",
                         "* profileExpiration: \(Bundle.main.profileExpirationString)",
                         "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
                         "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
@@ -600,11 +602,11 @@ final class DeviceDataManager {
                         "## Device Communication Log",
                         deviceLogReport,
                         "",
-                        String(reflecting: self.watchManager!),
-                        "",
-                        String(reflecting: self.statusExtensionManager!),
-                        "",
-                        loopReport,
+                        // String(reflecting: self.watchManager!),
+                        // "",
+                        // String(reflecting: self.statusExtensionManager!),
+                        // "",
+                        // loopReport,
                         alertReport
                         ].joined(separator: "\n")
 


### PR DESCRIPTION
This PR, along with [Update capture-build-details.sh](https://github.com/LoopKit/Loop/pull/1591) will assist in providing full pod history for support of both Eros and Dash pods.

This PR:
* Removes some of the verbose portions of the Loop Report that are now available in the Export Critical Event Logs tab
* Extends the duration of the reported log to 84 hours, which should cover the full history of a pod for most cases
* Adds a header marker for the code Version in the markdown output

The last 2 items on the list simplify the work required to parse and report on Dash pods as we are testing the code to support Dash implementation.

The extended duration is helpful for supporting both Eros and Dash when Loop users report problems with their pods online.

Note that without the full history (and the corresponding 0x0115 and 0x011b messages from the pod), the lot, sequence number and firmware versions are not available.

The other PR, #1591, reports the commit for the associated LoopWorkspace, which for most builds, will identify the full build with submodules for the workspace build.