### PR TITLE
Bolus clear fix

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1108,9 +1108,6 @@ extension DeviceDataManager: GlucoseStoreDelegate {
 // MARK: - TestingPumpManager
 extension DeviceDataManager {
     func deleteTestingPumpData(completion: ((Error?) -> Void)? = nil) {
-//        guard FeatureFlags.scenariosEnabled else {
-//            fatalError("\(#function) should be invoked only when scenarios are enabled")
-//        }
 
         guard let testingPumpManager = pumpManager as? TestingPumpManager else {
             assertionFailure("\(#function) should be invoked only when a testing pump manager is in use")

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1108,9 +1108,9 @@ extension DeviceDataManager: GlucoseStoreDelegate {
 // MARK: - TestingPumpManager
 extension DeviceDataManager {
     func deleteTestingPumpData(completion: ((Error?) -> Void)? = nil) {
-        guard FeatureFlags.scenariosEnabled else {
-            fatalError("\(#function) should be invoked only when scenarios are enabled")
-        }
+//        guard FeatureFlags.scenariosEnabled else {
+//            fatalError("\(#function) should be invoked only when scenarios are enabled")
+//        }
 
         guard let testingPumpManager = pumpManager as? TestingPumpManager else {
             assertionFailure("\(#function) should be invoked only when a testing pump manager is in use")

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1133,8 +1133,6 @@ extension LoopDataManager {
             throw LoopError.pumpDataTooOld(date: pumpStatusDate)
         }
 
-        logger.default("*************** predict glucose")
-
         var momentum: [GlucoseEffect] = []
         var retrospectiveGlucoseEffect = self.retrospectiveGlucoseEffect
         var effects: [[GlucoseEffect]] = []

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1133,6 +1133,8 @@ extension LoopDataManager {
             throw LoopError.pumpDataTooOld(date: pumpStatusDate)
         }
 
+        logger.default("*************** predict glucose")
+
         var momentum: [GlucoseEffect] = []
         var retrospectiveGlucoseEffect = self.retrospectiveGlucoseEffect
         var effects: [[GlucoseEffect]] = []
@@ -1914,8 +1916,6 @@ extension LoopDataManager {
     /// - Parameter state: The current state of the manager. This is invalid to access outside of the closure.
     func getLoopState(_ handler: @escaping (_ manager: LoopDataManager, _ state: LoopState) -> Void) {
         dataAccessQueue.async {
-            self.logger.debug("getLoopState: update()")
-
             let (_, updateError) = self.update(for: .getLoopState)
 
             handler(self, LoopStateView(loopDataManager: self, updateError: updateError))

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1226,10 +1226,6 @@ extension LoopDataManager {
             prediction.append(PredictedGlucoseValue(startDate: finalDate, quantity: last.quantity))
         }
 
-        if prediction.count > 1 && prediction.count < 50 {
-            print("**** Short forecast: \(prediction)")
-        }
-
         return prediction
     }
 

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1226,6 +1226,10 @@ extension LoopDataManager {
             prediction.append(PredictedGlucoseValue(startDate: finalDate, quantity: last.quantity))
         }
 
+        if prediction.count > 1 && prediction.count < 50 {
+            print("**** Short forecast: \(prediction)")
+        }
+
         return prediction
     }
 

--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -500,6 +500,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
             potentialCarbEntry: updatedEntry,
             selectedCarbAbsorptionTimeEmoji: selectedDefaultAbsorptionTimeEmoji
         )
+        viewModel.generateRecommendationAndStartObserving()
 
         let bolusEntryView = BolusEntryView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1248,6 +1248,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)
         } else {
             let viewModel = BolusEntryViewModel(delegate: deviceManager, isManualGlucoseEntryEnabled: enableManualGlucoseEntry)
+            viewModel.generateRecommendationAndStartObserving()
             let bolusEntryView = BolusEntryView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)
         }

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -227,7 +227,6 @@ final class BolusEntryViewModel: ObservableObject {
             .publisher(for: .LoopDataUpdated)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.log.debug("calling update() from LoopDataUpdated notification")
                 self?.update()
             }
             .store(in: &cancellables)
@@ -283,7 +282,6 @@ final class BolusEntryViewModel: ObservableObject {
 
                 // Update the manual glucose sample's timestamp, which should always be "now"
                 self.updateManualGlucoseSample(enteredAt: self.now())
-                self.log.debug("calling update() from observeElapsedTime")
                 self.update()
             }
             .store(in: &cancellables)
@@ -569,7 +567,6 @@ final class BolusEntryViewModel: ObservableObject {
 
         let predictedGlucoseValues: [PredictedGlucoseValue]
         do {
-            log.debug("predicting glucose with enteredDose: %@", enteredBolus)
             if let manualGlucoseEntry = manualGlucoseSample {
                 predictedGlucoseValues = try state.predictGlucoseFromManualGlucose(
                     manualGlucoseEntry,

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -707,8 +707,6 @@ final class BolusEntryViewModel: ObservableObject {
     private func computeBolusRecommendation(from state: LoopState) throws -> ManualBolusRecommendation? {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
-        log.debug("getting bolus recommendation")
-
         let manualGlucoseSample = DispatchQueue.main.sync { self.manualGlucoseSample }
         if manualGlucoseSample != nil {
             return try state.recommendBolusForManualGlucose(

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -74,11 +74,11 @@ struct BolusEntryView: View {
                         }
                         enteredBolusStringBinding.wrappedValue = newEnteredBolusString
                     }
-            }
-            .onReceive(self.viewModel.$isManualGlucoseEntryEnabled) { isManualGlucoseEntryEnabled in
-                // The view model can disable manual glucose entry if CGM data returns.
-                self.isManualGlucoseEntryRowVisible = isManualGlucoseEntryEnabled
-            }
+                }
+                .onReceive(self.viewModel.$isManualGlucoseEntryEnabled) { isManualGlucoseEntryEnabled in
+                    // The view model can disable manual glucose entry if CGM data returns.
+                    self.isManualGlucoseEntryRowVisible = isManualGlucoseEntryEnabled
+                }
         }
     }
     

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -55,12 +55,6 @@ struct BolusEntryView: View {
                 if state.height == 0 {
                     // Ensure tapping 'Enter Bolus' can make the text field the first responder again
                     self.shouldBolusEntryBecomeFirstResponder = false
-                } else {
-                    if !editedBolusAmount {
-                        enteredBolusString = ""
-                        self.viewModel.enteredBolus = HKQuantity(unit: .internationalUnit(), doubleValue: 0)
-                        editedBolusAmount = true
-                    }
                 }
             }
             .keyboardAware()
@@ -268,7 +262,6 @@ struct BolusEntryView: View {
         HStack {
             Text("Recommended Bolus", comment: "Label for recommended bolus row on bolus screen")
             Spacer()
-            ActivityIndicator(isAnimating: $viewModel.isRefreshingPump, style: .default)
             HStack(alignment: .firstTextBaseline) {
                 Text(recommendedBolusString)
                     .font(.title)
@@ -286,6 +279,14 @@ struct BolusEntryView: View {
         return Self.doseAmountFormatter.string(from: amount) ?? String(amount)
     }
 
+    private func didBeginEditing() {
+        if !editedBolusAmount {
+            enteredBolusString = ""
+            self.viewModel.enteredBolus = HKQuantity(unit: .internationalUnit(), doubleValue: 0)
+            editedBolusAmount = true
+        }
+    }
+
     private var bolusEntryRow: some View {
         HStack {
             Text("Bolus", comment: "Label for bolus entry row on bolus screen")
@@ -300,7 +301,8 @@ struct BolusEntryView: View {
                     keyboardType: .decimalPad,
                     shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
                     maxLength: 5,
-                    doneButtonColor: .loopAccent
+                    doneButtonColor: .loopAccent,
+                    textFieldDidBeginEditing: didBeginEditing
                 )
                 bolusUnitsLabel
             }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -58,6 +58,7 @@ struct BolusEntryView: View {
                 } else {
                     if !editedBolusAmount {
                         enteredBolusAmount = ""
+                        self.viewModel.enteredBolus = HKQuantity(unit: .internationalUnit(), doubleValue: 0)
                         editedBolusAmount = true
                     }
                 }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -57,7 +57,7 @@ struct BolusEntryView: View {
                     self.shouldBolusEntryBecomeFirstResponder = false
                 } else {
                     if !editedBolusAmount {
-                        typedBolusEntry.wrappedValue = ""
+                        enteredBolusAmount = ""
                         editedBolusAmount = true
                     }
                 }

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -41,6 +41,12 @@ class BolusEntryViewModelTests: XCTestCase {
     static let exampleBolusQuantity = HKQuantity(unit: .internationalUnit(), doubleValue: 1.0)
     static let noBolus = HKQuantity(unit: .internationalUnit(), doubleValue: 0.0)
 
+    static let exampleGlucoseRangeSchedule = GlucoseRangeSchedule(unit: .milligramsPerDeciliter, dailyItems: [
+        RepeatingScheduleValue(startTime: TimeInterval(0), value: DoubleRange(minValue: 100, maxValue: 110)),
+        RepeatingScheduleValue(startTime: TimeInterval(28800), value: DoubleRange(minValue: 90, maxValue: 100)),
+        RepeatingScheduleValue(startTime: TimeInterval(75600), value: DoubleRange(minValue: 100, maxValue: 110))
+    ], timeZone: .utcTimeZone)!
+
     static let mockUUID = UUID()
 
     static let exampleScheduleOverrideSettings = TemporaryScheduleOverrideSettings(unit: .millimolesPerLiter, targetRange: nil, insulinNeedsScaleFactor: nil)
@@ -79,6 +85,15 @@ class BolusEntryViewModelTests: XCTestCase {
                                                   selectedCarbAbsorptionTimeEmoji: selectedCarbAbsorptionTimeEmoji)
         bolusEntryViewModel.authenticate = authenticateOverride
         bolusEntryViewModel.maximumBolus = HKQuantity(unit: .internationalUnit(), doubleValue: 10)
+
+
+        let exp = expectation(description: "wait for initial recommendation generation")
+        exp.assertForOverFulfill = false
+        bolusEntryViewModel.generateRecommendationAndStartObserving() {
+            exp.fulfill()
+        }
+        try! triggerLoopStateResult(with: MockLoopState())
+        wait(for: [exp], timeout: 1.0)
     }
 
     var authenticateOverrideCompletion: ((Swift.Result<Void, Error>) -> Void)?
@@ -91,20 +106,18 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertEqual(0, bolusEntryViewModel.predictedGlucoseValues.count)
         XCTAssertNil(bolusEntryViewModel.activeCarbs)
         XCTAssertNil(bolusEntryViewModel.activeInsulin)
-        XCTAssertNil(bolusEntryViewModel.targetGlucoseSchedule)
+        XCTAssertEqual(bolusEntryViewModel.targetGlucoseSchedule, BolusEntryViewModelTests.exampleGlucoseRangeSchedule)
         XCTAssertNil(bolusEntryViewModel.preMealOverride)
         XCTAssertNil(bolusEntryViewModel.scheduleOverride)
        
         XCTAssertFalse(bolusEntryViewModel.isManualGlucoseEntryEnabled)
 
         XCTAssertNil(bolusEntryViewModel.manualGlucoseQuantity)
-        XCTAssertNil(bolusEntryViewModel.recommendedBolus)
+        XCTAssertEqual(HKQuantity(unit: .internationalUnit(), doubleValue: 0), bolusEntryViewModel.recommendedBolus)
         XCTAssertEqual(HKQuantity(unit: .internationalUnit(), doubleValue: 0), bolusEntryViewModel.enteredBolus)
 
         XCTAssertNil(bolusEntryViewModel.activeAlert)
         XCTAssertNil(bolusEntryViewModel.activeNotice)
-
-        XCTAssertFalse(bolusEntryViewModel.isRefreshingPump)
     }
     
     func testChartDateInterval() throws {
@@ -191,7 +204,7 @@ class BolusEntryViewModelTests: XCTestCase {
     func testUpdateSettings() throws {
         XCTAssertNil(bolusEntryViewModel.preMealOverride)
         XCTAssertNil(bolusEntryViewModel.scheduleOverride)
-        XCTAssertNil(bolusEntryViewModel.targetGlucoseSchedule)
+        XCTAssertEqual(bolusEntryViewModel.targetGlucoseSchedule, BolusEntryViewModelTests.exampleGlucoseRangeSchedule)
         let newGlucoseTargetRangeSchedule = GlucoseRangeSchedule(unit: .milligramsPerDeciliter, dailyItems: [
             RepeatingScheduleValue(startTime: TimeInterval(0), value: DoubleRange(minValue: 100, maxValue: 110)),
             RepeatingScheduleValue(startTime: TimeInterval(28800), value: DoubleRange(minValue: 90, maxValue: 100)),
@@ -218,7 +231,7 @@ class BolusEntryViewModelTests: XCTestCase {
         setUpViewModel(originalCarbEntry: mockOriginalCarbEntry, potentialCarbEntry: mockPotentialCarbEntry)
         XCTAssertNil(bolusEntryViewModel.preMealOverride)
         XCTAssertNil(bolusEntryViewModel.scheduleOverride)
-        XCTAssertNil(bolusEntryViewModel.targetGlucoseSchedule)
+        XCTAssertEqual(bolusEntryViewModel.targetGlucoseSchedule, BolusEntryViewModelTests.exampleGlucoseRangeSchedule)
         let newGlucoseTargetRangeSchedule = GlucoseRangeSchedule(unit: .milligramsPerDeciliter, dailyItems: [
             RepeatingScheduleValue(startTime: TimeInterval(0), value: DoubleRange(minValue: 100, maxValue: 110)),
             RepeatingScheduleValue(startTime: TimeInterval(28800), value: DoubleRange(minValue: 90, maxValue: 100)),
@@ -310,6 +323,7 @@ class BolusEntryViewModelTests: XCTestCase {
     func testUpdateRecommendedBolusWithNoticeMissingSuspendThreshold() throws {
         let mockState = MockLoopState()
         XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
+        delegate.settings.suspendThreshold = nil
         mockState.bolusRecommendationResult = ManualBolusRecommendation(amount: 1.234, pendingInsulin: 4.321, notice: BolusRecommendationNotice.glucoseBelowSuspendThreshold(minGlucose: Self.exampleGlucoseValue))
         try triggerLoopStateUpdatedWithDataAndWait(with: mockState)
         XCTAssertTrue(bolusEntryViewModel.isBolusRecommended)
@@ -382,41 +396,6 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertNil(bolusEntryViewModel.activeNotice)
     }
 
-    func testUpdateDoesNotRefreshPumpIfDataIsFresh() throws {
-        XCTAssertFalse(bolusEntryViewModel.isRefreshingPump)
-        try triggerLoopStateUpdatedWithDataAndWait()
-        XCTAssertFalse(bolusEntryViewModel.isRefreshingPump)
-        XCTAssertNil(delegate.ensureCurrentPumpDataCompletion)
-    }
-
-    func testUpdateIsRefreshingPump() throws {
-        delegate.mostRecentPumpDataDate = Date.distantPast
-        XCTAssertFalse(bolusEntryViewModel.isRefreshingPump)
-        try triggerLoopStateUpdatedWithDataAndWait()
-        XCTAssertTrue(bolusEntryViewModel.isRefreshingPump)
-        let completion = try XCTUnwrap(delegate.ensureCurrentPumpDataCompletion)
-        completion(Date())
-        // Need to once again trigger loop state
-        try triggerLoopStateResult(with: MockLoopState())
-        // then wait on main again (sigh)
-        waitOnMain()
-        XCTAssertFalse(bolusEntryViewModel.isRefreshingPump)
-    }
-        
-    func testRecommendedBolusSetsEnteredBolus() throws {
-        XCTAssertNil(bolusEntryViewModel.recommendedBolus)
-        bolusEntryViewModel.enteredBolus = Self.exampleBolusQuantity
-        let mockState = MockLoopState()
-        mockState.bolusRecommendationResult = ManualBolusRecommendation(amount: 1.234, pendingInsulin: 4.321)
-        try triggerLoopStateUpdatedWithDataAndWait(with: mockState)
-        // Now, through the magic of `observeRecommendedBolusChanges` and the recommendedBolus publisher it should update to 1.234.  But we have to wait twice on main to make this reliable...
-        // For some reason, starting with Xcode 12.5, in order for these tests to pass we need to call `waitOnMain()`
-        // _twice_ here.  Not exactly sure why, needs investigation.
-        waitOnMain()
-        waitOnMain()
-        XCTAssertEqual(HKQuantity(unit: .internationalUnit(), doubleValue: 1.234), bolusEntryViewModel.enteredBolus)
-    }
-
     // MARK: save data and bolus delivery
 
     func testDeliverBolusOnly() throws {
@@ -435,8 +414,8 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertTrue(delegate.glucoseSamplesAdded.isEmpty)
         XCTAssertTrue(delegate.carbEntriesAdded.isEmpty)
         XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        manualBolusRequested: 1.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 1.0)
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
     }
     
@@ -489,9 +468,9 @@ class BolusEntryViewModelTests: XCTestCase {
 
         XCTAssertTrue(delegate.carbEntriesAdded.isEmpty)
         XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        manualGlucoseSample: Self.exampleManualStoredGlucoseSample,
-                                                                                        manualBolusRequested: 0.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualGlucoseSample, Self.exampleManualStoredGlucoseSample)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 0.0)
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
         XCTAssertNil(delegate.enactedBolusUnits)
         XCTAssertNil(delegate.enactedBolusAutomatic)
@@ -510,16 +489,13 @@ class BolusEntryViewModelTests: XCTestCase {
 
         XCTAssertTrue(delegate.glucoseSamplesAdded.isEmpty)
         XCTAssertEqual(1, delegate.carbEntriesAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        originalCarbEntry: mockOriginalCarbEntry,
-                                                                                        carbEntry: mockFinalCarbEntry,
-                                                                                        manualBolusRequested: 0.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.originalCarbEntry, mockOriginalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.carbEntry, mockFinalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 0.0)
+
         XCTAssertEqual(mockOriginalCarbEntry, delegate.carbEntriesAdded.first?.1)
-        XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        originalCarbEntry: mockOriginalCarbEntry,
-                                                                                        carbEntry: mockFinalCarbEntry,
-                                                                                        manualBolusRequested: 0.0))
+
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
         XCTAssertNil(delegate.enactedBolusUnits)
         XCTAssertNil(delegate.enactedBolusAutomatic)
@@ -547,9 +523,9 @@ class BolusEntryViewModelTests: XCTestCase {
 
         XCTAssertTrue(delegate.carbEntriesAdded.isEmpty)
         XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        manualGlucoseSample: Self.exampleManualStoredGlucoseSample,
-                                                                                        manualBolusRequested: 1.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualGlucoseSample, Self.exampleManualStoredGlucoseSample)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 1.0)
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
         XCTAssertEqual(1.0, delegate.enactedBolusUnits)
         XCTAssertEqual(false, delegate.enactedBolusAutomatic)
@@ -578,10 +554,10 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertEqual(mockPotentialCarbEntry, delegate.carbEntriesAdded.first?.0)
         XCTAssertEqual(mockOriginalCarbEntry, delegate.carbEntriesAdded.first?.1)
         XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        originalCarbEntry: mockOriginalCarbEntry,
-                                                                                        carbEntry: mockFinalCarbEntry,
-                                                                                        manualBolusRequested: 1.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.originalCarbEntry, mockOriginalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.carbEntry, mockFinalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 1.0)
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
         XCTAssertEqual(1.0, delegate.enactedBolusUnits)
         XCTAssertEqual(false, delegate.enactedBolusAutomatic)
@@ -648,11 +624,11 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertEqual(mockPotentialCarbEntry, delegate.carbEntriesAdded.first?.0)
         XCTAssertEqual(mockOriginalCarbEntry, delegate.carbEntriesAdded.first?.1)
         XCTAssertEqual(1, delegate.bolusDosingDecisionsAdded.count)
-        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0, BolusDosingDecision(for: .normalBolus,
-                                                                                        originalCarbEntry: mockOriginalCarbEntry,
-                                                                                        carbEntry: mockFinalCarbEntry,
-                                                                                        manualGlucoseSample: Self.exampleManualStoredGlucoseSample,
-                                                                                        manualBolusRequested: 1.0))
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.reason, .normalBolus)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.originalCarbEntry, mockOriginalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.carbEntry, mockFinalCarbEntry)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualGlucoseSample, Self.exampleManualStoredGlucoseSample)
+        XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.0.manualBolusRequested, 1.0)
         XCTAssertEqual(delegate.bolusDosingDecisionsAdded.first?.1, now)
         XCTAssertEqual(1.0, delegate.enactedBolusUnits)
         XCTAssertEqual(false, delegate.enactedBolusAutomatic)
@@ -970,7 +946,12 @@ fileprivate class MockBolusEntryViewModelDelegate: BolusEntryViewModelDelegate {
     
     var insulinModel: InsulinModel? = MockInsulinModel()
     
-    var settings: LoopSettings = LoopSettings()
+    var settings: LoopSettings = LoopSettings(
+        dosingEnabled: true,
+        glucoseTargetRangeSchedule: BolusEntryViewModelTests.exampleGlucoseRangeSchedule,
+        maximumBasalRatePerHour: 3.0,
+        maximumBolus: 10.0,
+        suspendThreshold: GlucoseThreshold(unit: .internationalUnit(), value: 75))
 }
 
 fileprivate struct MockInsulinModel: InsulinModel {


### PR DESCRIPTION
There are some reports of the existing clear-on-edit mechanism not actually clearing out the editable bolus amount field in the bolus view. This uses a different strategy to clear the field. 

Looking to test reports from those who have experienced the failure to clear. 

It also contains changes to streamline forecast and recommendation generation; previously, bringing up the view would cause at least 7 forecast predictions to be run, and would cause flashing as the various parts of the UI updated, usually rendering a view without the bolus and then rendering one with the bolus.