### PR TITLE
Reduce WatchApp visible duration from 6 hours to 2 hours

### DIFF
--- a/WatchApp Extension/Extensions/NSUserDefaults+WatchApp.swift
+++ b/WatchApp Extension/Extensions/NSUserDefaults+WatchApp.swift
@@ -32,7 +32,7 @@ extension UserDefaults {
 //            if let value = object(forKey: Key.VisibleDuration.rawValue) as? TimeInterval {
 //                return value
 //            }
-            return TimeInterval(hours: 6)
+            return TimeInterval(hours: 2)
         }
         set {
             set(newValue.rawValue, forKey: Key.VisibleDuration.rawValue)


### PR DESCRIPTION
Based on some discussion in zulip [here](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/WatchApp.20on.20dev/near/271923672)

The shorter window has made it easier for me to see the recent trends and near-term projections, which is where the watch is most useful 🙂