### PR TITLE
Support more precision in remote bolus notifications

### DIFF
--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -163,8 +163,13 @@ extension NotificationManager {
     
     static func sendRemoteBolusNotification(amount: Double) {
         let notification = UNMutableNotificationContent()
-
-        notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %.1f U", comment: "The notification title for a remote bolus. (1: Bolus amount)"), amount)
+        let quantityFormatter = QuantityFormatter()
+        quantityFormatter.setPreferredNumberFormatter(for: .internationalUnit())
+        guard let amountDescription = quantityFormatter.numberFormatter.string(from: amount) else {
+            print("Unexpected, cannot convert remote bolus amount to string: \(amount)")
+            return
+        }
+        notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %@ U", comment: "The notification title for a remote bolus. (1: Bolus amount)"), amountDescription)
         
         let body = "Success!"
 
@@ -182,8 +187,14 @@ extension NotificationManager {
     
     static func sendRemoteBolusFailureNotification(for error: Error, amount: Double) {
         let notification = UNMutableNotificationContent()
+        let quantityFormatter = QuantityFormatter()
+        quantityFormatter.setPreferredNumberFormatter(for: .internationalUnit())
+        guard let amountDescription = quantityFormatter.numberFormatter.string(from: amount) else {
+            print("Unexpected, cannot convert remote bolus amount to string: \(amount)")
+            return
+        }
 
-        notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %.1f U", comment: "The notification title for a remote failure. (1: Bolus amount)"), amount)
+        notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %@ U", comment: "The notification title for a remote failure. (1: Bolus amount)"), amountDescription)
         notification.body = error.localizedDescription
         notification.sound = .default
 


### PR DESCRIPTION
Remote bolus notifications were not formatted properly for values like 1.02, which would round to 1.1 in the visible notifications. (would not affect delivery though). I was only supporting 1 precision unit. The screenshot below is with the fix.

![IMG_8CCF2067FDE8-1](https://user-images.githubusercontent.com/3207996/160239105-a19b235f-1607-4dad-8c95-b2134650978a.jpeg)

