### PR TITLE
Modify BolusEntryView

### DIFF
--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -818,7 +818,7 @@ extension BolusEntryViewModel {
         }
     }
     
-    private var hasBolusEntryReadyToDeliver: Bool {
+    public var hasBolusEntryReadyToDeliver: Bool {
         enteredBolus.doubleValue(for: .internationalUnit()) != 0
     }
 

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -182,6 +182,10 @@ struct BolusEntryView: View {
             if viewModel.isManualGlucoseEntryEnabled || viewModel.potentialCarbEntry != nil {
                 recommendedBolusRow
             }
+            
+            if viewModel.hasBolusEntryReadyToDeliver && viewModel.potentialCarbEntry != nil {
+                saveCarbsWithoutBolusButton
+            }
 
             bolusEntryRow
         }
@@ -289,32 +293,22 @@ struct BolusEntryView: View {
 
     private var bolusEntryRow: some View {
         HStack {
-            if !shouldBolusEntryBecomeFirstResponder {
-                Text("Accept with Save", comment: "Label for bolus entry row on bolus screen when shouldBolusEntryBecomeFirstResponder is false")
-                Spacer()
-                HStack(alignment: .firstTextBaseline) {
-                    // Instead of Text, insert a button with action of
-                    //  shouldBolusEntryBecomeFirstResponder = true
-                    Text("Edit Bolus")
-                }
-            } else {
-                Text("Bolus", comment: "Label for bolus entry row on bolus screen")
-                Spacer()
-                HStack(alignment: .firstTextBaseline) {
-                    DismissibleKeyboardTextField(
-                        text: enteredBolusStringBinding,
-                        placeholder: Self.doseAmountFormatter.string(from: 0.0)!,
-                        font: .preferredFont(forTextStyle: .title1),
-                        textColor: .loopAccent,
-                        textAlignment: .right,
-                        keyboardType: .decimalPad,
-                        shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
-                        maxLength: 5,
-                        doneButtonColor: .loopAccent,
-                        textFieldDidBeginEditing: didBeginEditing
-                    )
-                    bolusUnitsLabel
-                }
+            Text("Bolus", comment: "Label for bolus entry row on bolus screen")
+            Spacer()
+            HStack(alignment: .firstTextBaseline) {
+                DismissibleKeyboardTextField(
+                    text: enteredBolusStringBinding,
+                    placeholder: Self.doseAmountFormatter.string(from: 0.0)!,
+                    font: .preferredFont(forTextStyle: .title1),
+                    textColor: .loopAccent,
+                    textAlignment: .right,
+                    keyboardType: .decimalPad,
+                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
+                    maxLength: 5,
+                    doneButtonColor: .loopAccent,
+                    textFieldDidBeginEditing: didBeginEditing
+                )
+                bolusUnitsLabel
             }
         }
         .accessibilityElement(children: .combine)
@@ -392,6 +386,17 @@ struct BolusEntryView: View {
         )
         .buttonStyle(ActionButtonStyle(viewModel.primaryButton == .manualGlucoseEntry ? .primary : .secondary))
         .padding([.top, .horizontal])
+    }
+
+    private var saveCarbsWithoutBolusButton: some View {
+        Button(
+            action: {
+                enteredBolusStringBinding.wrappedValue = String("0.0")
+                self.viewModel.saveAndDeliver(onSuccess: self.dismiss)
+            },
+            label: { Text("Save Carbs without Bolusing", comment: "Button text to save carbs without bolusing") }
+        )
+        .buttonStyle(ActionButtonStyle(.primary))
     }
 
     private var actionButton: some View {

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -396,7 +396,7 @@ struct BolusEntryView: View {
             },
             label: { Text("Save Carbs without Bolusing", comment: "Button text to save carbs without bolusing") }
         )
-        .buttonStyle(ActionButtonStyle(.primary))
+        .buttonStyle(ActionButtonStyle(.secondary))
     }
 
     private var actionButton: some View {

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -289,22 +289,32 @@ struct BolusEntryView: View {
 
     private var bolusEntryRow: some View {
         HStack {
-            Text("Bolus", comment: "Label for bolus entry row on bolus screen")
-            Spacer()
-            HStack(alignment: .firstTextBaseline) {
-                DismissibleKeyboardTextField(
-                    text: enteredBolusStringBinding,
-                    placeholder: Self.doseAmountFormatter.string(from: 0.0)!,
-                    font: .preferredFont(forTextStyle: .title1),
-                    textColor: .loopAccent,
-                    textAlignment: .right,
-                    keyboardType: .decimalPad,
-                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
-                    maxLength: 5,
-                    doneButtonColor: .loopAccent,
-                    textFieldDidBeginEditing: didBeginEditing
-                )
-                bolusUnitsLabel
+            if !shouldBolusEntryBecomeFirstResponder {
+                Text("Accept with Save", comment: "Label for bolus entry row on bolus screen when shouldBolusEntryBecomeFirstResponder is false")
+                Spacer()
+                HStack(alignment: .firstTextBaseline) {
+                    // Instead of Text, insert a button with action of
+                    //  shouldBolusEntryBecomeFirstResponder = true
+                    Text("Edit Bolus")
+                }
+            } else {
+                Text("Bolus", comment: "Label for bolus entry row on bolus screen")
+                Spacer()
+                HStack(alignment: .firstTextBaseline) {
+                    DismissibleKeyboardTextField(
+                        text: enteredBolusStringBinding,
+                        placeholder: Self.doseAmountFormatter.string(from: 0.0)!,
+                        font: .preferredFont(forTextStyle: .title1),
+                        textColor: .loopAccent,
+                        textAlignment: .right,
+                        keyboardType: .decimalPad,
+                        shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
+                        maxLength: 5,
+                        doneButtonColor: .loopAccent,
+                        textFieldDidBeginEditing: didBeginEditing
+                    )
+                    bolusUnitsLabel
+                }
             }
         }
         .accessibilityElement(children: .combine)

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -182,12 +182,12 @@ struct BolusEntryView: View {
             if viewModel.isManualGlucoseEntryEnabled || viewModel.potentialCarbEntry != nil {
                 recommendedBolusRow
             }
-            
+
+            bolusEntryRow
+
             if viewModel.hasBolusEntryReadyToDeliver && viewModel.potentialCarbEntry != nil {
                 saveCarbsWithoutBolusButton
             }
-
-            bolusEntryRow
         }
     }
     


### PR DESCRIPTION
Revise this idea - removing graphic.  Update at end of conversation.

~~I'm not sure if this idea is acceptable, so I have not taken the time to add an actual button with the correct color coding and action. (The placeholder code is just a text box that doesn't respond, i.e., it is a dummy display for illustration purposes. I added the blue box around it with an image editer.)~~

~~The modification is applied to the bolusEntryRow~~
~~* if shouldBolusEntryBecomeFirstResponder is false (as when first displayed), do not show the DismissibleKeyboardTextField, instead display a button at that location similar to what is shown in the graphic below.~~
~~* once the button is tapped, then the display reverts to the current behavior with DismissibleKeyboardTextField showing with a default entry of 0 U.~~

~~Graphic with example text (would need formatting and be updated to be a button with appropriate action).~~


