### PR TITLE
Make Pre-Meal icon inactive if nil

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -783,7 +783,9 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func updatePreMealModeAvailability(isClosedLoop: Bool) {
-        let allowed = onboardingManager.isComplete && (isClosedLoop || !FeatureFlags.simpleBolusCalculatorEnabled)
+        let allowed = onboardingManager.isComplete &&
+                (isClosedLoop || !FeatureFlags.simpleBolusCalculatorEnabled)
+                && deviceManager.loopManager.settings.preMealTargetRange != nil
         toolbarItems![2] = createPreMealButtonItem(selected: preMealMode ?? false && allowed, isEnabled: allowed)
     }
 


### PR DESCRIPTION
This modification disables the Pre-Meal icon on the app home screen for the case where the Pre-Meal ranges are not set, i.e., equal to [:].

This change, in conjunction with [LoopKit PR #400: add a reset button to Pre-Meal screen](https://github.com/LoopKit/LoopKit/pull/400) should complete the required changes needed to close Issue #1654 