### PR TITLE
Split FeatureFlags.observeHealthKitSamplesFromOtherApps into three flags

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -22,7 +22,9 @@ struct FeatureFlagConfiguration: Decodable {
     let insulinDeliveryReservoirViewEnabled: Bool
     let mockTherapySettingsEnabled: Bool
     let nonlinearCarbModelEnabled: Bool
-    let observeHealthKitSamplesFromOtherApps: Bool
+    let observeHealthKitCarbSamplesFromOtherApps: Bool
+    let observeHealthKitDoseSamplesFromOtherApps: Bool
+    let observeHealthKitGlucoseSamplesFromOtherApps: Bool
     let remoteOverridesEnabled: Bool
     let predictedGlucoseChartClampEnabled: Bool
     let scenariosEnabled: Bool
@@ -101,7 +103,6 @@ struct FeatureFlagConfiguration: Decodable {
         self.insulinDeliveryReservoirViewEnabled = true
         #endif
 
-        // Swift compiler config is inverse, since the default state is enabled.
         #if MOCK_THERAPY_SETTINGS_ENABLED
         self.mockTherapySettingsEnabled = true
         #else
@@ -115,13 +116,32 @@ struct FeatureFlagConfiguration: Decodable {
         self.nonlinearCarbModelEnabled = true
         #endif
         
+        #if OBSERVE_HEALTH_KIT_CARB_SAMPLES_FROM_OTHER_APPS_ENABLED
+        self.observeHealthKitCarbSamplesFromOtherApps = true
+        #else
+        self.observeHealthKitCarbSamplesFromOtherApps = false
+        #endif
+        
         // Swift compiler config is inverse, since the default state is enabled.
         #if OBSERVE_HEALTH_KIT_SAMPLES_FROM_OTHER_APPS_DISABLED
-        self.observeHealthKitSamplesFromOtherApps = false
+        self.observeHealthKitCarbSamplesFromOtherApps = false
+        self.observeHealthKitDoseSamplesFromOtherApps = false
+        self.observeHealthKitGlucoseSamplesFromOtherApps = false
         #else
-        self.observeHealthKitSamplesFromOtherApps = true
+        self.observeHealthKitDoseSamplesFromOtherApps = true
+        self.observeHealthKitGlucoseSamplesFromOtherApps = true
         #endif
 
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if OBSERVE_HEALTH_KIT_DOSE_SAMPLES_FROM_OTHER_APPS_DISABLED
+        self.observeHealthKitDoseSamplesFromOtherApps = false
+        #endif
+
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if OBSERVE_HEALTH_KIT_GLUCOSE_SAMPLES_FROM_OTHER_APPS_DISABLED
+        self.observeHealthKitGlucoseSamplesFromOtherApps = false
+        #endif
+        
         #if PREDICTED_GLUCOSE_CHART_CLAMP_ENABLED
         self.predictedGlucoseChartClampEnabled = true
         #else
@@ -181,7 +201,9 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* includeServicesInSettingsEnabled: \(includeServicesInSettingsEnabled)",
             "* mockTherapySettingsEnabled: \(mockTherapySettingsEnabled)",
             "* nonlinearCarbModelEnabled: \(nonlinearCarbModelEnabled)",
-            "* observeHealthKitSamplesFromOtherApps: \(observeHealthKitSamplesFromOtherApps)",
+            "* observeHealthKitCarbSamplesFromOtherApps: \(observeHealthKitCarbSamplesFromOtherApps)",
+            "* observeHealthKitDoseSamplesFromOtherApps: \(observeHealthKitDoseSamplesFromOtherApps)",
+            "* observeHealthKitGlucoseSamplesFromOtherApps: \(observeHealthKitGlucoseSamplesFromOtherApps)",
             "* predictedGlucoseChartClampEnabled: \(predictedGlucoseChartClampEnabled)",
             "* remoteOverridesEnabled: \(remoteOverridesEnabled)",
             "* scenariosEnabled: \(scenariosEnabled)",

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -79,7 +79,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
 
     lazy var glucoseStore = GlucoseStore(
         healthStore: healthStore,
-        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
+        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitGlucoseSamplesFromOtherApps,
         storeSamplesToHealthKit: false,
         cacheStore: cacheStore,
         observationEnabled: false,
@@ -88,7 +88,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
 
     lazy var doseStore = DoseStore(
         healthStore: healthStore,
-        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
+        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitDoseSamplesFromOtherApps,
         storeSamplesToHealthKit: false,
         cacheStore: cacheStore,
         observationEnabled: false,

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -116,10 +116,16 @@ final class DeviceDataManager {
     private var readTypes: Set<HKSampleType> {
         var readTypes: Set<HKSampleType> = []
 
-        if FeatureFlags.observeHealthKitSamplesFromOtherApps {
-            readTypes.insert(glucoseStore.sampleType)
+        if FeatureFlags.observeHealthKitCarbSamplesFromOtherApps {
+            readTypes.insert(carbStore.sampleType)
+        }
+        if FeatureFlags.observeHealthKitDoseSamplesFromOtherApps {
             readTypes.insert(doseStore.sampleType)
         }
+        if FeatureFlags.observeHealthKitGlucoseSamplesFromOtherApps {
+            readTypes.insert(glucoseStore.sampleType)
+        }
+
         readTypes.insert(HKObjectType.categoryType(forIdentifier: HKCategoryTypeIdentifier.sleepAnalysis)!)
 
         return readTypes
@@ -226,7 +232,7 @@ final class DeviceDataManager {
         
         self.carbStore = CarbStore(
             healthStore: healthStore,
-            observeHealthKitSamplesFromOtherApps: false, // At some point we should let the user decide which apps they would like to import from.
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitCarbSamplesFromOtherApps, // At some point we should let the user decide which apps they would like to import from.
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             defaultAbsorptionTimes: absorptionTimes,
@@ -240,7 +246,7 @@ final class DeviceDataManager {
         
         self.doseStore = DoseStore(
             healthStore: healthStore,
-            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitDoseSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             insulinModelProvider: PresetInsulinModelProvider(defaultRapidActingModel: UserDefaults.appGroup?.defaultRapidActingModel),
@@ -254,7 +260,7 @@ final class DeviceDataManager {
         
         self.glucoseStore = GlucoseStore(
             healthStore: healthStore,
-            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitGlucoseSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             observationInterval: .hours(24),
@@ -569,9 +575,9 @@ final class DeviceDataManager {
         healthStore.requestAuthorization(toShare: shareTypes, read: readTypes) { (success, error) in
             if success {
                 // Call the individual authorization methods to trigger query creation
-                self.carbStore.authorize(toShare: true, read: false, { _ in })
-                self.doseStore.insulinDeliveryStore.authorize(toShare: true, read: FeatureFlags.observeHealthKitSamplesFromOtherApps, { _ in })
-                self.glucoseStore.authorize(toShare: true, read: FeatureFlags.observeHealthKitSamplesFromOtherApps, { _ in })
+                self.carbStore.authorize(toShare: true, read: FeatureFlags.observeHealthKitCarbSamplesFromOtherApps, { _ in })
+                self.doseStore.insulinDeliveryStore.authorize(toShare: true, read: FeatureFlags.observeHealthKitDoseSamplesFromOtherApps, { _ in })
+                self.glucoseStore.authorize(toShare: true, read: FeatureFlags.observeHealthKitGlucoseSamplesFromOtherApps, { _ in })
             }
 
             self.getHealthStoreAuthorization(completion)


### PR DESCRIPTION
Per the discussion on [Zulip](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Reading.20from.20Apple.20Health/near/273676678) and further discussion in an unrelated [issue](https://github.com/LoopKit/LoopKit/issues/407#issuecomment-1120449748), this PR splits `FeatureFlags.observeHealthKitSamplesFromOtherApps` into three flags:
* `observeHealthKitCarbSamplesFromOtherApps`
* `observeHealthKitDoseSamplesFromOtherApps`
* `observeHealthKitGlucoseSamplesFromOtherApps`

Reading carb samples is "opt-in" via `OBSERVE_HEALTH_KIT_CARB_SAMPLES_FROM_OTHER_APPS_ENABLED`, and reading dose and glucose samples are "opt-out" to maintain backward-compatibility with `OBSERVE_HEALTH_KIT_SAMPLES_FROM_OTHER_APPS_DISABLED`. I don't love the intersection of 4 swift compiler directives, but it seems like the only way to maintain backward-compatibility and allow observation of each sample type to be managed independently.