### PR TITLE
shorten loop icon messages

### DIFF
--- a/LoopUI/Views/LoopCompletionHUDView.swift
+++ b/LoopUI/Views/LoopCompletionHUDView.swift
@@ -130,10 +130,17 @@ public final class LoopCompletionHUDView: BaseHUDView {
     }()
 
     private lazy var timeFormatter: DateFormatter = {
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateStyle = .short
-        timeFormatter.timeStyle = .short
-        return timeFormatter
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private lazy var timeDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
     }()
 
     @objc private func updateDisplay(_: Timer?) {
@@ -157,8 +164,14 @@ public final class LoopCompletionHUDView: BaseHUDView {
 
                 accessibilityLabel = String(format: LocalizedString("%1$@ ran %2$@ ago", comment: "Accessbility format label describing the time interval since the last completion date. (1: app name) (2: The localized date components)"), Bundle.main.bundleDisplayName, timeString)
 
+                var timeDateString = ""
+                if ago < .hours(4) {
+                    timeDateString = timeFormatter.string(from: date)
+                } else {
+                    timeDateString = timeDateFormatter.string(from: date)
+                }
                 if let fullTimeStr = formatterFull.string(from: ago) {
-                    lastLoopMessage = String(format: LocalizedString("Communication completed\n%2$@ ago,\n%3$@.", comment: "Last loop time completed message (1: last loop ago string) (1: last loop date string)"), fullTimeStr, timeFormatter.string(from: date))
+                    lastLoopMessage = String(format: LocalizedString("Communication completed\n%2$@ ago at\n%3$@.", comment: "Last loop time completed message (1: last loop ago string) (1: last loop date string)"), fullTimeStr, timeDateString)
                 }
             } else {
                 caption?.text = "–"


### PR DESCRIPTION
* Shorten the Loop Icon messages and add date-time of last communications. 
* Remove instances of app name in some cases.
* Modify the title to always say Open or Closed loop, therefore do not need to repeat that in the message.

This builds off PR #1682 (already accepted) and the comments of Issue #1683.

Notes: 
1. I kept the Warning and Failure strings to go with the Yellow and Red loop colors.
2. Once the information about last pump message and last CGM messages is accessible, it will be an easy addition to add that to the code.
3. I was not sure whether to add the time-stamp to the large font version or the accessible version.

Next few comments are graphics created with this PR.
