### PR TITLE
Fix DiagnosticLog missing logs in Console

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -392,6 +392,9 @@
 		A966152A23EA5A37005D8B29 /* DefaultAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */; };
 		A966152B23EA5A37005D8B29 /* DerivedAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152923EA5A37005D8B29 /* DerivedAssets.xcassets */; };
 		A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = A967D94B24F99B9300CDDF8A /* OutputStream.swift */; };
+		A96DAC242838325900D94E38 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96DAC232838325900D94E38 /* DiagnosticLog.swift */; };
+		A96DAC2A2838EF8A00D94E38 /* DiagnosticLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96DAC292838EF8A00D94E38 /* DiagnosticLogTests.swift */; };
+		A96DAC2C2838F31200D94E38 /* SharedLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96DAC2B2838F31200D94E38 /* SharedLogging.swift */; };
 		A977A2F424ACFECF0059C207 /* CriticalEventLogExportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A977A2F324ACFECF0059C207 /* CriticalEventLogExportManager.swift */; };
 		A97F250825E056D500F0EE19 /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97F250725E056D500F0EE19 /* OnboardingManager.swift */; };
 		A98556852493F901000FD662 /* AlertStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98556842493F901000FD662 /* AlertStore+SimulatedCoreData.swift */; };
@@ -1305,6 +1308,9 @@
 		A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DefaultAssets.xcassets; sourceTree = "<group>"; };
 		A966152923EA5A37005D8B29 /* DerivedAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DerivedAssets.xcassets; sourceTree = "<group>"; };
 		A967D94B24F99B9300CDDF8A /* OutputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStream.swift; sourceTree = "<group>"; };
+		A96DAC232838325900D94E38 /* DiagnosticLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
+		A96DAC292838EF8A00D94E38 /* DiagnosticLogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiagnosticLogTests.swift; sourceTree = "<group>"; };
+		A96DAC2B2838F31200D94E38 /* SharedLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedLogging.swift; sourceTree = "<group>"; };
 		A977A2F324ACFECF0059C207 /* CriticalEventLogExportManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLogExportManager.swift; sourceTree = "<group>"; };
 		A97F250725E056D500F0EE19 /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
 		A98556842493F901000FD662 /* AlertStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
@@ -2027,6 +2033,7 @@
 				892A5D58222F0A27008961AB /* Debug.swift */,
 				1D9650C72523FBA100A1370B /* DeviceDataManager+BolusEntryViewModelDelegate.swift */,
 				B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */,
+				A96DAC232838325900D94E38 /* DiagnosticLog.swift */,
 				A9C62D832331700D00535612 /* DiagnosticLog+Subsystem.swift */,
 				89D1503D24B506EB00EDE253 /* Dictionary.swift */,
 				89CA2B2F226C0161004D9350 /* DirectoryObserver.swift */,
@@ -2139,6 +2146,7 @@
 				1DA6499D2441266400F61E75 /* Alerts */,
 				E95D37FF24EADE68005E2F50 /* Store Protocols */,
 				C1F2075B26D6F9B0007AB7EB /* ProfileExpirationAlerter.swift */,
+				A96DAC2B2838F31200D94E38 /* SharedLogging.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -2155,6 +2163,7 @@
 				B4BC56362518DE8800373647 /* ViewModels */,
 				43E2D90F1D20C581004DA55F /* Info.plist */,
 				A9DF02CA24F72B9E00B7C988 /* CriticalEventLogTests.swift */,
+				A96DAC292838EF8A00D94E38 /* DiagnosticLogTests.swift */,
 				A9DAE7CF2332D77F006AE942 /* LoopTests.swift */,
 				B4FACBB02541FAB700199981 /* LoopSettingsAlerterTests.swift */,
 				8968B113240C55F10074BB48 /* LoopSettingsTests.swift */,
@@ -3518,6 +3527,7 @@
 				43511CE321FD80E400566C63 /* StandardRetrospectiveCorrection.swift in Sources */,
 				E95D380524EADF78005E2F50 /* GlucoseStoreProtocol.swift in Sources */,
 				43E3449F1B9D68E900C85C07 /* StatusTableViewController.swift in Sources */,
+				A96DAC242838325900D94E38 /* DiagnosticLog.swift in Sources */,
 				A9CBE45A248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift in Sources */,
 				A9C62D8A2331703100535612 /* ServicesManager.swift in Sources */,
 				43DBF0531C93EC8200B3C386 /* DeviceDataManager.swift in Sources */,
@@ -3576,6 +3586,7 @@
 				A98556852493F901000FD662 /* AlertStore+SimulatedCoreData.swift in Sources */,
 				899433B823FE129800FA4BEA /* OverrideBadgeView.swift in Sources */,
 				89D1503E24B506EB00EDE253 /* Dictionary.swift in Sources */,
+				A96DAC2C2838F31200D94E38 /* SharedLogging.swift in Sources */,
 				4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */,
 				1D63DEA526E950D400F46FA5 /* SupportManager.swift in Sources */,
 				4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,
@@ -3853,6 +3864,7 @@
 				E9C58A7324DB4A2700487A17 /* LoopDataManagerTests.swift in Sources */,
 				E98A55F324EDD9530008715D /* MockSettingsStore.swift in Sources */,
 				C165756F2534C468004AE16E /* SimpleBolusViewModelTests.swift in Sources */,
+				A96DAC2A2838EF8A00D94E38 /* DiagnosticLogTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,
 				B4FACBB12541FAB700199981 /* LoopSettingsAlerterTests.swift in Sources */,
 				E93E86B024DDE1BD00FF40C8 /* MockGlucoseStore.swift in Sources */,

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -8,13 +8,12 @@
 
 import UIKit
 import LoopKit
-import os.log
 
 final class AppDelegate: UIResponder, UIApplicationDelegate, WindowProvider {
     var window: UIWindow?
 
     private let loopAppManager = LoopAppManager()
-    private let log = OSLog(category: "AppDelegate")
+    private let log = DiagnosticLog(category: "AppDelegate")
 
     // MARK: - UIApplicationDelegate - Initialization
 

--- a/Loop/Extensions/DiagnosticLog.swift
+++ b/Loop/Extensions/DiagnosticLog.swift
@@ -1,0 +1,65 @@
+//
+//  DiagnosticLog.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 6/12/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import os.log
+
+public class DiagnosticLog {
+
+    private let subsystem: String
+
+    private let category: String
+
+    private let log: OSLog
+
+    public init(subsystem: String, category: String) {
+        self.subsystem = subsystem
+        self.category = category
+        self.log = OSLog(subsystem: subsystem, category: category)
+    }
+
+    public func debug(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .debug, args)
+    }
+
+    public func info(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .info, args)
+    }
+
+    public func `default`(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .default, args)
+    }
+
+    public func error(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .error, args)
+    }
+
+    private func log(_ message: StaticString, type: OSLogType, _ args: [CVarArg]) {
+        switch args.count {
+        case 0:
+            os_log(message, log: log, type: type)
+        case 1:
+            os_log(message, log: log, type: type, args[0])
+        case 2:
+            os_log(message, log: log, type: type, args[0], args[1])
+        case 3:
+            os_log(message, log: log, type: type, args[0], args[1], args[2])
+        case 4:
+            os_log(message, log: log, type: type, args[0], args[1], args[2], args[3])
+        case 5:
+            os_log(message, log: log, type: type, args[0], args[1], args[2], args[3], args[4])
+        default:
+            os_log(message, log: log, type: type, args)
+        }
+
+        guard let sharedLogging = SharedLogging.instance else {
+            return
+        }
+        sharedLogging.log(message, subsystem: subsystem, category: category, type: type, args)
+    }
+
+}

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -8,7 +8,6 @@
 
 import LoopKit
 import UIKit
-import os.log
 
 protocol AlertManagerResponder: AnyObject {
     /// Method for our Handlers to call to kick off alert response.  Differs from AlertResponder because here we need the whole `Identifier`.
@@ -36,7 +35,7 @@ public enum AlertUserNotificationUserInfoKey: String {
 public final class AlertManager {
     private static let soundsDirectoryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).last!.appendingPathComponent("Sounds")
 
-    private let log = OSLog(category: "AlertManager")
+    private let log = DiagnosticLog(category: "AlertManager")
 
     private var handlers: [AlertIssuer] = []
     private var responders: [String: Weak<AlertResponder>] = [:]

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -8,7 +8,6 @@
 
 import CoreData
 import LoopKit
-import os.log
 
 public protocol AlertStoreDelegate: AnyObject {
     /**
@@ -40,7 +39,7 @@ public class AlertStore {
 
     private let expireAfter: TimeInterval
 
-    private let log = OSLog(category: "AlertStore")
+    private let log = DiagnosticLog(category: "AlertStore")
 
     // This is terribly inconvenient, but it turns out that executing the following expression in CoreData _differs_
     // depending on whether it is in-memory or SQLite

--- a/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
@@ -8,12 +8,11 @@
 
 import LoopKit
 import UIKit
-import os.log
 
 class UserNotificationAlertIssuer: AlertIssuer {
     
     let userNotificationCenter: UserNotificationCenter
-    let log = OSLog(category: "UserNotificationAlertIssuer")
+    let log = DiagnosticLog(category: "UserNotificationAlertIssuer")
     
     init(userNotificationCenter: UserNotificationCenter) {
         self.userNotificationCenter = userNotificationCenter

--- a/Loop/Managers/AnalyticsServicesManager.swift
+++ b/Loop/Managers/AnalyticsServicesManager.swift
@@ -9,11 +9,10 @@
 import Foundation
 import LoopKit
 import LoopCore
-import os.log
 
 final class AnalyticsServicesManager {
 
-    private lazy var log = OSLog(category: "AnalyticsServicesManager")
+    private lazy var log = DiagnosticLog(category: "AnalyticsServicesManager")
 
     private var analyticsServices = [AnalyticsService]()
 

--- a/Loop/Managers/CGMStalenessMonitor.swift
+++ b/Loop/Managers/CGMStalenessMonitor.swift
@@ -9,7 +9,6 @@
 import Foundation
 import LoopKit
 import LoopCore
-import os.log
 
 protocol CGMStalenessMonitorDelegate: AnyObject {
     func getLatestCGMGlucose(since: Date, completion: @escaping (_ result: Swift.Result<StoredGlucoseSample?, Error>) -> Void)
@@ -17,7 +16,7 @@ protocol CGMStalenessMonitorDelegate: AnyObject {
 
 class CGMStalenessMonitor {
     
-    private let log = OSLog(category: "CGMStalenessMonitor")
+    private let log = DiagnosticLog(category: "CGMStalenessMonitor")
     
     private var cgmStalenessTimer: Timer?
     

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -14,13 +14,12 @@ import LoopCore
 import LoopTestingKit
 import UserNotifications
 import Combine
-import os.log
 
 final class DeviceDataManager {
 
     private let queue = DispatchQueue(label: "com.loopkit.DeviceManagerQueue", qos: .utility)
     
-    private let log = OSLog(category: "DeviceDataManager")
+    private let log = DiagnosticLog(category: "DeviceDataManager")
 
     let pluginManager: PluginManager
     weak var alertManager: AlertManager!

--- a/Loop/Managers/DoseEnactor.swift
+++ b/Loop/Managers/DoseEnactor.swift
@@ -8,13 +8,12 @@
 
 import Foundation
 import LoopKit
-import os.log
 
 class DoseEnactor {
     
     fileprivate let dosingQueue: DispatchQueue = DispatchQueue(label: "com.loopkit.DeviceManagerDosingQueue", qos: .utility)
     
-    private let log = OSLog(category: "DoseEnactor")
+    private let log = DiagnosticLog(category: "DoseEnactor")
 
     func enact(recommendation: AutomaticDoseRecommendation, with pumpManager: PumpManager, completion: @escaping (PumpManagerError?) -> Void) {
         

--- a/Loop/Managers/LocalTestingScenariosManager.swift
+++ b/Loop/Managers/LocalTestingScenariosManager.swift
@@ -9,13 +9,13 @@
 import Foundation
 import LoopKit
 import LoopTestingKit
-import os.log
-
+import OSLog
 
 final class LocalTestingScenariosManager: TestingScenariosManagerRequirements, DirectoryObserver {
+    
     unowned let deviceManager: DeviceDataManager
 
-    let log = OSLog(category: "LocalTestingScenariosManager")
+    let log = DiagnosticLog(category: "LocalTestingScenariosManager")
 
     private let fileManager = FileManager.default
     private let scenariosSource: URL

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -7,14 +7,13 @@
 //
 
 import LoopKit
-import os.log
 
 /// Class responsible for monitoring "system level" operations and alerting the user to any anomalous situations (e.g. bluetooth off)
 public class LoopAlertsManager {
     
     static let managerIdentifier = "Loop"
     
-    private lazy var log = OSLog(category: String(describing: LoopAlertsManager.self))
+    private lazy var log = DiagnosticLog(category: String(describing: LoopAlertsManager.self))
     
     private weak var alertManager: AlertManager?
     

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -13,7 +13,6 @@ import LoopKit
 import LoopKitUI
 import MockKit
 import HealthKit
-import os.log
 
 public protocol AlertPresenter: AnyObject {
     /// Present the alert view controller, with or without animation.
@@ -78,7 +77,7 @@ class LoopAppManager: NSObject {
 
     private var state: State = .initialize
 
-    private let log = OSLog(category: "LoopAppManager")
+    private let log = DiagnosticLog(category: "LoopAppManager")
 
     private let closedLoopStatus = ClosedLoopStatus(isClosedLoop: false, isClosedLoopAllowed: false)
 

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -11,7 +11,6 @@ import Combine
 import HealthKit
 import LoopKit
 import LoopCore
-import os.log
 
 final class LoopDataManager: LoopSettingsAlerterDelegate {
     enum LoopUpdateContext: Int {
@@ -36,7 +35,7 @@ final class LoopDataManager: LoopSettingsAlerterDelegate {
 
     weak var delegate: LoopDataManagerDelegate?
 
-    private let logger = OSLog(category: "LoopDataManager")
+    private let logger = DiagnosticLog(category: "LoopDataManager")
 
     private let analyticsServicesManager: AnalyticsServicesManager
 

--- a/Loop/Managers/SharedLogging.swift
+++ b/Loop/Managers/SharedLogging.swift
@@ -1,0 +1,15 @@
+//
+//  SharedLogging.swift
+//  Loop
+//
+//  Created by Bill Gestrich on 5/21/22.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+import LoopKit
+
+public class SharedLogging {
+
+    /// A shared, global instance of Logging.
+    public static var instance: Logging?
+
+}

--- a/Loop/Managers/SupportManager.swift
+++ b/Loop/Managers/SupportManager.swift
@@ -12,11 +12,10 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 import MockKitUI
-import os.log
 
 public final class SupportManager {
     
-    private lazy var log = OSLog(category: "SupportManager")
+    private lazy var log = DiagnosticLog(category: "SupportManager")
 
     private var supports = Locked<[String: SupportUI]>([:])
     

--- a/Loop/Managers/TestingScenariosManager.swift
+++ b/Loop/Managers/TestingScenariosManager.swift
@@ -8,7 +8,6 @@
 
 import LoopKit
 import LoopTestingKit
-import os.log
 
 
 protocol TestingScenariosManagerDelegate: AnyObject {
@@ -31,7 +30,7 @@ protocol TestingScenariosManagerRequirements: TestingScenariosManager {
     var deviceManager: DeviceDataManager { get }
     var activeScenarioURL: URL? { get set }
     var activeScenario: TestingScenario? { get set }
-    var log: OSLog { get }
+    var log: DiagnosticLog { get }
     func fetchScenario(from url: URL, completion: @escaping (Result<TestingScenario, Error>) -> Void)
 }
 

--- a/Loop/Managers/TrustedTimeChecker.swift
+++ b/Loop/Managers/TrustedTimeChecker.swift
@@ -9,7 +9,6 @@
 import LoopKit
 import TrueTime
 import UIKit
-import os.log
 
 fileprivate extension UserDefaults {
     private enum Key: String {
@@ -33,7 +32,7 @@ class TrustedTimeChecker {
     // For NTP time checking
     private var ntpClient: TrueTimeClient
     private weak var alertManager: AlertManager?
-    private lazy var log = OSLog(category: "TrustedTimeChecker")
+    private lazy var log = DiagnosticLog(category: "TrustedTimeChecker")
 
     init(alertManager: AlertManager) {
         ntpClient = TrueTimeClient.sharedInstance

--- a/Loop/Managers/WatchDataManager.swift
+++ b/Loop/Managers/WatchDataManager.swift
@@ -11,7 +11,6 @@ import UIKit
 import WatchConnectivity
 import LoopKit
 import LoopCore
-import os.log
 
 final class WatchDataManager: NSObject {
 
@@ -32,7 +31,7 @@ final class WatchDataManager: NSObject {
         watchSession?.activate()
     }
 
-    private let log = OSLog(category: "WatchDataManager")
+    private let log = DiagnosticLog(category: "WatchDataManager")
 
     private var watchSession: WCSession? = {
         if WCSession.isSupported() {

--- a/LoopTests/DiagnosticLogTests.swift
+++ b/LoopTests/DiagnosticLogTests.swift
@@ -1,0 +1,151 @@
+//
+//  DiagnosticLogTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/23/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import os.log
+import LoopKit
+@testable import Loop
+
+class DiagnosticLogTests: XCTestCase {
+    
+    fileprivate var testLogging: TestLogging!
+    
+    override func setUp() {
+        testLogging = TestLogging()
+        SharedLogging.instance = testLogging
+    }
+    
+    override func tearDown() {
+        SharedLogging.instance = nil
+        testLogging = nil
+    }
+    
+    func testInitializer() {
+        XCTAssertNotNil(DiagnosticLog(subsystem: "subsystem", category: "category"))
+    }
+    
+    func testDebugWithoutArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "debug subsystem", category: "debug category")
+        
+        diagnosticLog.debug("debug message without arguments")
+        
+        XCTAssertEqual(testLogging.message.description, "debug message without arguments")
+        XCTAssertEqual(testLogging.subsystem, "debug subsystem")
+        XCTAssertEqual(testLogging.category, "debug category")
+        XCTAssertEqual(testLogging.type, .debug)
+        XCTAssertEqual(testLogging.args.count, 0)
+    }
+    
+    func testDebugWithArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "debug subsystem", category: "debug category")
+        
+        diagnosticLog.debug("debug message with arguments", "a")
+        
+        XCTAssertEqual(testLogging.message.description, "debug message with arguments")
+        XCTAssertEqual(testLogging.subsystem, "debug subsystem")
+        XCTAssertEqual(testLogging.category, "debug category")
+        XCTAssertEqual(testLogging.type, .debug)
+        XCTAssertEqual(testLogging.args.count, 1)
+    }
+    
+    func testInfoWithoutArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "info subsystem", category: "info category")
+        
+        diagnosticLog.info("info message without arguments")
+        
+        XCTAssertEqual(testLogging.message.description, "info message without arguments")
+        XCTAssertEqual(testLogging.subsystem, "info subsystem")
+        XCTAssertEqual(testLogging.category, "info category")
+        XCTAssertEqual(testLogging.type, .info)
+        XCTAssertEqual(testLogging.args.count, 0)
+    }
+    
+    func testInfoWithArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "info subsystem", category: "info category")
+        
+        diagnosticLog.info("info message with arguments", "a", "b")
+        
+        XCTAssertEqual(testLogging.message.description, "info message with arguments")
+        XCTAssertEqual(testLogging.subsystem, "info subsystem")
+        XCTAssertEqual(testLogging.category, "info category")
+        XCTAssertEqual(testLogging.type, .info)
+        XCTAssertEqual(testLogging.args.count, 2)
+    }
+    
+    func testDefaultWithoutArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "default subsystem", category: "default category")
+        
+        diagnosticLog.default("default message without arguments")
+        
+        XCTAssertEqual(testLogging.message.description, "default message without arguments")
+        XCTAssertEqual(testLogging.subsystem, "default subsystem")
+        XCTAssertEqual(testLogging.category, "default category")
+        XCTAssertEqual(testLogging.type, .default)
+        XCTAssertEqual(testLogging.args.count, 0)
+    }
+    
+    func testDefaultWithArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "default subsystem", category: "default category")
+        
+        diagnosticLog.default("default message with arguments", "a", "b", "c")
+        
+        XCTAssertEqual(testLogging.message.description, "default message with arguments")
+        XCTAssertEqual(testLogging.subsystem, "default subsystem")
+        XCTAssertEqual(testLogging.category, "default category")
+        XCTAssertEqual(testLogging.type, .default)
+        XCTAssertEqual(testLogging.args.count, 3)
+    }
+    
+    func testErrorWithoutArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "error subsystem", category: "error category")
+        
+        diagnosticLog.error("error message without arguments")
+        
+        XCTAssertEqual(testLogging.message.description, "error message without arguments")
+        XCTAssertEqual(testLogging.subsystem, "error subsystem")
+        XCTAssertEqual(testLogging.category, "error category")
+        XCTAssertEqual(testLogging.type, .error)
+        XCTAssertEqual(testLogging.args.count, 0)
+    }
+    
+    func testErrorWithArguments() {
+        let diagnosticLog = DiagnosticLog(subsystem: "error subsystem", category: "error category")
+        
+        diagnosticLog.error("error message with arguments", "a", "b", "c", "d")
+        
+        XCTAssertEqual(testLogging.message.description, "error message with arguments")
+        XCTAssertEqual(testLogging.subsystem, "error subsystem")
+        XCTAssertEqual(testLogging.category, "error category")
+        XCTAssertEqual(testLogging.type, .error)
+        XCTAssertEqual(testLogging.args.count, 4)
+    }
+    
+}
+
+fileprivate class TestLogging: Logging {
+
+    var message: StaticString!
+    
+    var subsystem: String!
+    
+    var category: String!
+    
+    var type: OSLogType!
+    
+    var args: [CVarArg]!
+    
+    init() {}
+    
+    func log (_ message: StaticString, subsystem: String, category: String, type: OSLogType, _ args: [CVarArg]) {
+        self.message = message
+        self.subsystem = subsystem
+        self.category = category
+        self.type = type
+        self.args = args
+    }
+}


### PR DESCRIPTION
### Background

DiagnosticLog is our custom logger that logs messages to both OSLog and forwards logs to any Services that support Logging, like the Loggly service. 

There is an issue defining methods with the StaticString type, that receive strings from other libraries (at least wrt to strings in Console logs). The DiagnosticLog API is located in LoopKit and receives calls from other libraries, like Loop. That sysdiagnose Logs in console will show "<compose failure [UUID]>". DiagnosticLog was disabled several weeks ago in favor of using OSLog directly to fix this; however, that removed our logging to Services, like Loggly.

![Screen-Shot-2022-05-19-at-8 10 38-PM](https://user-images.githubusercontent.com/79173438/169647394-33b138c0-abd0-4ffc-952a-2f9b1bb5effc.jpg)

### Fix

The fix in this PR is to move the DiagnosticLog from LoopKit to Loop to keep the StaticStrings in the same module. This limits DiagnosticLog to only supporting logs in the Loop module but that is the only place we've been using it. There are some other options discussed in [Zulip](https://loop.zulipchat.com/#narrow/stream/209438-Build-Issues/topic/Loop-dev/near/283137679) we can explore in the future but they would require more effort. 