### PR TITLE
Avoid uploading glucose data to Remote Services when disabled

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -353,7 +353,8 @@ final class DeviceDataManager {
         dosingDecisionStore.delegate = self
         glucoseStore.delegate = self
         doseStore.insulinDeliveryStore.delegate = self
-
+        remoteDataServicesManager.delegate = self
+        
         setupPump()
         setupCGM()
                 
@@ -1527,6 +1528,14 @@ struct CancelTempBasalFailedError: LocalizedError {
             }
         }
         return reason.map { $0.localizedDescription + paragraphEnd } ?? ""
+    }
+}
+
+//MARK: - RemoteDataServicesManagerDelegate protocol conformance
+
+extension DeviceDataManager : RemoteDataServicesManagerDelegate {
+    var shouldSyncToRemoteService: Bool {
+        return cgmManager?.shouldSyncToRemoteService ?? false
     }
 }
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1535,7 +1535,10 @@ struct CancelTempBasalFailedError: LocalizedError {
 
 extension DeviceDataManager : RemoteDataServicesManagerDelegate {
     var shouldSyncToRemoteService: Bool {
-        return cgmManager?.shouldSyncToRemoteService ?? false
+        guard let cgmManager = cgmManager else {
+            return true
+        }
+        return cgmManager.shouldSyncToRemoteService
     }
 }
 

--- a/Loop/Managers/RemoteDataServicesManager.swift
+++ b/Loop/Managers/RemoteDataServicesManager.swift
@@ -24,6 +24,8 @@ enum RemoteDataType: String {
 final class RemoteDataServicesManager {
 
     public typealias RawState = [String: Any]
+    
+    public weak var delegate: RemoteDataServicesManagerDelegate?
 
     private var lock = UnfairLock()
 
@@ -333,6 +335,11 @@ extension RemoteDataServicesManager {
     }
 
     private func uploadGlucoseData(to remoteDataService: RemoteDataService) {
+        
+        if delegate?.shouldSyncToRemoteService == false {
+            return
+        }
+        
         uploadGroup.enter()
         dispatchQueue(for: remoteDataService, withRemoteDataType: .glucose).async {
             let semaphore = DispatchSemaphore(value: 0)
@@ -520,6 +527,11 @@ extension RemoteDataServicesManager {
         }
     }
 
+}
+
+
+protocol RemoteDataServicesManagerDelegate: AnyObject {
+    var shouldSyncToRemoteService: Bool {get}
 }
 
 


### PR DESCRIPTION
This is a potential fix for https://github.com/LoopKit/Loop/issues/1642. In the master branch we were only uploading Glucose data when `CGMManager.shouldSyncToRemoteService` returned true. That feature was lost in dev with subsequent refactors.

This change will respect that value but checking just before a glucose upload is performed. I'm not that familiar with the history of this setting so I may be missing the bigger picture to how this is intended to work.