### PR TITLE
Handle settings migration with delayed device token fetch

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -259,7 +259,7 @@ final class DeviceDataManager {
         self.settingsManager = settingsManager
 
         let absorptionTimes = LoopCoreConstants.defaultCarbAbsorptionTimes
-        let sensitivitySchedule = settingsManager.latestSettings?.insulinSensitivitySchedule
+        let sensitivitySchedule = settingsManager.latestSettings.insulinSensitivitySchedule
         
         self.carbStore = CarbStore(
             healthStore: healthStore,
@@ -268,7 +268,7 @@ final class DeviceDataManager {
             cacheLength: localCacheDuration,
             defaultAbsorptionTimes: absorptionTimes,
             observationInterval: absorptionTimes.slow * 2,
-            carbRatioSchedule: settingsManager.latestSettings?.carbRatioSchedule,
+            carbRatioSchedule: settingsManager.latestSettings.carbRatioSchedule,
             insulinSensitivitySchedule: sensitivitySchedule,
             overrideHistory: overrideHistory,
             carbAbsorptionModel: FeatureFlags.nonlinearCarbModelEnabled ? .nonlinear : .linear,
@@ -280,9 +280,9 @@ final class DeviceDataManager {
             observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitDoseSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
-            insulinModelProvider: PresetInsulinModelProvider(defaultRapidActingModel: settingsManager.latestSettings?.defaultRapidActingModel?.presetForRapidActingInsulin),
+            insulinModelProvider: PresetInsulinModelProvider(defaultRapidActingModel: settingsManager.latestSettings.defaultRapidActingModel?.presetForRapidActingInsulin),
             longestEffectDuration: ExponentialInsulinModelPreset.rapidActingAdult.effectDuration,
-            basalProfile: settingsManager.latestSettings?.basalRateSchedule,
+            basalProfile: settingsManager.latestSettings.basalRateSchedule,
             insulinSensitivitySchedule: sensitivitySchedule,
             overrideHistory: overrideHistory,
             lastPumpEventsReconciliation: nil, // PumpManager is nil at this point. Will update this via addPumpEvents below

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -817,7 +817,7 @@ extension LoopDataManager {
         var dosingDecision = StoredDosingDecision(reason: reason.rawValue)
         let latestSettings = latestStoredSettingsProvider.latestSettings
         dosingDecision.settings = StoredDosingDecision.Settings(latestSettings)
-        dosingDecision.scheduleOverride = latestSettings?.scheduleOverride
+        dosingDecision.scheduleOverride = latestSettings.scheduleOverride
         dosingDecision.controllerStatus = UIDevice.current.controllerStatus
         dosingDecision.pumpManagerStatus = delegate?.pumpManagerStatus
         if let pumpStatusHighlight = delegate?.pumpStatusHighlight {

--- a/Loop/Managers/Store Protocols/LatestStoredSettingsProvider.swift
+++ b/Loop/Managers/Store Protocols/LatestStoredSettingsProvider.swift
@@ -9,7 +9,7 @@
 import LoopKit
 
 protocol LatestStoredSettingsProvider: AnyObject {
-    var latestSettings: StoredSettings? { get }
+    var latestSettings: StoredSettings { get }
 }
 
 extension SettingsManager: LatestStoredSettingsProvider { }

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -78,16 +78,19 @@ class LoopDataManagerDosingTests: XCTestCase {
     var loopDataManager: LoopDataManager!
     
     func setUp(for test: DataManagerTestType, basalDeliveryState: PumpManagerStatus.BasalDeliveryState? = nil) {
+        let basalRateSchedule = loadBasalRateScheduleFixture("basal_profile")
+
         let settings = LoopSettings(
             dosingEnabled: false,
             glucoseTargetRangeSchedule: glucoseTargetRangeSchedule,
+            basalRateSchedule: basalRateSchedule,
             maximumBasalRatePerHour: maxBasalRate,
             maximumBolus: maxBolus,
             suspendThreshold: suspendThreshold
         )
         
         let doseStore = MockDoseStore(for: test)
-        doseStore.basalProfile = loadBasalRateScheduleFixture("basal_profile")
+        doseStore.basalProfile = basalRateSchedule
         doseStore.basalProfileApplyingOverrideHistory = doseStore.basalProfile
         let glucoseStore = MockGlucoseStore(for: test)
         let carbStore = MockCarbStore(for: test)

--- a/LoopTests/Mock Stores/MockSettingsStore.swift
+++ b/LoopTests/Mock Stores/MockSettingsStore.swift
@@ -10,7 +10,7 @@ import LoopKit
 @testable import Loop
 
 class MockLatestStoredSettingsProvider: LatestStoredSettingsProvider {
-    var latestSettings: StoredSettings? { nil }
+    var latestSettings: StoredSettings { StoredSettings() }
     func storeSettings(_ settings: StoredSettings, completion: @escaping () -> Void) {
         completion()
     }


### PR DESCRIPTION
Storing migrated settings was failing as the store call was happening before device token had been fetched, and we guard against that on real devices. This change allows SettingsManager to keep the main copy of settings, so the migration can happen, followed by device token fetch, followed by actual storage into SettingsStore