### PR TITLE
Fix missing range bar in glucose chart

### DIFF
--- a/LoopUI/Extensions/ChartPoint.swift
+++ b/LoopUI/Extensions/ChartPoint.swift
@@ -47,7 +47,7 @@ extension ChartPoint {
                     result += [maxPoints + minPoints.reversed()]
                     maxPoints = []
                     minPoints = []
-                    addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: potentialOverride.scheduledEndDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
+                    addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: potentialOverride.startDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
                 } else {
                     addBar(value: range.value, unit: unit, startDate: startDate, endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
                 }


### PR DESCRIPTION
Fixes missing range bar in the glucose chart when an override without a target range is active.

Reported in https://github.com/LoopKit/Loop/issues/1620, https://github.com/LoopKit/Loop/issues/1644
