### PR TITLE
Crash Recovery Manager

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		C1E3862628247C6100F561A4 /* StoredLoopNotRunningNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E3862428247B7100F561A4 /* StoredLoopNotRunningNotification.swift */; };
 		C1E3DC4728595FAA00CA19FF /* SwiftCharts in Frameworks */ = {isa = PBXBuildFile; productRef = C1E3DC4628595FAA00CA19FF /* SwiftCharts */; };
 		C1E3DC4928595FAA00CA19FF /* SwiftCharts in Embed Frameworks */ = {isa = PBXBuildFile; productRef = C1E3DC4628595FAA00CA19FF /* SwiftCharts */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		C1EF747228D6A44A00C8C083 /* CrashRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EF747128D6A44A00C8C083 /* CrashRecoveryManager.swift */; };
 		C1F00C60285A802A006302C5 /* SwiftCharts in Frameworks */ = {isa = PBXBuildFile; productRef = C1F00C5F285A802A006302C5 /* SwiftCharts */; };
 		C1F00C78285A8256006302C5 /* SwiftCharts in Embed Frameworks */ = {isa = PBXBuildFile; productRef = C1F00C5F285A802A006302C5 /* SwiftCharts */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C1F2075C26D6F9B0007AB7EB /* ProfileExpirationAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F2075B26D6F9B0007AB7EB /* ProfileExpirationAlerter.swift */; };
@@ -1439,6 +1440,7 @@
 		C1E2773D224177C000354103 /* ClockKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ClockKit.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/System/Library/Frameworks/ClockKit.framework; sourceTree = DEVELOPER_DIR; };
 		C1E2774722433D7A00354103 /* MKRingProgressView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MKRingProgressView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1E3862428247B7100F561A4 /* StoredLoopNotRunningNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredLoopNotRunningNotification.swift; sourceTree = "<group>"; };
+		C1EF747128D6A44A00C8C083 /* CrashRecoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashRecoveryManager.swift; sourceTree = "<group>"; };
 		C1F2075B26D6F9B0007AB7EB /* ProfileExpirationAlerter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileExpirationAlerter.swift; sourceTree = "<group>"; };
 		C1F7822527CC056900C0919A /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		C1F8B1D122375E4200DD66CF /* BolusProgressTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusProgressTableViewCell.swift; sourceTree = "<group>"; };
@@ -1782,6 +1784,7 @@
 				C19008FD25225D3900721625 /* SimpleBolusCalculator.swift */,
 				C1E3862428247B7100F561A4 /* StoredLoopNotRunningNotification.swift */,
 				C1C660D0252E4DD5009B5C32 /* LoopConstants.swift */,
+				C1EF747128D6A44A00C8C083 /* CrashRecoveryManager.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3565,6 +3568,7 @@
 				439897371CD2F80600223065 /* AnalyticsServicesManager.swift in Sources */,
 				A9C62D842331700E00535612 /* DiagnosticLog+Subsystem.swift in Sources */,
 				895FE0952201234000FCF18A /* OverrideSelectionViewController.swift in Sources */,
+				C1EF747228D6A44A00C8C083 /* CrashRecoveryManager.swift in Sources */,
 				A9F66FC3247F451500096EA7 /* UIDevice+Loop.swift in Sources */,
 				439706E622D2E84900C81566 /* PredictionSettingTableViewCell.swift in Sources */,
 				430D85891F44037000AF2D4F /* HUDViewTableViewCell.swift in Sources */,

--- a/Loop/Extensions/UserDefaults+Loop.swift
+++ b/Loop/Extensions/UserDefaults+Loop.swift
@@ -15,6 +15,7 @@ extension UserDefaults {
         case legacyCGMManagerState = "com.loopkit.Loop.CGMManagerState"
         case legacyServicesState = "com.loopkit.Loop.ServicesState"
         case loopNotRunningNotifications = "com.loopkit.Loop.loopNotRunningNotifications"
+        case inFlightAutomaticDose = "com.loopkit.Loop.inFlightAutomaticDose"
     }
 
     var legacyPumpManagerRawValue: PumpManager.RawValue? {
@@ -47,6 +48,28 @@ extension UserDefaults {
         set(nil, forKey: Key.legacyServicesState.rawValue)
     }
 
+    var inFlightAutomaticDose: AutomaticDoseRecommendation? {
+        get {
+            let decoder = JSONDecoder()
+            guard let data = object(forKey: Key.inFlightAutomaticDose.rawValue) as? Data else {
+                return nil
+            }
+            return try? decoder.decode(AutomaticDoseRecommendation.self, from: data)
+        }
+        set {
+            do {
+                if let newValue = newValue {
+                    let encoder = JSONEncoder()
+                    let data = try encoder.encode(newValue)
+                    set(data, forKey: Key.inFlightAutomaticDose.rawValue)
+                } else {
+                    set(nil, forKey: Key.inFlightAutomaticDose.rawValue)
+                }
+            } catch {
+                assertionFailure("Unable to encode AutomaticDoseRecommendation")
+            }
+        }
+    }
 
     var loopNotRunningNotifications: [StoredLoopNotRunningNotification] {
         get {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -182,17 +182,17 @@ final class DeviceDataManager {
     /// True if any stores require HealthKit authorization
     var authorizationRequired: Bool {
         return glucoseStore.authorizationRequired ||
-               carbStore.authorizationRequired ||
-               doseStore.authorizationRequired ||
-               sleepDataAuthorizationRequired
+        carbStore.authorizationRequired ||
+        doseStore.authorizationRequired ||
+        sleepDataAuthorizationRequired
     }
 
     /// True if the user has explicitly denied access to any stores' HealthKit types
     private var sharingDenied: Bool {
         return glucoseStore.sharingDenied ||
-               carbStore.sharingDenied ||
-               doseStore.sharingDenied ||
-               sleepDataSharingDenied
+        carbStore.sharingDenied ||
+        doseStore.sharingDenied ||
+        sleepDataSharingDenied
     }
 
     // MARK: Services
@@ -208,6 +208,8 @@ final class DeviceDataManager {
     var remoteDataServicesManager: RemoteDataServicesManager { return servicesManager.remoteDataServicesManager }
 
     var criticalEventLogExportManager: CriticalEventLogExportManager!
+
+    var crashRecoveryManager: CrashRecoveryManager
 
     private(set) var pumpManagerHUDProvider: HUDProvider?
 
@@ -322,6 +324,9 @@ final class DeviceDataManager {
 
         self.trustedTimeChecker = trustedTimeChecker
 
+        crashRecoveryManager = CrashRecoveryManager(alertIssuer: alertManager)
+        alertManager.addAlertResponder(managerIdentifier: crashRecoveryManager.managerIdentifier, alertResponder: crashRecoveryManager)
+
         if let pumpManagerRawValue = rawPumpManager ?? UserDefaults.appGroup?.legacyPumpManagerRawValue {
             pumpManager = pumpManagerFromRawValue(pumpManagerRawValue)
             // Update lastPumpEventsReconciliation on DoseStore
@@ -365,7 +370,7 @@ final class DeviceDataManager {
         )
         cacheStore.delegate = loopManager
         loopManager.presetActivationObserver = alertManager
-        
+
         watchManager = WatchDataManager(deviceManager: self, healthStore: healthStore)
 
         let remoteDataServicesManager = RemoteDataServicesManager(
@@ -491,8 +496,14 @@ final class DeviceDataManager {
     }
     
     private func checkPumpDataAndLoop() {
+        guard !crashRecoveryManager.pendingCrashRecovery else {
+            self.log.default("Loop paused pending crash recovery acknowledgement.")
+            return
+        }
+
         self.log.default("Asserting current pump data")
         guard let pumpManager = pumpManager else {
+            // Run loop, even if pump is missing, to ensure stored dosing decision
             self.loopManager.loop()
             return
         }
@@ -1282,9 +1293,11 @@ extension DeviceDataManager: LoopDataManagerDelegate {
         }
 
         log.default("LoopManager did recommend dose: %{public}@", String(describing: automaticDose.recommendation))
-        
+
+        crashRecoveryManager.dosingStarted(dose: automaticDose.recommendation)
         doseEnactor.enact(recommendation: automaticDose.recommendation, with: pumpManager) { pumpManagerError in
             completion(pumpManagerError.map { .pumpManagerError($0) })
+            self.crashRecoveryManager.dosingFinished()
         }
     }
 }

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -242,6 +242,7 @@ class LoopAppManager: NSObject {
             rootNavigationController = RootNavigationController()
             rootViewController = rootNavigationController
         }
+
         rootNavigationController?.setViewControllers([statusTableViewController], animated: true)
 
         deviceDataManager.refreshDeviceData()

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1673,8 +1673,8 @@ extension LoopDataManager {
             delegateError = error
             updateGroup.leave()
         }
-
         updateGroup.wait()
+
         if delegateError == nil {
             self.recommendedAutomaticDose = nil
         }

--- a/Loop/Models/CrashRecoveryManager.swift
+++ b/Loop/Models/CrashRecoveryManager.swift
@@ -29,7 +29,6 @@ class CrashRecoveryManager {
         self.alertIssuer = alertIssuer
 
         doseRecoveredFromCrash = UserDefaults.appGroup?.inFlightAutomaticDose
-        UserDefaults.appGroup?.inFlightAutomaticDose = nil
 
         if doseRecoveredFromCrash != nil {
             issueCrashAlert()
@@ -69,6 +68,7 @@ class CrashRecoveryManager {
 
 extension CrashRecoveryManager: AlertResponder {
     func acknowledgeAlert(alertIdentifier: LoopKit.Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
+        UserDefaults.appGroup?.inFlightAutomaticDose = nil
         doseRecoveredFromCrash = nil
     }
 }

--- a/Loop/Models/CrashRecoveryManager.swift
+++ b/Loop/Models/CrashRecoveryManager.swift
@@ -1,0 +1,75 @@
+//
+//  CrashRecoveryManager.swift
+//  Loop
+//
+//  Created by Pete Schwamb on 9/17/22.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+
+class CrashRecoveryManager {
+
+    private let log = DiagnosticLog(category: "CrashRecoveryManager")
+
+    let managerIdentifier = "CrashRecoveryManager"
+
+    private let crashAlertIdentifier = "CrashAlert"
+
+    var doseRecoveredFromCrash: AutomaticDoseRecommendation?
+
+    let alertIssuer: AlertIssuer
+
+    var pendingCrashRecovery: Bool {
+        return doseRecoveredFromCrash != nil
+    }
+
+    init(alertIssuer: AlertIssuer) {
+        self.alertIssuer = alertIssuer
+
+        doseRecoveredFromCrash = UserDefaults.appGroup?.inFlightAutomaticDose
+        UserDefaults.appGroup?.inFlightAutomaticDose = nil
+
+        if doseRecoveredFromCrash != nil {
+            issueCrashAlert()
+        }
+    }
+
+    func dosingStarted(dose: AutomaticDoseRecommendation) {
+        UserDefaults.appGroup?.inFlightAutomaticDose = dose
+    }
+
+    func dosingFinished() {
+        UserDefaults.appGroup?.inFlightAutomaticDose = nil
+    }
+
+    private func issueCrashAlert() {
+        let title = NSLocalizedString("Loop Crashed", comment: "Title for crash recovery alert")
+        let modalBody = NSLocalizedString("Oh no! Loop crashed while dosing, and insulin adjustments have been paused until this dialog is closed. Dosing history may not be accurate. Please review Insulin Delivery charts, and monitor your blood glucose carefully.", comment: "Modal body for crash recovery alert")
+        let modalContent = Alert.Content(title: title,
+                                         body: modalBody,
+                                         acknowledgeActionButtonLabel: NSLocalizedString("Continue", comment: "Default alert dismissal"))
+        let notificationBody = NSLocalizedString("Insulin adjustments have been disabled!", comment: "Notification body for crash recovery alert")
+        let notificationContent = Alert.Content(title: title,
+                                                body: notificationBody,
+                                                acknowledgeActionButtonLabel: NSLocalizedString("Continue", comment: "Default alert dismissal"))
+
+        let identifier = Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: crashAlertIdentifier)
+
+        let alert = Alert(identifier: identifier,
+                         foregroundContent: modalContent,
+                         backgroundContent: notificationContent,
+                         trigger: .immediate,
+                         interruptionLevel: .critical)
+
+        self.alertIssuer.issueAlert(alert)
+    }
+}
+
+extension CrashRecoveryManager: AlertResponder {
+    func acknowledgeAlert(alertIdentifier: LoopKit.Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
+        doseRecoveredFromCrash = nil
+    }
+}
+

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -41,6 +41,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     lazy private var cancellables = Set<AnyCancellable>()
 
     override func viewDidLoad() {
+
         super.viewDidLoad()
         tableView.register(BolusProgressTableViewCell.nib(), forCellReuseIdentifier: BolusProgressTableViewCell.className)
         tableView.register(AlertPermissionsDisabledWarningCell.self, forCellReuseIdentifier: AlertPermissionsDisabledWarningCell.className)
@@ -166,6 +167,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
+
         super.viewDidAppear(animated)
 
         if !appearedOnce {


### PR DESCRIPTION
Add CrashRecoveryManager, which generates an alert, and prevents looping, if a crash during dosing enactment or storage is encountered. 

Mitigation for #1796 

Also fixes "black screen" issue when alerts are issued before status view controller is presented, by deferring alert issuance.

![IMG_0086](https://user-images.githubusercontent.com/14649/190918950-61dbcf32-8d92-4a03-ae14-c717f22b17c0.PNG)
![IMG_0087](https://user-images.githubusercontent.com/14649/190918955-548d97d9-28f6-4946-9ae7-963bcb91ba8a.PNG)

