### PR TITLE
Add "now" line to main charts

### DIFF
--- a/LoopUI/Charts/COBChart.swift
+++ b/LoopUI/Charts/COBChart.swift
@@ -63,6 +63,10 @@ public extension COBChart {
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
+        let currentTimeValue = ChartAxisValueDate(date: Date(),  formatter: { _ in "" })
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
+
         if gestureRecognizer != nil {
             cobChartCache = ChartPointsTouchHighlightLayerViewCache(
                 xAxisLayer: xAxisLayer,
@@ -76,6 +80,7 @@ public extension COBChart {
 
         let layers: [ChartLayer?] = [
             gridLayer,
+            currentTimeLayer,
             xAxisLayer,
             yAxisLayer,
             cobChartCache?.highlightLayer,

--- a/LoopUI/Charts/COBChart.swift
+++ b/LoopUI/Charts/COBChart.swift
@@ -64,7 +64,7 @@ public extension COBChart {
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
         let currentTimeValue = ChartAxisValueDate(date: Date(),  formatter: { _ in "" })
-        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.carbTintColor, linesWidth: 1.0)
         let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
 
         if gestureRecognizer != nil {

--- a/LoopUI/Charts/DoseChart.swift
+++ b/LoopUI/Charts/DoseChart.swift
@@ -107,7 +107,7 @@ public extension DoseChart {
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
         let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
-        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: colors.insulinTint, linesWidth: 1.0)
         let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
 
         // 0-line

--- a/LoopUI/Charts/DoseChart.swift
+++ b/LoopUI/Charts/DoseChart.swift
@@ -106,6 +106,10 @@ public extension DoseChart {
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
+        let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
+
         // 0-line
         let dummyZeroChartPoint = ChartPoint(x: ChartAxisValueDouble(0), y: ChartAxisValueDouble(0))
         let zeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: [dummyZeroChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
@@ -130,6 +134,7 @@ public extension DoseChart {
 
         let layers: [ChartLayer?] = [
             gridLayer,
+            currentTimeLayer,
             xAxisLayer,
             yAxisLayer,
             zeroGuidelineLayer,

--- a/LoopUI/Charts/IOBChart.swift
+++ b/LoopUI/Charts/IOBChart.swift
@@ -62,6 +62,10 @@ public extension IOBChart {
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
+        let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
+
         // 0-line
         let dummyZeroChartPoint = ChartPoint(x: ChartAxisValueDouble(0), y: ChartAxisValueDouble(0))
         let zeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: [dummyZeroChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
@@ -86,6 +90,7 @@ public extension IOBChart {
 
         let layers: [ChartLayer?] = [
             gridLayer,
+            currentTimeLayer,
             xAxisLayer,
             yAxisLayer,
             zeroGuidelineLayer,

--- a/LoopUI/Charts/IOBChart.swift
+++ b/LoopUI/Charts/IOBChart.swift
@@ -63,7 +63,7 @@ public extension IOBChart {
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
         let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
-        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: colors.insulinTint, linesWidth: 1.0)
         let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
 
         // 0-line

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -167,10 +167,6 @@ extension PredictedGlucoseChart {
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
-        let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
-        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
-        let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
-
         let circles = ChartPointsScatterCirclesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: glucosePoints, displayDelay: 0, itemSize: CGSize(width: 4, height: 4), itemFillColor: colors.glucoseTint, optimized: true)
 
         var alternatePrediction: ChartLayer?
@@ -209,7 +205,6 @@ extension PredictedGlucoseChart {
 
         let layers: [ChartLayer?] = [
             gridLayer,
-            currentTimeLayer,
             targetsLayer,
             xAxisLayer,
             yAxisLayer,

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -167,6 +167,10 @@ extension PredictedGlucoseChart {
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
 
+        let currentTimeValue = ChartAxisValueDate(date: Date(), formatter: { _ in "" })
+        let currentTimeSettings = ChartGuideLinesLayerSettings(linesColor: UIColor.systemGray2, linesWidth: 0.5)
+        let currentTimeLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: currentTimeSettings, axisValuesX: [currentTimeValue], axisValuesY: [])
+
         let circles = ChartPointsScatterCirclesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: glucosePoints, displayDelay: 0, itemSize: CGSize(width: 4, height: 4), itemFillColor: colors.glucoseTint, optimized: true)
 
         var alternatePrediction: ChartLayer?
@@ -205,6 +209,7 @@ extension PredictedGlucoseChart {
 
         let layers: [ChartLayer?] = [
             gridLayer,
+            currentTimeLayer,
             targetsLayer,
             xAxisLayer,
             yAxisLayer,


### PR DESCRIPTION
Problem I'm trying to solve:
* In portrait mode, when reviewing the charts, the current glucose is pretty easy to see, but lining that up with Insulin and Carbs can be tricky
  * it sometimes takes me a couple of tries to get the readout (that lists values and times) to show and my finger often covers up the item of interest
*  In landscape mode, I am usually reviewing further back in time (so having now seems less important)
   * In practice, having the now indicator makes it a little easier to orient myself, I think because it "breaks" the horizontal display into history and prediction

Code changes taken from this [zulipchat post](https://loop.zulipchat.com/#narrow/stream/198661-ux/topic/Current.20time.20line/near/300675504) with thanks to Nils Evert for posting the modified files.

First graphic created from my real phone (no overnight carbs) using straight dev.

![pr_no_timeline](https://user-images.githubusercontent.com/19607791/193295183-139191ec-c978-4d68-8de7-62bd33ec459d.jpg)

Second graphic created from my real phone with this code change.

![pr_with_timeline](https://user-images.githubusercontent.com/19607791/193295576-8861fdde-1d9a-495f-ad5b-bb795b6a007b.jpg)


