### PR TITLE
limit maxCarbs to 99g

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -33,7 +33,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
         return deviceManager.displayGlucoseUnitObservable.displayGlucoseUnit
     }
 
-    var maxQuantity = HKQuantity(unit: .gram(), doubleValue: 250)
+    var maxQuantity = HKQuantity(unit: .gram(), doubleValue: 99)
 
     /// Entry configuration values. Must be set before presenting.
     var absorptionTimePickerInterval = TimeInterval(minutes: 30)


### PR DESCRIPTION
Reason for the change: Safety / prevent accidental entry of large number of carbs.

We discussed, earlier this year, adding a setting to Loop Therapy Settings to enable the user to adjust maxCarb for their app.

However, I checked my notes - I tried to work on this but did not succeed (my local branch name for both Loop and LoopKit is "dev_not_working_add_maxCarb_to_deliverylimits" with a date of April 30, 2022).

Details:
I think this is an important safety consideration (several mentors have helped people who accidentally got too much insulin by adding an extra digit to the carb entry, e.g., 115 instead of 15). I'd rather have the 2-digit protection for everyone and inconvenience those who eat 100 g or more into needing to do more than one entry.

In my mind it is similar to putting the 1 hour limit on future carb entries.  It annoys some folks, but there are work-arounds.