### PR TITLE
Add ability to estimate delivery duration of bolus

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1276,6 +1276,10 @@ extension DeviceDataManager: LoopDataManagerDelegate {
 
         return rounded
     }
+    
+    func loopDataManager(_ manager: LoopDataManager, estimateBolusDuration bolusUnits: Double) -> TimeInterval? {
+        pumpManager?.estimatedDuration(toDeliver: bolusUnits)
+    }
 
     func loopDataManager(
         _ manager: LoopDataManager,

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -2080,6 +2080,13 @@ protocol LoopDataManagerDelegate: AnyObject {
     /// - Returns: a supported rate of delivery in Units/hr. The rate returned should not be larger than the passed in rate.
     func loopDataManager(_ manager: LoopDataManager, roundBasalRate unitsPerHour: Double) -> Double
 
+    /// Asks the delegate to estimate the duration to deliver the bolus.
+    ///
+    /// - Parameters:
+    ///   - bolusUnits: size of the bolus in U
+    /// - Returns: the estimated time it will take to deliver bolus
+    func loopDataManager(_ manager: LoopDataManager, estimateBolusDuration bolusUnits: Double) -> TimeInterval?
+
     /// Asks the delegate to round a recommended bolus volume to a supported volume
     ///
     /// - Parameters:

--- a/LoopTests/Managers/DoseEnactorTests.swift
+++ b/LoopTests/Managers/DoseEnactorTests.swift
@@ -117,8 +117,8 @@ class MockPumpManager: PumpManager {
 
     }
     
-    func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval {
-        .minutes(bolusUnits / deliveryUnitsPerMinute)
+    func estimatedDuration(toBolus units: Double) -> TimeInterval {
+        .minutes(units / deliveryUnitsPerMinute)
     }
 
     var managerIdentifier: String = "MockPumpManager"

--- a/LoopTests/Managers/DoseEnactorTests.swift
+++ b/LoopTests/Managers/DoseEnactorTests.swift
@@ -42,6 +42,8 @@ class MockPumpManager: PumpManager {
 
     static var onboardingSupportedMaximumBolusVolumes: [Double] = [1,2,3]
     
+    let deliveryUnitsPerMinute = 1.5
+    
     var supportedBasalRates: [Double] = [1,2,3]
     
     var supportedBolusVolumes: [Double] = [1,2,3]
@@ -113,6 +115,10 @@ class MockPumpManager: PumpManager {
 
     func syncDeliveryLimits(limits deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void) {
 
+    }
+    
+    func estimatedDuration(toDeliver bolusUnits: Double) -> TimeInterval {
+        .minutes(bolusUnits / deliveryUnitsPerMinute)
     }
 
     var managerIdentifier: String = "MockPumpManager"


### PR DESCRIPTION
See https://github.com/LoopKit/LoopKit/pull/431/files for a description of the main changes. In `Loop`, I've added a delegate function to `LoopDataManagerDelegate` so the missed meal detection feature can compute the estimated autobolus duration when scheduling a missed meal notification.