### PR TITLE
Handle invalid remote carb absorption values

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1337,7 +1337,7 @@ extension DeviceDataManager {
         let command: RemoteCommand
         
         do {
-            command = try RemoteCommand.createRemoteCommand(notification: notification, allowedPresets: loopManager.settings.overridePresets).get()
+            command = try RemoteCommand.createRemoteCommand(notification: notification, allowedPresets: loopManager.settings.overridePresets, defaultAbsorptionTime: carbStore.defaultAbsorptionTimes.medium).get()
         } catch {
             log.error("Remote Notification Error: %{public}@", String(describing: error))
             return

--- a/Loop/Models/LoopConstants.swift
+++ b/Loop/Models/LoopConstants.swift
@@ -18,6 +18,8 @@ enum LoopConstants {
     static let maxCarbEntryQuantity = HKQuantity(unit: .gram(), doubleValue: 250)
     
     static let validManualGlucoseEntryRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 10)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 600)
+    
+    static let maxCarbAbsorptionTime = TimeInterval(hours: 8)
 
     
     // MARK - Display settings

--- a/Loop/Models/RemoteCommand.swift
+++ b/Loop/Models/RemoteCommand.swift
@@ -66,7 +66,7 @@ extension RemoteCommand {
         } else if let carbsValue = notification["carbs-entry"] as? Double {
 
             let minAbsorptionTime = TimeInterval(hours: 0.5)
-            let maxAbsorptionTime = TimeInterval(hours: 8)
+            let maxAbsorptionTime = LoopConstants.maxCarbAbsorptionTime
             
             var absorptionTime = defaultAbsorptionTime
             if let absorptionOverrideInHours = notification["absorption-time"] as? Double {

--- a/Loop/Models/RemoteCommand.swift
+++ b/Loop/Models/RemoteCommand.swift
@@ -49,7 +49,7 @@ enum RemoteCommand {
 
 // Push Notifications
 extension RemoteCommand {
-    static func createRemoteCommand(notification: [String: Any], allowedPresets: [TemporaryScheduleOverridePreset], nowDate: Date = Date()) -> Result<RemoteCommand, RemoteCommandParseError> {
+    static func createRemoteCommand(notification: [String: Any], allowedPresets: [TemporaryScheduleOverridePreset], defaultAbsorptionTime: TimeInterval, nowDate: Date = Date()) -> Result<RemoteCommand, RemoteCommandParseError> {
         if let overrideName = notification["override-name"] as? String,
             let preset = allowedPresets.first(where: { $0.name == overrideName }),
             let remoteAddress = notification["remote-address"] as? String
@@ -64,11 +64,19 @@ extension RemoteCommand {
         }  else if let bolusValue = notification["bolus-entry"] as? Double {
             return .success(.bolusEntry(bolusValue))
         } else if let carbsValue = notification["carbs-entry"] as? Double {
-            // TODO: get default absorption value
-            var absorptionTime = TimeInterval(hours: 3.0)
-            if let absorptionOverride = notification["absorption-time"] as? Double {
-                absorptionTime = TimeInterval(hours: absorptionOverride)
+
+            let minAbsorptionTime = TimeInterval(hours: 0.5)
+            let maxAbsorptionTime = TimeInterval(hours: 8)
+            
+            var absorptionTime = defaultAbsorptionTime
+            if let absorptionOverrideInHours = notification["absorption-time"] as? Double {
+                absorptionTime = TimeInterval(hours: absorptionOverrideInHours)
             }
+            
+            if absorptionTime < minAbsorptionTime || absorptionTime > maxAbsorptionTime {
+                return .failure(RemoteCommandParseError.invalidAbsorptionSeconds(absorptionTime))
+            }
+            
             let quantity = HKQuantity(unit: .gram(), doubleValue: carbsValue)
             
             var startDate = nowDate
@@ -91,6 +99,7 @@ extension RemoteCommand {
     
     enum RemoteCommandParseError: LocalizedError {
         case invalidStartTime(String)
+        case invalidAbsorptionSeconds(Double)
         case unhandledNotication(String)
     }
 }

--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -38,7 +38,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
     /// Entry configuration values. Must be set before presenting.
     var absorptionTimePickerInterval = TimeInterval(minutes: 30)
 
-    var maxAbsorptionTime = TimeInterval(hours: 8)
+    var maxAbsorptionTime = LoopConstants.maxCarbAbsorptionTime
 
     var maximumDateFutureInterval = TimeInterval(hours: 4)
 


### PR DESCRIPTION
A few changes in this PR:

* Enforce carb absorption range of 30 minutes to 8 hours.
* Use the user's default medium absorption if none supplied (A previous TODO in code).
* Add tests.

This issue was reported in https://github.com/LoopKit/Loop/issues/1841

Sending very large values also seems to make Loop crash or at least cause all carbs to disappear as I seemed to reproduce and also reported by a Loop user recently https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Red.20loop.