### PR TITLE
Widget glucose staleness

### DIFF
--- a/StatusWidget/GlucoseView.swift
+++ b/StatusWidget/GlucoseView.swift
@@ -12,13 +12,14 @@ import HealthKit
 import LoopCore
 
 struct GlucoseView: View {
+
     var entry: StatusWidgetEntry
     
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             HStack(spacing: 2) {
                 if let glucose = entry.currentGlucose,
-                   entry.date.timeIntervalSince(glucose.startDate) < LoopCoreConstants.inputDataRecencyInterval,
+                   !entry.glucoseIsStale,
                    let unit = entry.unit
                 {
                     let quantity = glucose.quantity
@@ -43,7 +44,7 @@ struct GlucoseView: View {
             }
             // Prevent truncation of text
             .fixedSize(horizontal: true, vertical: false)
-            .foregroundColor(entry.isOld || entry.glucoseIsStale ? Color(UIColor.systemGray3) : .primary)
+            .foregroundColor(entry.glucoseStatusIsStale ? Color(UIColor.systemGray3) : .primary)
             
             let unitString = entry.unit == nil ? "-" : entry.unit!.localizedShortUnitString
             if let delta = entry.delta, let unit = entry.unit {
@@ -54,13 +55,13 @@ struct GlucoseView: View {
                 Text(deltaString + " " + unitString)
                 // Dynamic text causes string to be cut off
                     .font(.system(size: 13))
-                    .foregroundColor(entry.isOld || entry.glucoseIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
+                    .foregroundColor(entry.glucoseStatusIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
                     .fixedSize(horizontal: true, vertical: true)
             }
             else {
                 Text(unitString)
                     .font(.footnote)
-                    .foregroundColor(entry.isOld || entry.glucoseIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
+                    .foregroundColor(entry.glucoseStatusIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
             }
         }
     }

--- a/StatusWidget/LoopCircleView.swift
+++ b/StatusWidget/LoopCircleView.swift
@@ -22,7 +22,7 @@ struct LoopCircleView: View {
         
         Circle()
             .trim(from: closeLoop ? 0 : 0.2, to: 1)
-            .stroke(entry.isOld ? Color(UIColor.systemGray3) : loopColor, lineWidth: 8)
+            .stroke(entry.contextIsStale ? Color(UIColor.systemGray3) : loopColor, lineWidth: 8)
             .rotationEffect(Angle(degrees: -126))
             .frame(width: 36, height: 36)
     }

--- a/StatusWidget/SmallStatusWidgetEntryView.swift
+++ b/StatusWidget/SmallStatusWidgetEntryView.swift
@@ -42,7 +42,7 @@ struct SmallStatusWidgetEntryView : View {
                     }
                 }
                 else if let netBasal = entry.netBasal {
-                    BasalView(netBasal: netBasal, isOld: entry.isOld)
+                    BasalView(netBasal: netBasal, isOld: entry.contextIsStale)
 
                     if let eventualGlucose = entry.eventualGlucose {
                         let glucoseFormatter = NumberFormatter.glucoseFormatter(for: eventualGlucose.unit)
@@ -50,7 +50,7 @@ struct SmallStatusWidgetEntryView : View {
                             VStack {
                                 Text("Eventual")
                                 .font(.footnote)
-                                .foregroundColor(entry.isOld ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
+                                .foregroundColor(entry.contextIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
 
                                 Text("\(glucoseString)")
                                     .font(.subheadline)
@@ -58,7 +58,7 @@ struct SmallStatusWidgetEntryView : View {
 
                                 Text(eventualGlucose.unit.shortLocalizedUnitString())
                                     .font(.footnote)
-                                    .foregroundColor(entry.isOld ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
+                                    .foregroundColor(entry.contextIsStale ? Color(UIColor.systemGray3) : Color(UIColor.secondaryLabel))
                             }
                         }
                     }
@@ -73,7 +73,7 @@ struct SmallStatusWidgetEntryView : View {
                     .fill(Color("WidgetSecondaryBackground"))
             )
         }
-        .foregroundColor(entry.isOld ? Color(UIColor.systemGray3) : nil)
+        .foregroundColor(entry.contextIsStale ? Color(UIColor.systemGray3) : nil)
         .padding(5)
         .background(Color("WidgetBackground"))
     }

--- a/StatusWidget/StatusWidget.swift
+++ b/StatusWidget/StatusWidget.swift
@@ -195,7 +195,7 @@ struct StatusWidgetEntry: TimelineEntry {
     let eventualGlucose: GlucoseContext?
     
     // Whether context data is old
-    var isOld: Bool {
+    var contextIsStale: Bool {
         return (date - contextUpdatedAt) >= StatusWidgetProvider.stalenessAge
     }
 

--- a/StatusWidget/StatusWidget.swift
+++ b/StatusWidget/StatusWidget.swift
@@ -20,7 +20,7 @@ class StatusWidgetProvider: TimelineProvider {
 
     private let log = OSLog(category: "LoopWidgets")
 
-    static let stalenessAge = TimeInterval(minutes: 5)
+    static let stalenessAge = TimeInterval(minutes: 6)
 
     lazy var cacheStore = PersistenceController.controllerInAppGroupDirectory()
 
@@ -42,7 +42,7 @@ class StatusWidgetProvider: TimelineProvider {
     func placeholder(in context: Context) -> StatusWidgetEntry {
         log.default("%{public}@: context=%{public}@", #function, String(describing: context))
 
-        return StatusWidgetEntry(date: Date(), statusUpdatedAt: Date(), lastLoopCompleted: nil, closeLoop: true, currentGlucose: nil, delta: nil, unit: .milligramsPerDeciliter, sensor: nil, pumpHighlight: nil, netBasal: nil, eventualGlucose: nil)
+        return StatusWidgetEntry(date: Date(), contextUpdatedAt: Date(), lastLoopCompleted: nil, closeLoop: true, currentGlucose: nil, glucoseFetchedAt: Date(), delta: nil, unit: .milligramsPerDeciliter, sensor: nil, pumpHighlight: nil, netBasal: nil, eventualGlucose: nil)
     }
 
     func getSnapshot(in context: Context, completion: @escaping (StatusWidgetEntry) -> ()) {
@@ -64,14 +64,20 @@ class StatusWidgetProvider: TimelineProvider {
                 datesToRefreshWidget.append(lastLoopCompleted.addingTimeInterval(LoopCompletionFreshness.aging.maxAge!+1)) // Turns red
             }
 
+            // Date glucose status staleness changes
+            if let lastGlucoseFetch = newEntry.glucoseFetchedAt {
+                let glucoseFetchStaleAt = lastGlucoseFetch.addingTimeInterval(StatusWidgetProvider.stalenessAge+1)
+                datesToRefreshWidget.append(glucoseFetchStaleAt)
+            }
+
             // Date glucose staleness changes
             if let lastBGTime = newEntry.currentGlucose?.startDate {
                 let staleBgRefreshTime = lastBGTime.addingTimeInterval(LoopCoreConstants.inputDataRecencyInterval+1)
                 datesToRefreshWidget.append(staleBgRefreshTime)
             }
 
-            // Date we mark entire widget stale
-            datesToRefreshWidget.append(newEntry.statusUpdatedAt.addingTimeInterval(StatusWidgetProvider.stalenessAge+1))
+            // Date context staleness changes
+            datesToRefreshWidget.append(newEntry.contextUpdatedAt.addingTimeInterval(StatusWidgetProvider.stalenessAge+1))
 
             for date in datesToRefreshWidget {
                 // Copy the previous entry but mark it as stale
@@ -92,7 +98,7 @@ class StatusWidgetProvider: TimelineProvider {
 
         var glucose: [StoredGlucoseSample] = []
 
-        let startDate: Date = Calendar.current.nextDate(after: Date(timeIntervalSinceNow: .minutes(-5)), matching: DateComponents(minute: 0), matchingPolicy: .strict, direction: .backward) ?? Date()
+        let startDate = Date(timeIntervalSinceNow: -LoopCoreConstants.inputDataRecencyInterval)
 
         group.enter()
         glucoseStore.getGlucoseSamples(start: startDate) { (result) in
@@ -143,12 +149,15 @@ class StatusWidgetProvider: TimelineProvider {
             
             let eventualGlucose = predictedGlucose?.last
 
+            let updateDate = Date()
+
             let entry = StatusWidgetEntry(
-                date: Date(),
-                statusUpdatedAt: contextUpdatedAt,
+                date: updateDate,
+                contextUpdatedAt: contextUpdatedAt,
                 lastLoopCompleted: lastCompleted,
                 closeLoop: closeLoop,
                 currentGlucose: currentGlucose,
+                glucoseFetchedAt: updateDate,
                 delta: delta,
                 unit: unit,
                 sensor: context.glucoseDisplay,
@@ -169,12 +178,13 @@ class StatusWidgetProvider: TimelineProvider {
 struct StatusWidgetEntry: TimelineEntry {
     var date: Date
     
-    let statusUpdatedAt: Date
+    let contextUpdatedAt: Date
     
     let lastLoopCompleted: Date?
     let closeLoop: Bool
     
     let currentGlucose: GlucoseValue?
+    let glucoseFetchedAt: Date?
     let delta: HKQuantity?
     let unit: HKUnit?
     let sensor: GlucoseDisplayableContext?
@@ -186,7 +196,15 @@ struct StatusWidgetEntry: TimelineEntry {
     
     // Whether context data is old
     var isOld: Bool {
-        return (date - statusUpdatedAt) >= StatusWidgetProvider.stalenessAge
+        return (date - contextUpdatedAt) >= StatusWidgetProvider.stalenessAge
+    }
+
+    var glucoseStatusIsStale: Bool {
+        guard let glucoseFetchedAt = glucoseFetchedAt else {
+            return true
+        }
+        let glucoseStatusAge = date - glucoseFetchedAt
+        return glucoseStatusAge >= StatusWidgetProvider.stalenessAge
     }
 
     var glucoseIsStale: Bool {


### PR DESCRIPTION
Glucose data for the widget is fetched from CoreData, not from the context (UserDefaults).  In the case where Loop has not updated the context, but there is fresh data in GlucoseStore, the glucose staleness should be based off of how recently we fetched data from GlucoseStore.