### PR TITLE
Fix target range display when override and premeal are both active

### DIFF
--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -98,6 +98,8 @@ extension PredictedGlucoseChart {
     public func generate(withFrame frame: CGRect, xAxisModel: ChartAxisModel, xAxisValues: [ChartAxisValue], axisLabelSettings: ChartLabelSettings, guideLinesLayerSettings: ChartGuideLinesLayerSettings, colors: ChartColorPalette, chartSettings: ChartSettings, labelsWidthY: CGFloat, gestureRecognizer: UIGestureRecognizer?, traitCollection: UITraitCollection) -> Chart
     {
         if targetGlucosePoints.isEmpty, xAxisValues.count > 1, let schedule = targetGlucoseSchedule {
+
+            // TODO: This only considers one override: pre-meal or an active override. ChartPoint.barsForGlucoseRangeSchedule needs to accept list of overridden ranges.
             let potentialOverride = (preMealOverride?.isActive() ?? false) ? preMealOverride : (scheduleOverride?.isActive() ?? false) ? scheduleOverride : nil
             targetGlucosePoints = ChartPoint.barsForGlucoseRangeSchedule(schedule, unit: glucoseUnit, xAxisValues: xAxisValues, considering: potentialOverride)
 
@@ -107,7 +109,8 @@ extension PredictedGlucoseChart {
 
                 if displayedScheduleOverride != nil {
                     if displayedScheduleOverride!.scheduledEndDate > preMealOverride.scheduledEndDate {
-                        displayedScheduleOverride!.scheduledInterval = DateInterval(start: preMealOverride.scheduledEndDate, end: displayedScheduleOverride!.scheduledEndDate)
+                        let start = max(displayedScheduleOverride!.startDate, preMealOverride.scheduledEndDate)
+                        displayedScheduleOverride!.scheduledInterval = DateInterval(start: start, end: displayedScheduleOverride!.scheduledEndDate)
                     } else {
                         displayedScheduleOverride = nil
                     }


### PR DESCRIPTION
Updated version of https://github.com/LoopKit/Loop/pull/1757, to fix https://github.com/LoopKit/Loop/issues/1741