### PR TITLE
Ensure remote treatments are uploaded to NS while in background

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1432,30 +1432,54 @@ extension DeviceDataManager {
     }
     
     func addRemoteCarbEntry(_ carbEntry: NewCarbEntry, completion: @escaping (_ result: CarbStoreResult<StoredCarbEntry>) -> Void) {
-        let backgroundTaskID = "Add Remote Carb Entry"
-        let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: backgroundTaskID)
+
+        var backgroundTask: UIBackgroundTaskIdentifier?
+        backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "Add Remote Carb Entry") {
+            guard let backgroundTask = backgroundTask else {return}
+            UIApplication.shared.endBackgroundTask(backgroundTask)
+            self.log.error("Add Remote Carb Entry background task expired")
+        }
+
         carbStore.addCarbEntry(carbEntry) { result in
             self.triggerBackgroundUpload(for: .carb)
-            UIApplication.shared.endBackgroundTask(backgroundTask)
+            if let backgroundTask = backgroundTask {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
             completion(result)
         }
     }
     
     func enactRemoteBolus(units: Double, completion: @escaping (_ error: Error?) -> Void = { _ in }) {
-        let backgroundTaskID = "Add Remote Bolus Entry"
-        let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: backgroundTaskID)
+        
+        var backgroundTask: UIBackgroundTaskIdentifier?
+        backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "Enact Remote Bolus") {
+            guard let backgroundTask = backgroundTask else {return}
+            UIApplication.shared.endBackgroundTask(backgroundTask)
+            self.log.error("Enact Remote Bolus background task expired")
+        }
+        
         self.enactBolus(units: units, activationType: .manualNoRecommendation) { error in
             self.triggerBackgroundUpload(for: .dose)
-            UIApplication.shared.endBackgroundTask(backgroundTask)
+            if let backgroundTask = backgroundTask {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
             completion(error)
         }
     }
     
     func triggerBackgroundUpload(for triggeringType: RemoteDataType) {
-        let backgroundTaskID = "Remote Data upload"
-        let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: backgroundTaskID)
-        self.remoteDataServicesManager.triggerUpload(for: triggeringType) {
+        
+        var backgroundTask: UIBackgroundTaskIdentifier?
+        backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "Remote Data Upload") {
+            guard let backgroundTask = backgroundTask else {return}
             UIApplication.shared.endBackgroundTask(backgroundTask)
+            self.log.error("Remote Data Upload background task expired")
+        }
+        
+        self.remoteDataServicesManager.triggerUpload(for: triggeringType) {
+            if let backgroundTask = backgroundTask {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
         }
     }
 }

--- a/Loop/Managers/RemoteDataServicesManager.swift
+++ b/Loop/Managers/RemoteDataServicesManager.swift
@@ -176,10 +176,6 @@ final class RemoteDataServicesManager {
         clearSettingsQueryAnchor(for: remoteDataService)
     }
 
-    public func waitForUploadsToFinish(timeout: DispatchTime = .now() + TimeInterval(10)) -> DispatchTimeoutResult {
-        return uploadGroup.wait(timeout: timeout)
-    }
-
     func triggerUpload(for triggeringType: RemoteDataType) {
         let uploadTypes = [triggeringType] + failedUploads.map { $0.remoteDataType }
 
@@ -204,6 +200,13 @@ final class RemoteDataServicesManager {
             case .overrides:
                 remoteDataServices.forEach { self.uploadTemporaryOverrideData(to: $0) }
             }
+        }
+    }
+    
+    func triggerUpload(for triggeringType: RemoteDataType, completion: @escaping () -> Void) {
+        triggerUpload(for: triggeringType)
+        self.uploadGroup.notify(queue: DispatchQueue.main) {
+            completion()
         }
     }
 }


### PR DESCRIPTION
Nightscout remote treatments (bolus, carbs, overrides) are sometimes delayed in showing up in Nightscout. This seems related to the app being in the background.

The primary reason for the delays seems to be the various delivery/upload threads halting their progress while in the background -- iOS just stops giving CPU time. Opening the app will "wake" the threads back up and finish the upload process.

A mechanism for synchronously waiting on the GCD groupTask did not seem to working as intended from what could tell. It seems the reason was there was no groupTasks to wait on when the `wait` was invoked as the code that enacts treatments is highly asynchronous. There were often several dispatches to different queues to wait on before the groupTasks were added.

The change in this PR is to use backgroundTasks rather than waits. We _could_  instead use a wait with this same pattern I'm using for backgroundTasks... The reason I went with a background task is the wait is causing Xcode to show thread priority inversion warnings since several of the queues we would need to wait on are `.background` priority. 