### PR TITLE
Trigger dosing decision creation after manual bolus or carb editing

### DIFF
--- a/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
+++ b/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
@@ -19,11 +19,20 @@ extension DeviceDataManager: BolusEntryViewModelDelegate, ManualDoseViewModelDel
     func withLoopState(do block: @escaping (LoopState) -> Void) {
         loopManager.getLoopState { block($1) }
     }
-    
-    func addGlucoseSamples(_ samples: [NewGlucoseSample], completion: ((Swift.Result<[StoredGlucoseSample], Error>) -> Void)?) {
-        loopManager.addGlucoseSamples(samples, completion: completion)
+
+    func saveGlucose(sample: NewGlucoseSample) async -> StoredGlucoseSample? {
+        return await withCheckedContinuation { continuation in
+            loopManager.addGlucoseSamples([sample]) { result in
+                switch result {
+                case .success(let samples):
+                    continuation.resume(returning: samples.first)
+                case .failure:
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
     }
-    
+
     func addCarbEntry(_ carbEntry: NewCarbEntry, replacing replacingEntry: StoredCarbEntry?, completion: @escaping (Result<StoredCarbEntry>) -> Void) {
         loopManager.addCarbEntry(carbEntry, replacing: replacingEntry, completion: completion)
     }
@@ -76,4 +85,7 @@ extension DeviceDataManager: BolusEntryViewModelDelegate, ManualDoseViewModelDel
         return loopManager.settings
     }
 
+    func updateRemoteRecommendation() {
+        loopManager.updateRemoteRecommendation()
+    }
 }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -786,6 +786,8 @@ extension DeviceDataManager {
                     completion(nil)
                 }
             }
+            // Trigger forecast/recommendation update for remote clients
+            self.loopManager.updateRemoteRecommendation()
         }
     }
 

--- a/Loop/Managers/WatchDataManager.swift
+++ b/Loop/Managers/WatchDataManager.swift
@@ -391,6 +391,8 @@ final class WatchDataManager: NSObject {
 
                 // When we've successfully started the bolus, send a new context with our new prediction
                 self.sendWatchContextIfNeeded()
+
+                self.deviceManager.loopManager.updateRemoteRecommendation()
             }
         }
 

--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -496,6 +496,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
 
         let viewModel = BolusEntryViewModel(
             delegate: deviceManager,
+            screenWidth: UIScreen.main.bounds.width,
             originalCarbEntry: originalCarbEntry,
             potentialCarbEntry: updatedEntry,
             selectedCarbAbsorptionTimeEmoji: selectedDefaultAbsorptionTimeEmoji

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1291,7 +1291,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             let bolusEntryView = SimpleBolusView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)
         } else {
-            let viewModel = BolusEntryViewModel(delegate: deviceManager, isManualGlucoseEntryEnabled: enableManualGlucoseEntry)
+            let viewModel = BolusEntryViewModel(delegate: deviceManager, screenWidth: UIScreen.main.bounds.width, isManualGlucoseEntryEnabled: enableManualGlucoseEntry)
             viewModel.generateRecommendationAndStartObserving()
             let bolusEntryView = BolusEntryView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -410,7 +410,11 @@ struct BolusEntryView: View {
                 if self.viewModel.actionButtonAction == .enterBolus {
                     self.shouldBolusEntryBecomeFirstResponder = true
                 } else {
-                    self.viewModel.saveAndDeliver(onSuccess: self.dismiss)
+                    Task {
+                        if await self.viewModel.didPressActionButton() {
+                            dismiss()
+                        }
+                    }
                 }
             },
             label: {
@@ -427,7 +431,7 @@ struct BolusEntryView: View {
             }
         )
         .buttonStyle(ActionButtonStyle(viewModel.primaryButton == .actionButton ? .primary : .secondary))
-        .disabled(viewModel.isInitiatingSaveOrBolus)
+        .disabled(viewModel.enacting)
         .padding()
     }
 


### PR DESCRIPTION
Fixes https://github.com/LoopKit/Loop/issues/1858

Simplifies error prone callback spaghetti of saving glucose/carbs/bolusing by switching to async context, which makes it easier to ensure that the remote dosing decision is updated at the right time.