### PR TITLE
Improve Remote failure error messaging

### DIFF
--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -77,6 +77,29 @@ extension NotificationManager {
     
 
     // MARK: - Notifications
+    
+    static func sendRemoteCommandExpiredNotification(timeExpired: TimeInterval) {
+        let notification = UNMutableNotificationContent()
+
+        notification.title = NSLocalizedString("Remote Command Expired", comment: "The notification title for the remote command expiration error")
+
+        notification.body = String(format: NSLocalizedString("The remote command expired %.0f minutes ago.", comment: "The notification body for a remote command expiration. (1: Expiration in minutes)"), fabs(timeExpired / 60.0))
+        notification.sound = .default
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .timeSensitive
+        }
+         
+        notification.categoryIdentifier = LoopNotificationCategory.remoteCommandExpired.rawValue
+
+        let request = UNNotificationRequest(
+            // Only support 1 expiration notification at once
+            identifier: LoopNotificationCategory.remoteCommandExpired.rawValue,
+            content: notification,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request)
+    }
 
     static func sendBolusFailureNotification(for error: PumpManagerError, units: Double, at startDate: Date, activationType: BolusActivationType) {
         let notification = UNMutableNotificationContent()
@@ -130,6 +153,9 @@ extension NotificationManager {
 
         notification.body = body
         notification.sound = .default
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .timeSensitive
+        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteBolus.rawValue,
@@ -151,6 +177,9 @@ extension NotificationManager {
         notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %@ U", comment: "The notification title for a remote failure. (1: Bolus amount)"), amountDescription)
         notification.body = error.localizedDescription
         notification.sound = .default
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .timeSensitive
+        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteBolusFailure.rawValue,
@@ -171,6 +200,9 @@ extension NotificationManager {
 
         notification.body = body
         notification.sound = .default
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .timeSensitive
+        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteCarbs.rawValue,
@@ -191,6 +223,9 @@ extension NotificationManager {
         
         notification.body = body
         notification.sound = .default
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .timeSensitive
+        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteCarbsFailure.rawValue,

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -85,9 +85,6 @@ extension NotificationManager {
 
         notification.body = String(format: NSLocalizedString("The remote command expired %.0f minutes ago.", comment: "The notification body for a remote command expiration. (1: Expiration in minutes)"), fabs(timeExpired / 60.0))
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
          
         notification.categoryIdentifier = LoopNotificationCategory.remoteCommandExpired.rawValue
 
@@ -116,9 +113,6 @@ extension NotificationManager {
 
         notification.body = body
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
 
         if startDate.timeIntervalSinceNow >= TimeInterval(minutes: -5) {
             notification.categoryIdentifier = LoopNotificationCategory.bolusFailure.rawValue
@@ -153,9 +147,6 @@ extension NotificationManager {
 
         notification.body = body
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteBolus.rawValue,
@@ -177,9 +168,6 @@ extension NotificationManager {
         notification.title =  String(format: NSLocalizedString("Remote Bolus Entry: %@ U", comment: "The notification title for a remote failure. (1: Bolus amount)"), amountDescription)
         notification.body = error.localizedDescription
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteBolusFailure.rawValue,
@@ -200,9 +188,6 @@ extension NotificationManager {
 
         notification.body = body
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteCarbs.rawValue,
@@ -223,9 +208,6 @@ extension NotificationManager {
         
         notification.body = body
         notification.sound = .default
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .timeSensitive
-        }
 
         let request = UNNotificationRequest(
             identifier: LoopNotificationCategory.remoteCarbsFailure.rawValue,


### PR DESCRIPTION
We have had some reports of failed remote deliveries and the current error messaging isn't very helpful for understanding why a remote push failed. This information is captured in diagnostic logs but ideally this would be surfaced to a user. This PR enhances our user-facing errors messages.

Associated PRs:

LoopKit: https://github.com/LoopKit/Loop/pull/1867
NightscoutService: https://github.com/ps2/NightscoutService/pull/24
