### PR TITLE
Use maxBolus to set automaticDosingIOBLimit

### DIFF
--- a/DoseMathTests/DoseMathTests.swift
+++ b/DoseMathTests/DoseMathTests.swift
@@ -55,16 +55,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     fileprivate let maxBasalRate = 3.0
 
-    fileprivate let maxBolus = 12.5
-
-    var automaticDosingIOBLimit: Double {
-        return 2.0 * maxBolus
-    }
-
-    var maxAutomaticBolus: Double {
-        return maxBolus * 0.4
-    }
-
     fileprivate let fortyIncrementsPerUnitRounder = { round($0 * 40) / 40 }
 
     func loadGlucoseValueFixture(_ resourceName: String) -> [GlucoseFixtureValue] {

--- a/DoseMathTests/DoseMathTests.swift
+++ b/DoseMathTests/DoseMathTests.swift
@@ -55,7 +55,15 @@ class RecommendTempBasalTests: XCTestCase {
 
     fileprivate let maxBasalRate = 3.0
 
-    fileprivate let maxBolus = 5.0
+    fileprivate let maxBolus = 12.5
+
+    var automaticDosingIOBLimit: Double {
+        return 2.0 * maxBolus
+    }
+
+    var maxAutomaticBolus: Double {
+        return maxBolus * 0.4
+    }
 
     fileprivate let fortyIncrementsPerUnitRounder = { round($0 * 40) / 40 }
 
@@ -107,13 +115,8 @@ class RecommendTempBasalTests: XCTestCase {
         return TimeInterval(hours: 4)
     }
 
-    var automaticDosingIOBLimit: Double {
-        return 2.0 * maxBolus
-    }
-
     func testNoChange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
-        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -123,9 +126,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -133,7 +134,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
-        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -143,9 +143,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -153,7 +151,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeAutomaticBolusing() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
-        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -164,9 +161,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -174,7 +169,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testNoChangeOverrideActive() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -185,9 +179,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertEqual(0.8, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -196,7 +188,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeOverrideActiveAutomaticBolusing() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -208,9 +199,7 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -220,7 +209,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -230,9 +218,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -254,9 +240,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -265,7 +249,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRangeAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -276,9 +259,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -301,9 +282,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -313,7 +292,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRangeAutomaticBolusWithOverride() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -325,9 +303,7 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -352,9 +328,7 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: lastTempBasal,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertNil(dose)
@@ -362,7 +336,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndInRange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -372,9 +345,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -395,9 +366,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -406,7 +375,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartLowEndInRangeExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -416,9 +384,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -439,9 +405,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -450,7 +414,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndInRangeAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -461,9 +424,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -485,9 +446,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -497,7 +456,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testCorrectLowAtMin() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_correct_low_at_min")
-        let insulinOnBoard = 7.69
 
         // Cancel existing dose
         let lastTempBasal = DoseEntry(
@@ -516,9 +474,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -532,9 +488,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -542,7 +496,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testCorrectLowAtMinAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_correct_low_at_min")
-        let insulinOnBoard = 7.69
 
         // Cancel existing dose
         let lastTempBasal = DoseEntry(
@@ -562,9 +515,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -580,9 +531,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -590,7 +539,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndLow() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -600,9 +548,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -611,7 +557,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartHighEndLowAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -622,9 +567,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -634,7 +577,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartHighEndLowExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -644,9 +586,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -655,7 +595,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndHigh() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_high")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -665,9 +604,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -689,9 +626,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -700,7 +635,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndHighAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_high")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -711,9 +645,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -735,9 +667,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: lastTempBasal
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -747,7 +677,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHigh() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -757,9 +686,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(3.0, dose!.unitsPerHour)
@@ -768,7 +695,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHighAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -779,9 +705,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -790,7 +714,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHighAutomaticBolusWithOverride() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -802,9 +725,7 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -830,9 +751,7 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: lastTempBasal,
-            isBasalRateScheduleOverrideActive: true,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            isBasalRateScheduleOverrideActive: true
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -842,7 +761,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testHighAndFalling() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
-        let insulinOnBoard = 7.69
 
         let insulinModel = WalshInsulinModel(actionDuration: insulinActionDuration, delay: 0)
 
@@ -854,9 +772,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: insulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(1.425, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -865,7 +781,6 @@ class RecommendTempBasalTests: XCTestCase {
  
     func testHighAndFallingAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -876,9 +791,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -887,7 +800,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testHighAndFallingExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -897,9 +809,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(2.68, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -908,7 +818,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testInRangeAndRisingAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_in_range_and_rising")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -919,9 +828,7 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -930,7 +837,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testInRangeAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_in_range_and_rising")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -940,9 +846,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(1.60, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -951,7 +855,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testHighAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
-        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -961,9 +864,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(3.0, dose!.unitsPerHour)
@@ -980,9 +881,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertEqual(2.975, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -991,7 +890,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testVeryLowAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_very_low_end_in_range")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -1001,9 +899,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
         
         XCTAssertEqual(0.0, dose!.unitsPerHour)
@@ -1012,7 +908,6 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testRiseAfterExponentialModelDIA() {
         let glucose = loadGlucoseValueFixture("far_future_high_bg_forecast_after_6_hours")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -1022,9 +917,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -1032,7 +925,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testRiseAfterDIA() {
         let glucose = loadGlucoseValueFixture("far_future_high_bg_forecast")
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -1042,9 +934,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)
@@ -1053,7 +943,6 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testNoInputGlucose() {
         let glucose: [GlucoseFixtureValue] = []
-        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -1062,184 +951,7 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertNil(dose)
-    }
-
-    // Next four tests, recommended bolus is 2.30 U (no limit)
-    //   adjust IOB to modify AutomaticBolus
-
-    func testFlatAndHighAutomaticBolusNoLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-        let insulinOnBoard = 7.69
-
-        let dose = glucose.recommendedAutomaticDose(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxAutomaticBolus: maxBolus,
-            partialApplicationFactor: 1.0,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertNil(dose!.basalAdjustment)
-        XCTAssertEqual(2.30, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
-    }
-
-    func testFlatAndHighAutomaticBolusWithLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-
-        // max allowed dose will be 0.5 units
-        let maxAutoCorrection = 0.5
-        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
-
-        let dose = glucose.recommendedAutomaticDose(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxAutomaticBolus: maxBolus,
-            partialApplicationFactor: 1.0,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertNil(dose!.basalAdjustment)
-        XCTAssertEqual(maxAutoCorrection, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
-    }
-
-    func testFlatAndHighAutomaticBolusWithLimitPAF() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-
-        // max allowed dose will be 0.5 units
-        // for this test use partialApplicationFactor of 0.5, instead of 1.0
-        let maxAutoCorrection = 0.5
-        let partialApplicationFactor = 0.5
-        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
-
-        let dose = glucose.recommendedAutomaticDose(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxAutomaticBolus: maxBolus,
-            partialApplicationFactor: partialApplicationFactor,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertNil(dose!.basalAdjustment)
-        XCTAssertEqual(partialApplicationFactor * maxAutoCorrection, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
-    }
-
-    func testFlatAndHighAutomaticBolusFullLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
-
-        // no automatic dose
-        let insulinOnBoard = automaticDosingIOBLimit + 0.1
-
-        let dose = glucose.recommendedAutomaticDose(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxAutomaticBolus: maxBolus,
-            partialApplicationFactor: 1.0,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertNil(dose)
-    }
-
-    // Next three test recommended TempBasal is 3.0 U/hr (no limit)
-    //   Adjust IOB to modify automatic TempBasal
-    let noLimitBasalRate = 3.0
-    let scheduledBasalRate = 0.8
-
-    func testHighAndRisingTempBasalNoLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
-
-        // no limit
-        let insulinOnBoard = 0.0
-
-        let dose = glucose.recommendedTempBasal(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: self.insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertEqual(noLimitBasalRate, dose!.unitsPerHour)
-        XCTAssertEqual(TimeInterval(minutes: 30), dose!.duration)
-    }
-
-    func testHighAndRisingTempBasalWithLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
-
-        // max allowed dose will be 0.5 units, temp basal twice that
-        let maxAutoCorrection = 0.5
-        let limitedBasalRate = scheduledBasalRate + 2.0 * maxAutoCorrection
-        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
-
-        let dose = glucose.recommendedTempBasal(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: self.insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
-        )
-
-        XCTAssertEqual(limitedBasalRate, dose!.unitsPerHour)
-        XCTAssertEqual(TimeInterval(minutes: 30), dose!.duration)
-    }
-
-    func testHighAndRisingTempBasalFullLimit() {
-        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
-
-        // no automatic dose
-        let insulinOnBoard = automaticDosingIOBLimit + 0.1
-
-        let dose = glucose.recommendedTempBasal(
-            to: glucoseTargetRange,
-            at: glucose.first!.startDate,
-            suspendThreshold: suspendThreshold.quantity,
-            sensitivity: self.insulinSensitivitySchedule,
-            model: exponentialInsulinModel,
-            basalRates: basalRateSchedule,
-            maxBasalRate: maxBasalRate,
-            lastTempBasal: nil,
-            insulinOnBoard: insulinOnBoard,
-            automaticDosingIOBLimit: automaticDosingIOBLimit
+            lastTempBasal: nil
         )
 
         XCTAssertNil(dose)

--- a/DoseMathTests/DoseMathTests.swift
+++ b/DoseMathTests/DoseMathTests.swift
@@ -55,6 +55,8 @@ class RecommendTempBasalTests: XCTestCase {
 
     fileprivate let maxBasalRate = 3.0
 
+    fileprivate let maxBolus = 5.0
+
     fileprivate let fortyIncrementsPerUnitRounder = { round($0 * 40) / 40 }
 
     func loadGlucoseValueFixture(_ resourceName: String) -> [GlucoseFixtureValue] {
@@ -105,8 +107,13 @@ class RecommendTempBasalTests: XCTestCase {
         return TimeInterval(hours: 4)
     }
 
+    var automaticDosingIOBLimit: Double {
+        return 2.0 * maxBolus
+    }
+
     func testNoChange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
+        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -116,7 +123,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -124,6 +133,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
+        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -133,7 +143,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -141,6 +153,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeAutomaticBolusing() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
+        let insulinOnBoard = 0.0
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -151,7 +164,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -159,6 +174,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testNoChangeOverrideActive() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -169,7 +185,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0.8, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -178,6 +196,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testNoChangeOverrideActiveAutomaticBolusing() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_no_change_glucose")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -189,7 +208,9 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -199,6 +220,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -208,7 +230,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -230,7 +254,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -239,6 +265,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRangeAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -249,7 +276,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -272,7 +301,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -282,6 +313,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndInRangeAutomaticBolusWithOverride() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -293,7 +325,9 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -318,7 +352,9 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: lastTempBasal,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -326,6 +362,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndInRange() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -335,7 +372,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -356,7 +395,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -365,6 +406,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartLowEndInRangeExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -374,7 +416,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -395,7 +439,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -404,6 +450,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndInRangeAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_in_range")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -414,7 +461,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -436,7 +485,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -446,6 +497,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testCorrectLowAtMin() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_correct_low_at_min")
+        let insulinOnBoard = 7.69
 
         // Cancel existing dose
         let lastTempBasal = DoseEntry(
@@ -464,7 +516,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -478,7 +532,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -486,6 +542,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testCorrectLowAtMinAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_correct_low_at_min")
+        let insulinOnBoard = 7.69
 
         // Cancel existing dose
         let lastTempBasal = DoseEntry(
@@ -505,7 +562,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -521,7 +580,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -529,6 +590,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartHighEndLow() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -538,7 +600,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -547,6 +611,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartHighEndLowAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -557,7 +622,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -567,6 +634,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testStartHighEndLowExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_high_end_low")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -576,7 +644,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -585,6 +655,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndHigh() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_high")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -594,7 +665,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -616,7 +689,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.unitsPerHour)
@@ -625,6 +700,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testStartLowEndHighAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_start_low_end_high")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -635,7 +711,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -657,7 +735,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: lastTempBasal
+            lastTempBasal: lastTempBasal,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0, dose!.basalAdjustment!.unitsPerHour)
@@ -667,6 +747,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHigh() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -676,7 +757,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(3.0, dose!.unitsPerHour)
@@ -685,6 +768,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHighAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -695,7 +779,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -704,6 +790,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testFlatAndHighAutomaticBolusWithOverride() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -715,7 +802,9 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: nil,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(0.8, dose!.basalAdjustment!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -741,7 +830,9 @@ class RecommendTempBasalTests: XCTestCase {
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
             lastTempBasal: lastTempBasal,
-            isBasalRateScheduleOverrideActive: true
+            isBasalRateScheduleOverrideActive: true,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -751,7 +842,8 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testHighAndFalling() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
-        
+        let insulinOnBoard = 7.69
+
         let insulinModel = WalshInsulinModel(actionDuration: insulinActionDuration, delay: 0)
 
         let dose = glucose.recommendedTempBasal(
@@ -762,7 +854,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: insulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(1.425, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -771,6 +865,7 @@ class RecommendTempBasalTests: XCTestCase {
  
     func testHighAndFallingAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -781,7 +876,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -790,6 +887,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testHighAndFallingExponentialModel() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_falling")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -799,7 +897,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(2.68, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -808,6 +908,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testInRangeAndRisingAutomaticBolus() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_in_range_and_rising")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedAutomaticDose(
             to: glucoseTargetRange,
@@ -818,7 +919,9 @@ class RecommendTempBasalTests: XCTestCase {
             basalRates: basalRateSchedule,
             maxAutomaticBolus: 5,
             partialApplicationFactor: 0.5,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose!.basalAdjustment)
@@ -827,6 +930,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testInRangeAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_in_range_and_rising")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -836,7 +940,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(1.60, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -845,6 +951,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testHighAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
+        let insulinOnBoard = 7.69
 
         var dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -854,7 +961,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(3.0, dose!.unitsPerHour)
@@ -871,7 +980,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertEqual(2.975, dose!.unitsPerHour, accuracy: 1.0 / 40.0)
@@ -880,6 +991,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testVeryLowAndRising() {
         let glucose = loadGlucoseValueFixture("recommend_temp_basal_very_low_end_in_range")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -889,7 +1001,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
         
         XCTAssertEqual(0.0, dose!.unitsPerHour)
@@ -898,6 +1012,7 @@ class RecommendTempBasalTests: XCTestCase {
     
     func testRiseAfterExponentialModelDIA() {
         let glucose = loadGlucoseValueFixture("far_future_high_bg_forecast_after_6_hours")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -907,7 +1022,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: exponentialInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -915,6 +1032,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testRiseAfterDIA() {
         let glucose = loadGlucoseValueFixture("far_future_high_bg_forecast")
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -924,7 +1042,9 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)
@@ -933,6 +1053,7 @@ class RecommendTempBasalTests: XCTestCase {
 
     func testNoInputGlucose() {
         let glucose: [GlucoseFixtureValue] = []
+        let insulinOnBoard = 7.69
 
         let dose = glucose.recommendedTempBasal(
             to: glucoseTargetRange,
@@ -941,7 +1062,184 @@ class RecommendTempBasalTests: XCTestCase {
             model: walshInsulinModel,
             basalRates: basalRateSchedule,
             maxBasalRate: maxBasalRate,
-            lastTempBasal: nil
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertNil(dose)
+    }
+
+    // Next four tests, recommended bolus is 2.30 U (no limit)
+    //   adjust IOB to modify AutomaticBolus
+
+    func testFlatAndHighAutomaticBolusNoLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+        let insulinOnBoard = 7.69
+
+        let dose = glucose.recommendedAutomaticDose(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxAutomaticBolus: maxBolus,
+            partialApplicationFactor: 1.0,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertNil(dose!.basalAdjustment)
+        XCTAssertEqual(2.30, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
+    }
+
+    func testFlatAndHighAutomaticBolusWithLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+
+        // max allowed dose will be 0.5 units
+        let maxAutoCorrection = 0.5
+        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
+
+        let dose = glucose.recommendedAutomaticDose(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxAutomaticBolus: maxBolus,
+            partialApplicationFactor: 1.0,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertNil(dose!.basalAdjustment)
+        XCTAssertEqual(maxAutoCorrection, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
+    }
+
+    func testFlatAndHighAutomaticBolusWithLimitPAF() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+
+        // max allowed dose will be 0.5 units
+        // for this test use partialApplicationFactor of 0.5, instead of 1.0
+        let maxAutoCorrection = 0.5
+        let partialApplicationFactor = 0.5
+        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
+
+        let dose = glucose.recommendedAutomaticDose(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxAutomaticBolus: maxBolus,
+            partialApplicationFactor: partialApplicationFactor,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertNil(dose!.basalAdjustment)
+        XCTAssertEqual(partialApplicationFactor * maxAutoCorrection, dose!.bolusUnits!, accuracy: 1.0 / 40.0)
+    }
+
+    func testFlatAndHighAutomaticBolusFullLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_flat_and_high")
+
+        // no automatic dose
+        let insulinOnBoard = automaticDosingIOBLimit + 0.1
+
+        let dose = glucose.recommendedAutomaticDose(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxAutomaticBolus: maxBolus,
+            partialApplicationFactor: 1.0,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertNil(dose)
+    }
+
+    // Next three test recommended TempBasal is 3.0 U/hr (no limit)
+    //   Adjust IOB to modify automatic TempBasal
+    let noLimitBasalRate = 3.0
+    let scheduledBasalRate = 0.8
+
+    func testHighAndRisingTempBasalNoLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
+
+        // no limit
+        let insulinOnBoard = 0.0
+
+        let dose = glucose.recommendedTempBasal(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: self.insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxBasalRate: maxBasalRate,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertEqual(noLimitBasalRate, dose!.unitsPerHour)
+        XCTAssertEqual(TimeInterval(minutes: 30), dose!.duration)
+    }
+
+    func testHighAndRisingTempBasalWithLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
+
+        // max allowed dose will be 0.5 units, temp basal twice that
+        let maxAutoCorrection = 0.5
+        let limitedBasalRate = scheduledBasalRate + 2.0 * maxAutoCorrection
+        let insulinOnBoard = automaticDosingIOBLimit - maxAutoCorrection
+
+        let dose = glucose.recommendedTempBasal(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: self.insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxBasalRate: maxBasalRate,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
+        )
+
+        XCTAssertEqual(limitedBasalRate, dose!.unitsPerHour)
+        XCTAssertEqual(TimeInterval(minutes: 30), dose!.duration)
+    }
+
+    func testHighAndRisingTempBasalFullLimit() {
+        let glucose = loadGlucoseValueFixture("recommend_temp_basal_high_and_rising")
+
+        // no automatic dose
+        let insulinOnBoard = automaticDosingIOBLimit + 0.1
+
+        let dose = glucose.recommendedTempBasal(
+            to: glucoseTargetRange,
+            at: glucose.first!.startDate,
+            suspendThreshold: suspendThreshold.quantity,
+            sensitivity: self.insulinSensitivitySchedule,
+            model: exponentialInsulinModel,
+            basalRates: basalRateSchedule,
+            maxBasalRate: maxBasalRate,
+            lastTempBasal: nil,
+            insulinOnBoard: insulinOnBoard,
+            automaticDosingIOBLimit: automaticDosingIOBLimit
         )
 
         XCTAssertNil(dose)

--- a/Loop/Managers/DoseMath.swift
+++ b/Loop/Managers/DoseMath.swift
@@ -424,7 +424,6 @@ extension Collection where Element: GlucoseValue {
     ///   - isBasalRateScheduleOverrideActive: A flag describing whether a basal rate schedule override is in progress
     ///   - duration: The duration of the temporary basal
     ///   - continuationInterval: The duration of time before an ongoing temp basal should be continued with a new command
-    ///   - insulinOnBoard:
     /// - Returns: The recommended dosing, or nil if no dose adjustment recommended
     func recommendedAutomaticDose(
         to correctionRange: GlucoseRangeSchedule,

--- a/Loop/Managers/DoseMath.swift
+++ b/Loop/Managers/DoseMath.swift
@@ -352,6 +352,7 @@ extension Collection where Element: GlucoseValue {
     ///   - sensitivity: The schedule of insulin sensitivities
     ///   - model: The insulin absorption model
     ///   - basalRates: The schedule of basal rates
+    ///   - additionalActiveInsulinClamp: Max amount of additional insulin above scheduled basal rate allowed to be scheduled
     ///   - maxBasalRate: The maximum allowed basal rate
     ///   - lastTempBasal: The previously set temp basal
     ///   - rateRounder: Closure that rounds recommendation to nearest supported rate. If nil, no rounding is performed
@@ -367,6 +368,7 @@ extension Collection where Element: GlucoseValue {
         model: InsulinModel,
         basalRates: BasalRateSchedule,
         maxBasalRate: Double,
+        additionalActiveInsulinClamp: Double? = nil,
         lastTempBasal: DoseEntry?,
         rateRounder: ((Double) -> Double)? = nil,
         isBasalRateScheduleOverrideActive: Bool = false,
@@ -389,6 +391,11 @@ extension Collection where Element: GlucoseValue {
             min.quantity < highBasalThreshold
         {
             maxBasalRate = scheduledBasalRate
+        }
+
+        if let additionalActiveInsulinClamp {
+            let maxThirtyMinuteRateToKeepIOBBelowLimit = additionalActiveInsulinClamp * 2.0 + scheduledBasalRate  // 30 minutes of a U/hr rate
+            maxBasalRate = Swift.min(maxThirtyMinuteRateToKeepIOBBelowLimit, maxBasalRate)
         }
 
         let temp = correction?.asTempBasal(

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1675,9 +1675,6 @@ extension LoopDataManager {
                 )
             case .tempBasalOnly:
 
-                let maxThirtyMinuteRateToKeepIOBBelowLimit = iobHeadroom * 2.0  // 30 minutes of a U/hr rate
-                let maxTempBasalRate = min(maxThirtyMinuteRateToKeepIOBBelowLimit, maxBasal!)
-
                 let temp = predictedGlucose.recommendedTempBasal(
                     to: glucoseTargetRange!,
                     at: predictedGlucose[0].startDate,
@@ -1685,7 +1682,8 @@ extension LoopDataManager {
                     sensitivity: insulinSensitivity!,
                     model: doseStore.insulinModelProvider.model(for: pumpInsulinType),
                     basalRates: basalRateSchedule!,
-                    maxBasalRate: maxTempBasalRate,
+                    maxBasalRate: maxBasal!,
+                    additionalActiveInsulinClamp: iobHeadroom,
                     lastTempBasal: lastTempBasal,
                     rateRounder: rateRounder,
                     isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1675,7 +1675,7 @@ extension LoopDataManager {
                 )
             case .tempBasalOnly:
 
-                let maxThirtyMinuteRateToKeepIOBBelowLimit = iobHeadroom / 2.0  // 30 minutes of a U/hr rate
+                let maxThirtyMinuteRateToKeepIOBBelowLimit = iobHeadroom * 2.0  // 30 minutes of a U/hr rate
                 let maxTempBasalRate = min(maxThirtyMinuteRateToKeepIOBBelowLimit, maxBasal!)
 
                 let temp = predictedGlucose.recommendedTempBasal(

--- a/Loop/Models/LoopError.swift
+++ b/Loop/Models/LoopError.swift
@@ -43,6 +43,7 @@ enum MissingDataErrorDetail: String, Codable {
     case momentumEffect
     case carbEffect
     case insulinEffect
+    case activeInsulin
     case insulinEffectIncludingPendingInsulin
     
     var localizedDetail: String {
@@ -55,6 +56,8 @@ enum MissingDataErrorDetail: String, Codable {
             return NSLocalizedString("Carb effects", comment: "Details for missing data error when carb effects are missing")
         case .insulinEffect:
             return NSLocalizedString("Insulin effects", comment: "Details for missing data error when insulin effects are missing")
+        case .activeInsulin:
+            return NSLocalizedString("Active Insulin", comment: "Details for missing data error when active insulin amount is missing")
         case .insulinEffectIncludingPendingInsulin:
             return NSLocalizedString("Insulin effects", comment: "Details for missing data error when insulin effects including pending insulin are missing")
         }
@@ -68,9 +71,7 @@ enum MissingDataErrorDetail: String, Codable {
             return nil
         case .carbEffect:
             return nil
-        case .insulinEffect:
-            return nil
-        case .insulinEffectIncludingPendingInsulin:
+        case .insulinEffect, .activeInsulin, .insulinEffectIncludingPendingInsulin:
             return nil
         }
     }

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -456,7 +456,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         }
         loopDataManager.loop()
         wait(for: [exp], timeout: 1.0)
-        let expectedAutomaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: TempBasalRecommendation(unitsPerHour: 4.577747629410191, duration: .minutes(30)))
+        let expectedAutomaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: TempBasalRecommendation(unitsPerHour: 4.55, duration: .minutes(30)))
         XCTAssertEqual(delegate.recommendation, expectedAutomaticDoseRecommendation)
         XCTAssertEqual(dosingDecisionStore.dosingDecisions.count, 1)
         if dosingDecisionStore.dosingDecisions.count == 1 {
@@ -480,7 +480,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         }
         loopDataManager.loop()
         wait(for: [exp], timeout: 1.0)
-        let expectedAutomaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: TempBasalRecommendation(unitsPerHour: 4.577747629410191, duration: .minutes(30)))
+        let expectedAutomaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: TempBasalRecommendation(unitsPerHour: 4.55, duration: .minutes(30)))
         XCTAssertNil(delegate.recommendation)
         XCTAssertEqual(dosingDecisionStore.dosingDecisions.count, 1)
         XCTAssertEqual(dosingDecisionStore.dosingDecisions[0].reason, "loop")
@@ -653,7 +653,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         }
         updateGroup.wait()
 
-        XCTAssertEqual(recommendedBasal!.unitsPerHour, 4.2, accuracy: 0.01)
+        XCTAssertEqual(recommendedBasal!.unitsPerHour, 4.25, accuracy: 0.01)
         XCTAssertEqual(insulinOnBoard?.value, 9.87)
     }
 

--- a/LoopTests/Mock Stores/MockCarbStore.swift
+++ b/LoopTests/Mock Stores/MockCarbStore.swift
@@ -124,7 +124,7 @@ extension MockCarbStore {
             return "flat_and_stable_carb_effect"
         case .highAndStable:
             return "high_and_stable_carb_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_carb_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_carb_effect"

--- a/LoopTests/Mock Stores/MockCarbStore.swift
+++ b/LoopTests/Mock Stores/MockCarbStore.swift
@@ -124,7 +124,7 @@ extension MockCarbStore {
             return "flat_and_stable_carb_effect"
         case .highAndStable:
             return "high_and_stable_carb_effect"
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return "high_and_rising_with_cob_carb_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_carb_effect"

--- a/LoopTests/Mock Stores/MockDoseStore.swift
+++ b/LoopTests/Mock Stores/MockDoseStore.swift
@@ -60,7 +60,12 @@ class MockDoseStore: DoseStoreProtocol {
     }
     
     func insulinOnBoard(at date: Date, completion: @escaping (DoseStoreResult<InsulinValue>) -> Void) {
-        completion(.failure(.configurationError))
+        switch testType {
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+            completion(.success(.init(startDate: MockDoseStore.currentDate(for: testType), value: 9.5)))
+        default:
+            completion(.failure(.configurationError))
+        }
     }
     
     func generateDiagnosticReport(_ completion: @escaping (String) -> Void) {
@@ -112,7 +117,7 @@ class MockDoseStore: DoseStoreProtocol {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -140,7 +145,7 @@ extension MockDoseStore {
             return "flat_and_stable_insulin_effect"
         case .highAndStable:
             return "high_and_stable_insulin_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_insulin_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_insulin_effect"

--- a/LoopTests/Mock Stores/MockDoseStore.swift
+++ b/LoopTests/Mock Stores/MockDoseStore.swift
@@ -61,10 +61,12 @@ class MockDoseStore: DoseStoreProtocol {
     
     func insulinOnBoard(at date: Date, completion: @escaping (DoseStoreResult<InsulinValue>) -> Void) {
         switch testType {
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .flatAndStable, .highAndFalling, .highAndStable, .lowAndFallingWithCOB, .lowWithLowTreatment:
             completion(.success(.init(startDate: MockDoseStore.currentDate(for: testType), value: 9.5)))
-        default:
-            completion(.failure(.configurationError))
+        case .autoBolusIOBClamping:
+            completion(.success(.init(startDate: MockDoseStore.currentDate(for: testType), value: 9.47)))
+        case .tempBasalIOBClamping:
+            completion(.success(.init(startDate: MockDoseStore.currentDate(for: testType), value: 9.87)))
         }
     }
     
@@ -117,7 +119,7 @@ class MockDoseStore: DoseStoreProtocol {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -145,7 +147,7 @@ extension MockDoseStore {
             return "flat_and_stable_insulin_effect"
         case .highAndStable:
             return "high_and_stable_insulin_effect"
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return "high_and_rising_with_cob_insulin_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_insulin_effect"

--- a/LoopTests/Mock Stores/MockGlucoseStore.swift
+++ b/LoopTests/Mock Stores/MockGlucoseStore.swift
@@ -112,7 +112,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_counteraction_effect"
         case .highAndStable:
             return "high_and_stable_counteraction_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_counteraction_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_counteraction_effect"
@@ -129,7 +129,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_momentum_effect"
         case .highAndStable:
             return "high_and_stable_momentum_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_momentum_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_momentum_effect"
@@ -146,7 +146,7 @@ extension MockGlucoseStore {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -163,7 +163,7 @@ extension MockGlucoseStore {
             return 123.42849966275706
         case .highAndStable:
             return 200.0
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return 129.93174411197853
         case .lowAndFallingWithCOB:
             return 75.10768374646841

--- a/LoopTests/Mock Stores/MockGlucoseStore.swift
+++ b/LoopTests/Mock Stores/MockGlucoseStore.swift
@@ -112,7 +112,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_counteraction_effect"
         case .highAndStable:
             return "high_and_stable_counteraction_effect"
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return "high_and_rising_with_cob_counteraction_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_counteraction_effect"
@@ -129,7 +129,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_momentum_effect"
         case .highAndStable:
             return "high_and_stable_momentum_effect"
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return "high_and_rising_with_cob_momentum_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_momentum_effect"
@@ -146,7 +146,7 @@ extension MockGlucoseStore {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -163,7 +163,7 @@ extension MockGlucoseStore {
             return 123.42849966275706
         case .highAndStable:
             return 200.0
-        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping, .tempBasalIOBClamping:
             return 129.93174411197853
         case .lowAndFallingWithCOB:
             return 75.10768374646841

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -784,6 +784,8 @@ fileprivate class MockLoopState: LoopState {
     
     var carbsOnBoard: CarbValue?
     
+    var insulinOnBoard: InsulinValue?
+    
     var error: LoopError?
     
     var insulinCounteractionEffects: [GlucoseEffectVelocity] = []


### PR DESCRIPTION
This replaces PR #1870.
This PR adds one safety check so that automatic dosing of insulin cannot exceed a simple ratio multiplied by a constant set in LoopConstants. It addresses the more critical portion of Issue #1863.

If this is deemed a good direction, there are some items to do:
* add proper logging
* report in the Delivery Limits section that the maximum of automatic delivery of insulin will be capped by the ratio times maxBolus to make it clear to the user
* decide what the correct ratio should be (1.2 was entered as a placeholder) - subsequently changed to 2.0.