### PR TITLE
Restore support for showing eventual blood glucose on watch

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -30,6 +30,7 @@ struct FeatureFlagConfiguration: Decodable {
     let predictedGlucoseChartClampEnabled: Bool
     let scenariosEnabled: Bool
     let sensitivityOverridesEnabled: Bool
+    let showEventualBloodGlucoseOnWatchEnabled: Bool
     let simulatedCoreDataEnabled: Bool
     let siriEnabled: Bool
     let simpleBolusCalculatorEnabled: Bool
@@ -171,6 +172,12 @@ struct FeatureFlagConfiguration: Decodable {
         self.scenariosEnabled = false
         #endif
 
+        #if SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_ENABLED
+        self.showEventualBloodGlucoseOnWatchEnabled = true
+        #else
+        self.showEventualBloodGlucoseOnWatchEnabled = false
+        #endif
+        
         #if SIMULATED_CORE_DATA_ENABLED
         self.simulatedCoreDataEnabled = true
         #else
@@ -227,6 +234,7 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* remoteOverridesEnabled: \(remoteOverridesEnabled)",
             "* scenariosEnabled: \(scenariosEnabled)",
             "* sensitivityOverridesEnabled: \(sensitivityOverridesEnabled)",
+            "* showEventualBloodGlucoseOnWatchEnabled: \(showEventualBloodGlucoseOnWatchEnabled)",
             "* simulatedCoreDataEnabled: \(simulatedCoreDataEnabled)",
             "* siriEnabled: \(siriEnabled)",
             "* automaticBolusEnabled: \(automaticBolusEnabled)",

--- a/WatchApp Extension/Controllers/HUDInterfaceController.swift
+++ b/WatchApp Extension/Controllers/HUDInterfaceController.swift
@@ -14,6 +14,7 @@ class HUDInterfaceController: WKInterfaceController {
 
     @IBOutlet weak var loopHUDImage: WKInterfaceImage!
     @IBOutlet weak var glucoseLabel: WKInterfaceLabel!
+    @IBOutlet weak var eventualGlucoseLabel: WKInterfaceLabel!
 
     var loopManager = ExtensionDelegate.shared().loopManager
 
@@ -71,12 +72,23 @@ class HUDInterfaceController: WKInterfaceController {
         if date != nil {
             glucoseLabel.setText(NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)"))
             glucoseLabel.setHidden(false)
+            
+            let showEventualGlucose = FeatureFlags.showEventualBloodGlucoseOnWatchEnabled
+            if showEventualGlucose {
+                eventualGlucoseLabel.setHidden(true)
+            }
+                
             if let glucose = activeContext.glucose, let glucoseDate = activeContext.glucoseDate, let unit = activeContext.displayGlucoseUnit, glucoseDate.timeIntervalSinceNow > -LoopCoreConstants.inputDataRecencyInterval {
                 let formatter = NumberFormatter.glucoseFormatter(for: unit)
                 
                 if let glucoseValue = formatter.string(from: glucose.doubleValue(for: unit)) {
                     let trend = activeContext.glucoseTrend?.symbol ?? ""
                     glucoseLabel.setText(glucoseValue + trend)
+                }
+                
+                if showEventualGlucose, let eventualGlucose = activeContext.eventualGlucose, let eventualGlucoseValue = formatter.string(from: eventualGlucose.doubleValue(for: unit)) {
+                    eventualGlucoseLabel.setText(eventualGlucoseValue)
+                    eventualGlucoseLabel.setHidden(false)
                 }
             }
         }

--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -34,6 +34,9 @@
                                                 <label height="1" alignment="left" hidden="YES" textAlignment="center" id="MHD-Is-5mK">
                                                     <fontDescription key="font" type="system" weight="light" pointSize="24"/>
                                                 </label>
+                                                <label height="1" alignment="right" hidden="YES" textAlignment="center" id="hOH-sV-9TN" userLabel="Eventual Glucose Label">
+                                                    <fontDescription key="font" type="system" weight="light" pointSize="24"/>
+                                                </label>
                                             </items>
                                             <variation key="device=watch42mm" height="29"/>
                                         </group>
@@ -155,6 +158,7 @@
                         <outlet property="carbsButton" destination="5iF-jW-tC8" id="him-XO-Jod"/>
                         <outlet property="carbsButtonBackground" destination="C7f-Mo-eUU" id="ere-wU-Kax"/>
                         <outlet property="carbsButtonImage" destination="4aO-ao-Sp9" id="Nlk-SP-VmT"/>
+                        <outlet property="eventualGlucoseLabel" destination="hOH-sV-9TN" id="c4T-Va-zeT"/>
                         <outlet property="glucoseLabel" destination="MHD-Is-5mK" id="MDr-iV-fr1"/>
                         <outlet property="loopHUDImage" destination="Q7C-xN-eH8" id="CIe-B3-umI"/>
                         <outlet property="overrideButton" destination="dYe-c2-Sfm" id="m7H-fY-Cxg"/>
@@ -191,6 +195,9 @@
                                                 </label>
                                                 <label height="1" alignment="right" hidden="YES" text="– – –" textAlignment="center" id="yl8-ZP-c3l">
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="font" type="system" weight="light" pointSize="24"/>
+                                                </label>
+                                                <label height="1" alignment="right" hidden="YES" textAlignment="center" id="6sn-Q8-nGV" userLabel="Eventual Glucose Label">
                                                     <fontDescription key="font" type="system" weight="light" pointSize="24"/>
                                                 </label>
                                             </items>
@@ -264,6 +271,7 @@
                     </items>
                     <variation key="device=watch38mm" spacing="5"/>
                     <connections>
+                        <outlet property="eventualGlucoseLabel" destination="6sn-Q8-nGV" id="tX0-mq-Heq"/>
                         <outlet property="glucoseLabel" destination="Dt1-kz-jMZ" id="MQj-0o-PaV"/>
                         <outlet property="glucoseScene" destination="9BI-AC-l6c" id="O4a-P8-cHI"/>
                         <outlet property="loopHUDImage" destination="ifw-dh-btK" id="Bc0-er-dfe"/>


### PR DESCRIPTION
Restores the eventual blood glucose label in the WatchApp user interface and shows/updates it on the basis of a new feature flag `showEventualBloodGlucoseOnWatchEnabled` governed by the `SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_ENABLED` compiler directive.

This is functionally identical to the code that exists in the master branch, but it's wrapped in a feature check and one additional let to ensure that the eventualGlucoseValue can be obtained.

Let me know if any further changes are needed.