### PR TITLE
reverse FeatureFlag logic for eventual glucose on watch

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -172,10 +172,11 @@ struct FeatureFlagConfiguration: Decodable {
         self.scenariosEnabled = false
         #endif
 
-        #if SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_ENABLED
-        self.showEventualBloodGlucoseOnWatchEnabled = true
-        #else
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_DISABLED
         self.showEventualBloodGlucoseOnWatchEnabled = false
+        #else
+        self.showEventualBloodGlucoseOnWatchEnabled = true
         #endif
         
         #if SIMULATED_CORE_DATA_ENABLED


### PR DESCRIPTION
Reverse the logic so that eventual glucose is shown on the watch by default.
New feature flag is SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_DISABLED
* test with no flag, eventual glucose shows on watch
* test with flag: SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_DISABLED, eventual glucose on watch is not shown
* test with "temporary flag", no longer used: SHOW_EVENTUAL_BLOOD_GLUCOSE_ON_WATCH_ENABLED
  * app builds
  * eventual glucose shows on watch