### PR TITLE
Adds sorting to AlertView-like dialog for adding a CGM

### DIFF
--- a/Loop/Extensions/UIAlertController.swift
+++ b/Loop/Extensions/UIAlertController.swift
@@ -103,14 +103,17 @@ extension UIAlertController {
             preferredStyle: .actionSheet
         )
         
-        for availableCGMManager in availableCGMManagers {
+        for availableCGMManager in availableCGMManagers.sorted(by: {$0.localizedTitle < $1.localizedTitle}) {
             addAction(UIAlertAction(
                 title: availableCGMManager.localizedTitle,
+                
                 style: .default,
                 handler: { (_) in
                     selectionHandler(availableCGMManager.identifier)
             }
-            ))
+            )
+            
+            )
         }
     }
 

--- a/Loop/Extensions/UIAlertController.swift
+++ b/Loop/Extensions/UIAlertController.swift
@@ -106,14 +106,11 @@ extension UIAlertController {
         for availableCGMManager in availableCGMManagers.sorted(by: {$0.localizedTitle < $1.localizedTitle}) {
             addAction(UIAlertAction(
                 title: availableCGMManager.localizedTitle,
-                
                 style: .default,
                 handler: { (_) in
                     selectionHandler(availableCGMManager.identifier)
             }
-            )
-            
-            )
+            ))
         }
     }
 


### PR DESCRIPTION
Currently the availableCGMs are unsorted when the user taps the 'Add CGM' pill in UIAlertController, where they're sorted by LocalizedTitle when triggered from settings. 

This PR corrects this difference, making the CGMs easier to parse for new users.

Before:
<img src="https://user-images.githubusercontent.com/5185892/210609281-baeec1c4-bac2-4374-9806-c7e430fe072f.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/5185892/210609018-86b0f92f-c29d-42d7-a9ca-3ba0b9deec3f.png" width="300">