### PR TITLE
Prevent Automatic Dosing with Future Glucose

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1130,7 +1130,7 @@ extension LoopDataManager {
     ///     - LoopError.missingDataError
     ///     - LoopError.configurationError
     ///     - LoopError.glucoseTooOld
-    ///     - LoopError.glucoseInFuture
+    ///     - LoopError.invalidFutureGlucose
     ///     - LoopError.pumpDataTooOld
     fileprivate func predictGlucose(
         startingAt startingGlucoseOverride: GlucoseValue? = nil,
@@ -1158,7 +1158,7 @@ extension LoopDataManager {
         }
 
         guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.futureGlucoseDataInterval else {
-            throw LoopError.glucoseInFuture(date: lastGlucoseDate)
+            throw LoopError.invalidFutureGlucose(date: lastGlucoseDate)
         }
 
         guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
@@ -1395,7 +1395,7 @@ extension LoopDataManager {
     /// - Throws:
     ///     - LoopError.missingDataError
     ///     - LoopError.glucoseTooOld
-    ///     - LoopError.glucoseInFuture
+    ///     - LoopError.invalidFutureGlucose
     ///     - LoopError.pumpDataTooOld
     ///     - LoopError.configurationError
     fileprivate func recommendBolusValidatingDataRecency<Sample: GlucoseValue>(forPrediction predictedGlucose: [Sample],
@@ -1412,7 +1412,7 @@ extension LoopDataManager {
         }
 
         guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.inputDataRecencyInterval else {
-            throw LoopError.glucoseInFuture(date: lastGlucoseDate)
+            throw LoopError.invalidFutureGlucose(date: lastGlucoseDate)
         }
 
         guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
@@ -1526,7 +1526,7 @@ extension LoopDataManager {
     /// - Throws:
     ///     - LoopError.configurationError
     ///     - LoopError.glucoseTooOld
-    ///     - LoopError.glucoseInFuture
+    ///     - LoopError.invalidFutureGlucose
     ///     - LoopError.missingDataError
     ///     - LoopError.pumpDataTooOld
     private func updatePredictedGlucoseAndRecommendedDose(with dosingDecision: StoredDosingDecision) -> (StoredDosingDecision, LoopError?) {
@@ -1551,7 +1551,7 @@ extension LoopDataManager {
         }
 
         if glucose.startDate.timeIntervalSince(startDate) > LoopCoreConstants.inputDataRecencyInterval {
-            errors.append(.glucoseInFuture(date: glucose.startDate))
+            errors.append(.invalidFutureGlucose(date: glucose.startDate))
         }
 
         let pumpStatusDate = doseStore.lastAddedPumpData

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1130,6 +1130,7 @@ extension LoopDataManager {
     ///     - LoopError.missingDataError
     ///     - LoopError.configurationError
     ///     - LoopError.glucoseTooOld
+    ///     - LoopError.glucoseInFuture
     ///     - LoopError.pumpDataTooOld
     fileprivate func predictGlucose(
         startingAt startingGlucoseOverride: GlucoseValue? = nil,
@@ -1154,6 +1155,10 @@ extension LoopDataManager {
 
         guard now().timeIntervalSince(lastGlucoseDate) <= LoopCoreConstants.inputDataRecencyInterval else {
             throw LoopError.glucoseTooOld(date: glucose.startDate)
+        }
+
+        guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.inputDataRecencyInterval else {
+            throw LoopError.glucoseInFuture(date: lastGlucoseDate)
         }
 
         guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
@@ -1390,6 +1395,7 @@ extension LoopDataManager {
     /// - Throws:
     ///     - LoopError.missingDataError
     ///     - LoopError.glucoseTooOld
+    ///     - LoopError.glucoseInFuture
     ///     - LoopError.pumpDataTooOld
     ///     - LoopError.configurationError
     fileprivate func recommendBolusValidatingDataRecency<Sample: GlucoseValue>(forPrediction predictedGlucose: [Sample],
@@ -1403,6 +1409,10 @@ extension LoopDataManager {
 
         guard now().timeIntervalSince(lastGlucoseDate) <= LoopCoreConstants.inputDataRecencyInterval else {
             throw LoopError.glucoseTooOld(date: glucose.startDate)
+        }
+
+        guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.inputDataRecencyInterval else {
+            throw LoopError.glucoseInFuture(date: lastGlucoseDate)
         }
 
         guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
@@ -1516,6 +1526,7 @@ extension LoopDataManager {
     /// - Throws:
     ///     - LoopError.configurationError
     ///     - LoopError.glucoseTooOld
+    ///     - LoopError.glucoseInFuture
     ///     - LoopError.missingDataError
     ///     - LoopError.pumpDataTooOld
     private func updatePredictedGlucoseAndRecommendedDose(with dosingDecision: StoredDosingDecision) -> (StoredDosingDecision, LoopError?) {
@@ -1537,6 +1548,10 @@ extension LoopDataManager {
 
         if startDate.timeIntervalSince(glucose.startDate) > LoopCoreConstants.inputDataRecencyInterval {
             errors.append(.glucoseTooOld(date: glucose.startDate))
+        }
+
+        if glucose.startDate.timeIntervalSince(startDate) > LoopCoreConstants.inputDataRecencyInterval {
+            errors.append(.glucoseInFuture(date: glucose.startDate))
         }
 
         let pumpStatusDate = doseStore.lastAddedPumpData

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1157,7 +1157,7 @@ extension LoopDataManager {
             throw LoopError.glucoseTooOld(date: glucose.startDate)
         }
 
-        guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.inputDataRecencyInterval else {
+        guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.futureGlucoseDataInterval else {
             throw LoopError.glucoseInFuture(date: lastGlucoseDate)
         }
 

--- a/Loop/Models/LoopError.swift
+++ b/Loop/Models/LoopError.swift
@@ -89,6 +89,9 @@ enum LoopError: Error {
     // Glucose data is too old to perform action
     case glucoseTooOld(date: Date)
 
+    // Glucose data is in the future
+    case glucoseInFuture(date: Date)
+
     // Pump data is too old to perform action
     case pumpDataTooOld(date: Date)
 
@@ -120,6 +123,8 @@ extension LoopError {
             return "missingDataError"
         case .glucoseTooOld:
             return "glucoseTooOld"
+        case .glucoseInFuture:
+            return "glucoseInFuture"
         case .pumpDataTooOld:
             return "pumpDataTooOld"
         case .recommendationExpired:
@@ -141,6 +146,8 @@ extension LoopError {
         case .missingDataError(let detail):
             details["detail"] = detail.rawValue
         case .glucoseTooOld(let date):
+            details["date"] = StoredDosingDecisionIssue.description(for: date)
+        case .glucoseInFuture(let date):
             details["date"] = StoredDosingDecisionIssue.description(for: date)
         case .pumpDataTooOld(let date):
             details["date"] = StoredDosingDecisionIssue.description(for: date)
@@ -183,6 +190,9 @@ extension LoopError: LocalizedError {
         case .glucoseTooOld(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
             return String(format: NSLocalizedString("Glucose data is %1$@ old", comment: "The error message when glucose data is too old to be used. (1: glucose data age in minutes)"), minutes)
+        case .glucoseInFuture(let date):
+            let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
+            return String(format: NSLocalizedString("Glucose data is %1$@ in the future", comment: "The error message when glucose data is in the future to be used. (1: glucose data time in future in minutes)"), minutes)
         case .pumpDataTooOld(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
             return String(format: NSLocalizedString("Pump data is %1$@ old", comment: "The error message when pump data is too old to be used. (1: pump data age in minutes)"), minutes)

--- a/Loop/Models/LoopError.swift
+++ b/Loop/Models/LoopError.swift
@@ -192,7 +192,7 @@ extension LoopError: LocalizedError {
             return String(format: NSLocalizedString("Glucose data is %1$@ old", comment: "The error message when glucose data is too old to be used. (1: glucose data age in minutes)"), minutes)
         case .glucoseInFuture(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
-            return String(format: NSLocalizedString("Glucose data is %1$@ in the future", comment: "The error message when glucose data is in the future to be used. (1: glucose data time in future in minutes)"), minutes)
+            return String(format: NSLocalizedString("Invalid glucose reading with a timestamp that is %1$@ in the future", comment: "The error message when glucose data is in the future. (1: glucose data time in future in minutes)"), minutes)
         case .pumpDataTooOld(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
             return String(format: NSLocalizedString("Pump data is %1$@ old", comment: "The error message when pump data is too old to be used. (1: pump data age in minutes)"), minutes)

--- a/Loop/Models/LoopError.swift
+++ b/Loop/Models/LoopError.swift
@@ -90,7 +90,7 @@ enum LoopError: Error {
     case glucoseTooOld(date: Date)
 
     // Glucose data is in the future
-    case glucoseInFuture(date: Date)
+    case invalidFutureGlucose(date: Date)
 
     // Pump data is too old to perform action
     case pumpDataTooOld(date: Date)
@@ -123,8 +123,8 @@ extension LoopError {
             return "missingDataError"
         case .glucoseTooOld:
             return "glucoseTooOld"
-        case .glucoseInFuture:
-            return "glucoseInFuture"
+        case .invalidFutureGlucose:
+            return "invalidFutureGlucose"
         case .pumpDataTooOld:
             return "pumpDataTooOld"
         case .recommendationExpired:
@@ -147,7 +147,7 @@ extension LoopError {
             details["detail"] = detail.rawValue
         case .glucoseTooOld(let date):
             details["date"] = StoredDosingDecisionIssue.description(for: date)
-        case .glucoseInFuture(let date):
+        case .invalidFutureGlucose(let date):
             details["date"] = StoredDosingDecisionIssue.description(for: date)
         case .pumpDataTooOld(let date):
             details["date"] = StoredDosingDecisionIssue.description(for: date)
@@ -190,7 +190,7 @@ extension LoopError: LocalizedError {
         case .glucoseTooOld(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
             return String(format: NSLocalizedString("Glucose data is %1$@ old", comment: "The error message when glucose data is too old to be used. (1: glucose data age in minutes)"), minutes)
-        case .glucoseInFuture(let date):
+        case .invalidFutureGlucose(let date):
             let minutes = formatter.string(from: -date.timeIntervalSinceNow) ?? ""
             return String(format: NSLocalizedString("Invalid glucose reading with a timestamp that is %1$@ in the future", comment: "The error message when glucose data is in the future. (1: glucose data time in future in minutes)"), minutes)
         case .pumpDataTooOld(let date):

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -674,7 +674,7 @@ final class BolusEntryViewModel: ObservableObject {
             switch error {
             case LoopError.missingDataError(.glucose), LoopError.glucoseTooOld:
                 notice = .staleGlucoseData
-            case LoopError.glucoseInFuture:
+            case LoopError.invalidFutureGlucose:
                 notice = .futureGlucoseData
             case LoopError.pumpDataTooOld:
                 notice = .stalePumpData

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -76,6 +76,7 @@ final class BolusEntryViewModel: ObservableObject {
         case predictedGlucoseBelowSuspendThreshold(suspendThreshold: HKQuantity)
         case glucoseBelowTarget
         case staleGlucoseData
+        case futureGlucoseData
         case stalePumpData
     }
 
@@ -668,6 +669,8 @@ final class BolusEntryViewModel: ObservableObject {
             switch error {
             case LoopError.missingDataError(.glucose), LoopError.glucoseTooOld:
                 notice = .staleGlucoseData
+            case LoopError.missingDataError(.glucose), LoopError.glucoseInFuture:
+                notice = .futureGlucoseData
             case LoopError.pumpDataTooOld:
                 notice = .stalePumpData
             default:

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -674,7 +674,7 @@ final class BolusEntryViewModel: ObservableObject {
             switch error {
             case LoopError.missingDataError(.glucose), LoopError.glucoseTooOld:
                 notice = .staleGlucoseData
-            case LoopError.missingDataError(.glucose), LoopError.glucoseInFuture:
+            case LoopError.glucoseInFuture:
                 notice = .futureGlucoseData
             case LoopError.pumpDataTooOld:
                 notice = .stalePumpData

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -334,6 +334,11 @@ struct BolusEntryView: View {
                 title: Text("No Recent Glucose Data", comment: "Title for bolus screen notice when glucose data is missing or stale"),
                 caption: Text("Enter a blood glucose from a meter for a recommended bolus amount.", comment: "Caption for bolus screen notice when glucose data is missing or stale")
             )
+        case .futureGlucoseData:
+            return WarningView(
+                title: Text("Glucose in Future", comment: "Title for bolus screen notice when glucose data is in the future"),
+                caption: Text("Check for data in the future on phone.", comment: "Caption for bolus screen notice when glucose data is in the future")
+            )
         case .stalePumpData:
             return WarningView(
                 title: Text("No Recent Pump Data", comment: "Title for bolus screen notice when pump data is missing or stale"),

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -337,7 +337,7 @@ struct BolusEntryView: View {
         case .futureGlucoseData:
             return WarningView(
                 title: Text("Invalid Future Glucose", comment: "Title for bolus screen notice when glucose data is in the future"),
-                caption: Text("Check for device time and/or remove any invalid data from Apple Health.", comment: "Caption for bolus screen notice when glucose data is in the future")
+                caption: Text("Check your device time and/or remove any invalid data from Apple Health.", comment: "Caption for bolus screen notice when glucose data is in the future")
             )
         case .stalePumpData:
             return WarningView(

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -336,8 +336,8 @@ struct BolusEntryView: View {
             )
         case .futureGlucoseData:
             return WarningView(
-                title: Text("Glucose in Future", comment: "Title for bolus screen notice when glucose data is in the future"),
-                caption: Text("Check for data in the future on phone.", comment: "Caption for bolus screen notice when glucose data is in the future")
+                title: Text("Invalid Future Glucose", comment: "Title for bolus screen notice when glucose data is in the future"),
+                caption: Text("Check for device time and/or remove any invalid data from Apple Health.", comment: "Caption for bolus screen notice when glucose data is in the future")
             )
         case .stalePumpData:
             return WarningView(

--- a/LoopCore/LoopCoreConstants.swift
+++ b/LoopCore/LoopCoreConstants.swift
@@ -13,6 +13,9 @@ public enum LoopCoreConstants {
     /// The amount of time since a given date that input data should be considered valid
     public static let inputDataRecencyInterval = TimeInterval(minutes: 15)
     
+    /// The amount of time in the future a glucose value should be considered valid
+    public static let futureGlucoseDataInterval = TimeInterval(minutes: 5)
+
     public static let defaultCarbAbsorptionTimes: CarbStore.DefaultAbsorptionTimes = (fast: .minutes(30), medium: .hours(3), slow: .hours(5))
 
     /// How much historical glucose to include in a dosing decision

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -358,9 +358,9 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertEqual(.staleGlucoseData, bolusEntryViewModel.activeNotice)
     }
 
-    func testUpdateRecommendedBolusThrowsGlucoseInFuture() async throws {
+    func testUpdateRecommendedBolusThrowsInvalidFutureGlucose() async throws {
         XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
-        delegate.loopState.bolusRecommendationError = LoopError.glucoseInFuture(date: now)
+        delegate.loopState.bolusRecommendationError = LoopError.invalidFutureGlucose(date: now)
         await bolusEntryViewModel.update()
         XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
         let recommendedBolus = bolusEntryViewModel.recommendedBolus

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -348,6 +348,26 @@ class BolusEntryViewModelTests: XCTestCase {
         XCTAssertEqual(.stalePumpData, bolusEntryViewModel.activeNotice)
     }
 
+    func testUpdateRecommendedBolusThrowsGlucoseTooOld() async throws {
+        XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
+        delegate.loopState.bolusRecommendationError = LoopError.glucoseTooOld(date: now)
+        await bolusEntryViewModel.update()
+        XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
+        let recommendedBolus = bolusEntryViewModel.recommendedBolus
+        XCTAssertNil(recommendedBolus)
+        XCTAssertEqual(.staleGlucoseData, bolusEntryViewModel.activeNotice)
+    }
+
+    func testUpdateRecommendedBolusThrowsGlucoseInFuture() async throws {
+        XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
+        delegate.loopState.bolusRecommendationError = LoopError.glucoseInFuture(date: now)
+        await bolusEntryViewModel.update()
+        XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
+        let recommendedBolus = bolusEntryViewModel.recommendedBolus
+        XCTAssertNil(recommendedBolus)
+        XCTAssertEqual(.futureGlucoseData, bolusEntryViewModel.activeNotice)
+    }
+
     func testUpdateRecommendedBolusThrowsOtherError() async throws {
         XCTAssertFalse(bolusEntryViewModel.isBolusRecommended)
         delegate.loopState.bolusRecommendationError = LoopError.pumpSuspended


### PR DESCRIPTION
This ~~is a work-in-progress~~ PR is in response to Issue #1890.

Configuration
* Test phone configured with future glucose and dosing strategy set to automatic bolus.
* Running dev, phone automatically boluses every 5 minutes, creating undesirable levels of IOB.
* With commit (updated to) fffcf505 of this branch, tested that the future glucose is detected and automated dosing stops

Display to User:
* Loop goes red over next 15 minutes, but need to add a better alerting system
* Tapping on glucose leads to the CGM
* Main screen continues to show the future glucose value (not CGM value)
* Tapping on bolus shows no recommendation with the new "Glucose in Future: Check for data in the future on phone" warning
* Tapping on meal entry allows the meal entry, but meal bolus screen is set for Save without Bolusing (no recommended bolus) with Glucose in Future warning
* In both cases, can bolus successfully if bolus value is added

Edited to change figure to that displayed with commit: ffbdc469

![IMG_F8750773B91E-1](https://user-images.githubusercontent.com/19607791/211367967-d109393f-1c52-4f42-83c0-fc4d83ddd71e.jpeg)


Debug log message:
* 2023-01-09 08:01:34.624572-0800 Loop[47592:5278115] [LoopDataManager] glucoseInFuture(date: 2023-01-10 14:11:00 +0000)

