### PR TITLE
Open Loop with "Loop://" URLs from other applications

### DIFF
--- a/Loop.xcconfig
+++ b/Loop.xcconfig
@@ -45,6 +45,9 @@ LOOP_PROVISIONING_PROFILE_SPECIFIER_WATCHAPP_EXTENSION_RELEASE =
 // Min iOS Version [DEFAULT]					
 IPHONEOS_DEPLOYMENT_TARGET = 15.1
 
+// Base string for opening app via URL [DEFAULT]
+URL_SCHEME_NAME = $(MAIN_APP_DISPLAY_NAME)
+
 // Version [DEFAULT]
 #include? "Version.xcconfig"
 

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -91,34 +91,4 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, WindowProvider {
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return loopAppManager.supportedInterfaceOrientations
     }
-    
-    // MARK: - UIApplicationDelegate - handle external URLs
-
-    func application(_ application: UIApplication,
-                     open url: URL,
-                     options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
-
-        // Process the URL.
-        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true), let linkTarget = components.host else {
-            // No sub-path specified
-            return true
-        }
-        
-        // Below examples would call something like the function presentCarbEntryScreen defined in StatusTableViewController; not sure if that type of code has to all be copied here, or if those various functions (e.g. carb entry, bolus view, settings) should be put elsewhere, or could be repurposed from existing files.
-
-        switch linkTarget.lowercased() {
-        case "carbs" :
-            // open carb entry view controller
-            return true
-        case "bolus" :
-            // open bolus view controller
-            return true
-        case "settings" :
-            // open settings view
-            return true
-        default :
-            return true
-        }
-    }
-  
 }

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -99,16 +99,26 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, WindowProvider {
                      options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
 
         // Process the URL.
-        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true), components.host != "" else {
+        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true), let linkTarget = components.host else {
             // No sub-path specified
             return true
         }
         
-        // Could be a case statement if more than one deep link defined
-        if components.host == "carbs" {
-            // Here we would call something like the function presentCarbEntryScreen defined in StatusTableViewController; not sure if that type of code has to all be copied here, or if those various functions (e.g. carb entry, bolus view, settings) should be put elsewhere, or could be repurposed from existing files.
+        // Below examples would call something like the function presentCarbEntryScreen defined in StatusTableViewController; not sure if that type of code has to all be copied here, or if those various functions (e.g. carb entry, bolus view, settings) should be put elsewhere, or could be repurposed from existing files.
+
+        switch linkTarget.lowercased() {
+        case "carbs" :
+            // open carb entry view controller
+            return true
+        case "bolus" :
+            // open bolus view controller
+            return true
+        case "settings" :
+            // open settings view
+            return true
+        default :
+            return true
         }
-        return true
     }
   
 }

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -91,4 +91,24 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, WindowProvider {
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return loopAppManager.supportedInterfaceOrientations
     }
+    
+    // MARK: - UIApplicationDelegate - handle external URLs
+
+    func application(_ application: UIApplication,
+                     open url: URL,
+                     options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
+
+        // Process the URL.
+        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true), components.host != "" else {
+            // No sub-path specified
+            return true
+        }
+        
+        // Could be a case statement if more than one deep link defined
+        if components.host == "carbs" {
+            // Here we would call something like the function presentCarbEntryScreen defined in StatusTableViewController; not sure if that type of code has to all be copied here, or if those various functions (e.g. carb entry, bolus view, settings) should be put elsewhere, or could be repurposed from existing files.
+        }
+        return true
+    }
+  
 }

--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -31,9 +31,13 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
+				<string>$(URL_SCHEME_NAME)</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
This PR defines a general URL scheme for opening Loop from other applications.  There is a config variable that defines the URL to use, which by default is the app's display name.  I'll submit a separate PR to LoopWorkspace with a placeholder override variable showing how to override that. 

There is skeleton code that extracts the rest of the URL so that URLs like "Loop://bolus" could be used to link to the Bolus view directly, but right now I'm unsure of the right place/method for doing that.  I thought I'd start by PR'ing this part to get started, and perhaps you could advise on next steps for the deeper links. 