### PR TITLE
Re-add `ckcomplication.strings` to project manifest

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		4FF4D0F81E1725B000846527 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F54561D287FDB002A9274 /* NibLoadable.swift */; };
 		4FF4D1001E18374700846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
 		4FF4D1011E18375000846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
+		63F5E17C297DDF3900A62D4B /* ckcomplication.strings in Resources */ = {isa = PBXBuildFile; fileRef = 63F5E17A297DDF3900A62D4B /* ckcomplication.strings */; };
 		7D23667D21250C7E0028B67D /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D23667C21250C7E0028B67D /* LocalizedString.swift */; };
 		7D7076351FE06EDE004AC8EA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D7076371FE06EDE004AC8EA /* Localizable.strings */; };
 		7D7076451FE06EE0004AC8EA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D7076471FE06EE0004AC8EA /* InfoPlist.strings */; };
@@ -1073,6 +1074,7 @@
 		4FDDD23620DC51DF00D04B16 /* LoopDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopDataManager.swift; sourceTree = "<group>"; };
 		4FF4D0FF1E18374700846527 /* WatchContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchContext.swift; sourceTree = "<group>"; };
 		4FFEDFBE20E5CF22000BFC58 /* ChartHUDController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartHUDController.swift; sourceTree = "<group>"; };
+		63F5E17B297DDF3900A62D4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/ckcomplication.strings; sourceTree = "<group>"; };
 		7D199D93212A067600241026 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		7D199D94212A067600241026 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/MainInterface.strings; sourceTree = "<group>"; };
 		7D199D95212A067600241026 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Interface.strings; sourceTree = "<group>"; };
@@ -1961,6 +1963,7 @@
 		43A943821B926B7B0051FA24 /* WatchApp Extension */ = {
 			isa = PBXGroup;
 			children = (
+				63F5E17A297DDF3900A62D4B /* ckcomplication.strings */,
 				7D7076601FE06EE3004AC8EA /* Localizable.strings */,
 				43D533BB1CFD1DD7009E3085 /* WatchApp Extension.entitlements */,
 				43A943911B926B7B0051FA24 /* Info.plist */,
@@ -3314,6 +3317,7 @@
 				7D70765E1FE06EE3004AC8EA /* Localizable.strings in Resources */,
 				4B67E2C8289B4EDB002D92AF /* InfoPlist.strings in Resources */,
 				43A943901B926B7B0051FA24 /* Assets.xcassets in Resources */,
+				63F5E17C297DDF3900A62D4B /* ckcomplication.strings in Resources */,
 				B405E35924D2A75B00DD058D /* DerivedAssets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4298,6 +4302,14 @@
 				F5E0BDD627E1D71D0033557E /* he */,
 			);
 			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+		63F5E17A297DDF3900A62D4B /* ckcomplication.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				63F5E17B297DDF3900A62D4B /* Base */,
+			);
+			name = ckcomplication.strings;
 			sourceTree = "<group>";
 		};
 		7D7076371FE06EDE004AC8EA /* Localizable.strings */ = {


### PR DESCRIPTION
Closes #1596 

It appears that the file **ckcomplication.strings** which is referenced [here](https://github.com/LoopKit/Loop/blob/71de4d05b1b18241e697d380078be6d0d3dc4f14/WatchApp%20Extension/Extensions/CLKComplicationTemplate.swift#L131) was [accidentally](https://loop.zulipchat.com/#narrow/stream/144111-general/topic/utilitarianlargeflat.20on.20watch/near/189617223) removed as apart of [this PR](https://github.com/LoopKit/Loop/commit/b4189bcae6a353398aeacf59276df1e98ef266fd#diff-f0aa8d568dbfc3e4be53b044c73a1d372fb8a8b8286b2f2d4afcc757b6da79b2L1344).

This would explain the issue reported in #1596.

Before
![before](https://user-images.githubusercontent.com/16397058/213941587-d070e4af-770b-4e98-b884-7cf107676a4c.PNG)

After
![after](https://user-images.githubusercontent.com/16397058/213941592-d3ffb580-b287-4c10-9d8c-af719b927533.PNG)