### PR TITLE
Rename flag for disabling remote commands

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -26,7 +26,7 @@ struct FeatureFlagConfiguration: Decodable {
     let observeHealthKitCarbSamplesFromOtherApps: Bool
     let observeHealthKitDoseSamplesFromOtherApps: Bool
     let observeHealthKitGlucoseSamplesFromOtherApps: Bool
-    let remoteOverridesEnabled: Bool
+    let remoteCommandsEnabled: Bool
     let predictedGlucoseChartClampEnabled: Bool
     let scenariosEnabled: Bool
     let sensitivityOverridesEnabled: Bool
@@ -161,10 +161,10 @@ struct FeatureFlagConfiguration: Decodable {
         #endif
 
         // Swift compiler config is inverse, since the default state is enabled.
-        #if REMOTE_OVERRIDES_DISABLED
-        self.remoteOverridesEnabled = false
+        #if REMOTE_COMMANDS_DISABLED || REMOTE_OVERRIDES_DISABLED //REMOTE_OVERRIDES_DISABLED: backwards compatibility of Loop 3 & prior
+        self.remoteCommandsEnabled = false
         #else
-        self.remoteOverridesEnabled = true
+        self.remoteCommandsEnabled = true
         #endif
         
         #if SCENARIOS_ENABLED
@@ -240,7 +240,7 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* observeHealthKitDoseSamplesFromOtherApps: \(observeHealthKitDoseSamplesFromOtherApps)",
             "* observeHealthKitGlucoseSamplesFromOtherApps: \(observeHealthKitGlucoseSamplesFromOtherApps)",
             "* predictedGlucoseChartClampEnabled: \(predictedGlucoseChartClampEnabled)",
-            "* remoteOverridesEnabled: \(remoteOverridesEnabled)",
+            "* remoteCommandsEnabled: \(remoteCommandsEnabled)",
             "* scenariosEnabled: \(scenariosEnabled)",
             "* sensitivityOverridesEnabled: \(sensitivityOverridesEnabled)",
             "* showEventualBloodGlucoseOnWatchEnabled: \(showEventualBloodGlucoseOnWatchEnabled)",

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1347,8 +1347,8 @@ extension DeviceDataManager {
             log.default("Remote Notification: Finished handling")
         }
         
-        guard FeatureFlags.remoteOverridesEnabled else {
-            log.error("Remote Notification: Overrides not enabled.")
+        guard FeatureFlags.remoteCommandsEnabled else {
+            log.error("Remote Notification: Remote Commands not enabled.")
             return
         }
         

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -106,7 +106,7 @@ class LoopAppManager: NSObject {
 
         registerBackgroundTasks()
 
-        if FeatureFlags.remoteOverridesEnabled {
+        if FeatureFlags.remoteCommandsEnabled {
             DispatchQueue.main.async {
 #if targetEnvironment(simulator)
                 self.remoteNotificationRegistrationDidFinish(.failure(SimulatorError.remoteNotificationsNotAvailable))

--- a/Loop/Managers/SettingsManager.swift
+++ b/Loop/Managers/SettingsManager.swift
@@ -160,7 +160,7 @@ class SettingsManager {
 
         latestSettings = mergedSettings
 
-        if remoteNotificationRegistrationResult == nil && FeatureFlags.remoteOverridesEnabled {
+        if remoteNotificationRegistrationResult == nil && FeatureFlags.remoteCommandsEnabled {
             // remote notification registration not finished
             return
         }


### PR DESCRIPTION
The build flag for disabling remote commands is misleading --  REMOTE_OVERRIDES_DISABLED -- as it more generally is used for disabling all commands (bolus and carbs). 

This PR will rename the flag to REMOTE_COMMANDS_DISABLED while continuing to support the old flag so users are not opted-into remote commands with this change.

### Testing

I did some checks that building with both REMOTE_OVERRIDES_DISABLED and REMOTE_COMMANDS_DISABLED set disables remote commands. 