### PR TITLE
Add vertical time bars to charts

### DIFF
--- a/LoopUI/Charts/COBChart.swift
+++ b/LoopUI/Charts/COBChart.swift
@@ -74,13 +74,16 @@ public extension COBChart {
             )
         }
 
+        let currentTimeLineLayer = VerticalTimeChartLine.create(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis)
+        
         let layers: [ChartLayer?] = [
             gridLayer,
             xAxisLayer,
             yAxisLayer,
             cobChartCache?.highlightLayer,
             cobArea,
-            cobLine
+            cobLine,
+            currentTimeLineLayer,
         ]
 
         return Chart(frame: frame, innerFrame: innerFrame, settings: chartSettings, layers: layers.compactMap { $0 })

--- a/LoopUI/Charts/DoseChart.swift
+++ b/LoopUI/Charts/DoseChart.swift
@@ -128,6 +128,8 @@ public extension DoseChart {
             )
         }
 
+        let currentTimeLineLayer = VerticalTimeChartLine.create(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis)
+
         let layers: [ChartLayer?] = [
             gridLayer,
             xAxisLayer,
@@ -136,7 +138,8 @@ public extension DoseChart {
             doseChartCache?.highlightLayer,
             doseArea,
             doseLine,
-            bolusLayer
+            bolusLayer,
+            currentTimeLineLayer,
         ]
 
         let chart = Chart(frame: frame, innerFrame: innerFrame, settings: chartSettings, layers: layers.compactMap { $0 })

--- a/LoopUI/Charts/IOBChart.swift
+++ b/LoopUI/Charts/IOBChart.swift
@@ -88,6 +88,8 @@ public extension IOBChart {
             )
         }
 
+        let currentTimeLineLayer = VerticalTimeChartLine.create(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis)
+        
         let layers: [ChartLayer?] = [
             gridLayer,
             xAxisLayer,
@@ -96,6 +98,7 @@ public extension IOBChart {
             iobChartCache?.highlightLayer,
             iobArea,
             iobLine,
+            currentTimeLineLayer,
         ]
 
         return Chart(frame: frame, innerFrame: innerFrame, settings: chartSettings, layers: layers.compactMap { $0 })

--- a/LoopUI/Models/VerticalTimeChartLine.swift
+++ b/LoopUI/Models/VerticalTimeChartLine.swift
@@ -1,0 +1,25 @@
+//
+//  CurrentTimeChartPointsViewsLayer.swift
+//  LoopUI
+//
+//  Created by Chris Almond on 3/12/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftCharts
+
+class VerticalTimeChartLine {
+    static var defaultRed: CGColor = .init(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.5)
+    
+    static func create(xAxis: ChartAxis, yAxis: ChartAxis, date: Date = Date.now, color: CGColor = defaultRed) -> ChartPointsViewsLayer<ChartPoint, UIView> {
+        let currentTimeChartPoint = ChartPoint(x: ChartAxisValueDouble(date.timeIntervalSince1970), y: ChartAxisValueDouble(0))
+
+        return ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, chartPoints: [currentTimeChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+            let width: CGFloat = 1
+            let viewFrame = CGRect(x: chartPointModel.screenLoc.x, y: 0, width: width, height: chart.contentView.bounds.size.height)
+            let view = UIView(frame: viewFrame)
+            view.layer.backgroundColor = color
+            return view
+        })
+    }
+}


### PR DESCRIPTION
### Add a red vertical "current time line" to indicate the current time on charts. 

I have found this useful when looking at the **IOB, iDelivery, and COB** charts to see "where are we?" at a quick glance. 

Rationale: Since the time windows included on the charts roll forward on an hourly(?) cadence in chunks, it becomes difficult for a user to distinguish where they are within a basal adjustment window or active carb period.

1. This PR adds the utility function and adds this line exclusively to the loop charts that do **not** include a _past_ vs _future_ delineation. The historical vs predicted glucose chart distinguishes past vs future using dots and dashes, which I personally find effective, so I did not add this layer to that chart.
2. The "current time line" stays in the appropriate screen position regardless of if the phone is in portrait or landscape orientation. Screenshots included

This is one of a handful of small UI enhancements I have locally, so offering it up to see if there's interest.

Screenshots: 
![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 00 13 15](https://user-images.githubusercontent.com/47440708/224912000-85af6665-aa0e-42a4-a496-75dc634da727.png)
![FullPortraitDark](https://user-images.githubusercontent.com/47440708/224912002-fcc81c9b-ad92-42b0-89bc-2c06c4aa17ca.PNG)
![GlucoseLandscapeDark](https://user-images.githubusercontent.com/47440708/224912008-84bfae4f-863b-49a4-b18a-1cd64a16bf07.PNG)
![InsulinAndCarbsDark](https://user-images.githubusercontent.com/47440708/224912011-0fc03637-ff99-44a8-8c35-872f2d458cdd.PNG)
![InsulinDark](https://user-images.githubusercontent.com/47440708/224912013-c7b80c61-7156-44d4-b142-bfa0adef6869.PNG)
![Simulator Screen Shot - iPhone 14 - 2023-03-13 at 23 56 33](https://user-images.githubusercontent.com/47440708/224912014-3d668df7-fea9-4286-b308-3e8e7ea6cf22.png)
![Simulator Screen Shot - iPhone 14 - 2023-03-13 at 23 56 59](https://user-images.githubusercontent.com/47440708/224912017-e41be362-cc5b-4c81-b1c7-601b7dd35bb7.png)
![Simulator Screen Shot - iPhone 14 - 2023-03-13 at 23 57 09](https://user-images.githubusercontent.com/47440708/224912019-c955aacc-fa62-41cb-93f0-2c23dfcbdf33.png)
