### PR TITLE
Fixed numeral localization in insulin delivery table view

### DIFF
--- a/Loop/View Controllers/InsulinDeliveryTableViewController.swift
+++ b/Loop/View Controllers/InsulinDeliveryTableViewController.swift
@@ -609,7 +609,7 @@ fileprivate var numberFormatter: NumberFormatter {
 fileprivate func createAttributedDescription(from description: String, with font: UIFont) -> NSAttributedString? {
     let descriptionWithFont = String(format:"<style>body{font-family: '-apple-system', '\(font.fontName)'; font-size: \(font.pointSize);}</style>%@", description)
 
-    guard let attributedDescription = try? NSMutableAttributedString(data: Data(descriptionWithFont.utf8), options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil) else {
+    guard let attributedDescription = try? NSMutableAttributedString(data: descriptionWithFont.data(using: .utf16)!, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil) else {
         return nil
     }
 


### PR DESCRIPTION
Fixes #1968 
This fixes the issue of symbols appearing instead of numerals. Changes mainly affect Arabic but all numbers should be displayed correctly according to their language now.