### PR TITLE
Update Loop script to support Xcode 14.3 archiving

### DIFF
--- a/Scripts/copy-plugins.sh
+++ b/Scripts/copy-plugins.sh
@@ -14,7 +14,7 @@ function copy_plugins {
     for f in "$1"/*.loopplugin; do
       plugin=$(basename "$f")
       echo Copying plugin: $plugin to frameworks directory in app
-      plugin_path="$(readlink "$f" || echo "$f")"
+      plugin_path="$(readlink -f "$f" || echo "$f")"
       plugin_as_framework_path="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/${plugin%.*}.framework"
       rsync -va --exclude=Frameworks "$plugin_path/." "${plugin_as_framework_path}"
       # Rename .plugin to .framework
@@ -29,7 +29,7 @@ function copy_plugins {
         framework=$(basename "$framework_path")
         echo "Copying plugin's framework $framework_path to ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
         cp -avf "$framework_path" "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
-        plugin_path="$(readlink "$f" || echo "$f")"
+        plugin_path="$(readlink -f "$f" || echo "$f")"
         if [ "$EXPANDED_CODE_SIGN_IDENTITY" != "-" ] && [ "$EXPANDED_CODE_SIGN_IDENTITY" != "" ]; then
           echo "Signing $framework for $plugin with $EXPANDED_CODE_SIGN_IDENTITY_NAME"
           /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --timestamp=none --preserve-metadata=identifier,entitlements,flags "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/${framework}"


### PR DESCRIPTION
This PR aims to update the Loop codebase to accommodate Xcode 14.3 for successful archive preparation.

Currently, attempting to archive the Loop project using Xcode 14.3 results in the following error:

rsync error: some files could not be transferred (code 23) at /AppleInternal/Library/BuildRoots/97f6331a-ba75-11ed-a4bc-863efbbaf80d/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(996) [sender=2.6.9]
Command PhaseScriptExecution failed with a nonzero exit code

This PR incorporates the solution and background information outlined in the following post from TheLoopedGroup:
https://www.facebook.com/groups/TheLoopedGroup/posts/3354384161444893

The proposed changes have been tested and successfully resolved the archiving issue with Xcode 14.3.