### PR TITLE
Fix mmol unit conversion for missed meal detection

### DIFF
--- a/Loop/Managers/Missed Meal Detection/MealDetectionManager.swift
+++ b/Loop/Managers/Missed Meal Detection/MealDetectionManager.swift
@@ -19,6 +19,8 @@ enum MissedMealStatus: Equatable {
 
 class MealDetectionManager {
     private let log = OSLog(category: "MealDetectionManager")
+    // All math for meal detection occurs in mg/dL, with settings being converted if in mmol/L
+    private let unit = HKUnit.milligramsPerDeciliter
     
     public var carbRatioScheduleApplyingOverrideHistory: CarbRatioSchedule?
     public var insulinSensitivityScheduleApplyingOverrideHistory: InsulinSensitivitySchedule?
@@ -76,7 +78,6 @@ class MealDetectionManager {
         /// Compute how much of the ICE effect we can't explain via our entered carbs
         /// Effect caching inspired by `LoopMath.predictGlucose`
         var effectValueCache: [Date: Double] = [:]
-        let unit = HKUnit.milligramsPerDeciliter
 
         /// Carb effects are cumulative, so we have to subtract the previous effect value
         var previousEffectValue: Double = filteredCarbEffects.first?.quantity.doubleValue(for: unit) ?? 0
@@ -195,7 +196,7 @@ class MealDetectionManager {
     private func effectThreshold(mealStart: Date, carbsInGrams: Double) -> Double? {
         guard
             let carbRatio = carbRatioScheduleApplyingOverrideHistory?.value(at: mealStart),
-            let insulinSensitivity = insulinSensitivityScheduleApplyingOverrideHistory?.value(at: mealStart)
+            let insulinSensitivity = insulinSensitivityScheduleApplyingOverrideHistory?.value(for: unit, at: mealStart)
         else {
             return nil
         }

--- a/LoopTests/Managers/MealDetectionManagerTests.swift
+++ b/LoopTests/Managers/MealDetectionManagerTests.swift
@@ -33,6 +33,8 @@ enum MissedMealTestType {
     case dynamicCarbAutofill
     /// Test case for purely testing the notifications (not the algorithm)
     case notificationTest
+    /// Test case for testing the algorithm with settings in mmol/L
+    case mmolUser
 }
 
 extension MissedMealTestType {
@@ -48,7 +50,7 @@ extension MissedMealTestType {
             return "noisy_cgm_counteraction_effect"
         case .manyMeals, .missedMealWithCOB:
             return "realistic_report_counteraction_effect"
-        case .dynamicCarbAutofill:
+        case .dynamicCarbAutofill, .mmolUser:
             return "dynamic_autofill_counteraction_effect"
         }
     }
@@ -65,7 +67,7 @@ extension MissedMealTestType {
             return Self.dateFormatter.date(from: "2022-10-19T19:50:15")!
         case .manyMeals:
             return Self.dateFormatter.date(from: "2022-10-19T21:50:15")!
-        case .dynamicCarbAutofill:
+        case .dynamicCarbAutofill, .mmolUser:
             return Self.dateFormatter.date(from: "2022-10-17T07:51:09")!
         }
     }
@@ -78,7 +80,7 @@ extension MissedMealTestType {
             return Self.dateFormatter.date(from: "2022-10-19T19:00:00")
         case .manyMeals:
             return Self.dateFormatter.date(from: "2022-10-19T20:40:00 ")
-        case .dynamicCarbAutofill:
+        case .dynamicCarbAutofill, .mmolUser:
             return Self.dateFormatter.date(from: "2022-10-17T07:20:00")!
         default:
             return nil
@@ -136,13 +138,26 @@ extension MissedMealTestType {
     }
     
     var insulinSensitivitySchedule: InsulinSensitivitySchedule {
-        InsulinSensitivitySchedule(
-            unit: HKUnit.milligramsPerDeciliter,
-            dailyItems: [
-                RepeatingScheduleValue(startTime: 0.0, value: 50.0)
-            ],
-            timeZone: .utcTimeZone
-        )!
+        let value = 50.0
+        switch self {
+        case .mmolUser:
+            return InsulinSensitivitySchedule(
+                unit: HKUnit.millimolesPerLiter,
+                dailyItems: [
+                    RepeatingScheduleValue(startTime: 0.0,
+                                           value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value).doubleValue(for: .millimolesPerLiter))
+                ],
+                timeZone: .utcTimeZone
+            )!
+        default:
+            return InsulinSensitivitySchedule(
+                unit: HKUnit.milligramsPerDeciliter,
+                dailyItems: [
+                    RepeatingScheduleValue(startTime: 0.0, value: value)
+                ],
+                timeZone: .utcTimeZone
+            )!
+        }
     }
 }
 
@@ -330,6 +345,19 @@ class MealDetectionManagerTests: XCTestCase {
         updateGroup.enter()
         mealDetectionManager.hasMissedMeal(insulinCounteractionEffects: counteractionEffects, carbEffects: mealDetectionCarbEffects(using: counteractionEffects)) { status in
             XCTAssertEqual(status, .hasMissedMeal(startTime: testType.missedMealDate!, carbAmount: 40))
+            updateGroup.leave()
+        }
+        updateGroup.wait()
+    }
+    
+    func testMMOLUser() {
+        let testType = MissedMealTestType.mmolUser
+        let counteractionEffects = setUp(for: testType)
+
+        let updateGroup = DispatchGroup()
+        updateGroup.enter()
+        mealDetectionManager.hasMissedMeal(glucoseSamples: glucoseSamples, insulinCounteractionEffects: counteractionEffects, carbEffects: mealDetectionCarbEffects(using: counteractionEffects)) { status in
+            XCTAssertEqual(status, .hasMissedMeal(startTime: testType.missedMealDate!, carbAmount: 25))
             updateGroup.leave()
         }
         updateGroup.wait()

--- a/LoopTests/Managers/MealDetectionManagerTests.swift
+++ b/LoopTests/Managers/MealDetectionManagerTests.swift
@@ -356,7 +356,7 @@ class MealDetectionManagerTests: XCTestCase {
 
         let updateGroup = DispatchGroup()
         updateGroup.enter()
-        mealDetectionManager.hasMissedMeal(glucoseSamples: glucoseSamples, insulinCounteractionEffects: counteractionEffects, carbEffects: mealDetectionCarbEffects(using: counteractionEffects)) { status in
+        mealDetectionManager.hasMissedMeal(insulinCounteractionEffects: counteractionEffects, carbEffects: mealDetectionCarbEffects(using: counteractionEffects)) { status in
             XCTAssertEqual(status, .hasMissedMeal(startTime: testType.missedMealDate!, carbAmount: 25))
             updateGroup.leave()
         }


### PR DESCRIPTION
This PR ensures the meal detection algorithm correctly converts mmol/L units into mg/dL when performing missed meal detection calculations.

[Associated LoopKit PR](https://github.com/LoopKit/LoopKit/pull/479)