### PR TITLE
Use maximumDateFutureInterval for Carb Entry

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -405,7 +405,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
                         cell.datePicker.preferredDatePickerStyle = .wheels
                     }
                 #endif
-                cell.datePicker.maximumDate = date.addingTimeInterval(.hours(1))
+                cell.datePicker.maximumDate = date.addingTimeInterval(.hours(maximumDateFutureInterval))
                 cell.datePicker.minimumDate = date.addingTimeInterval(.hours(-12))
                 cell.datePicker.minuteInterval = 1
                 cell.date = date


### PR DESCRIPTION
The value for maximumDateFutureInterval is defined as 4 hours. But the usage in picker is hard-coded 1 hour.
Use the defined value in the picker.