### PR TITLE
Refactor RetrospectiveCorrection Initialization

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -433,15 +433,15 @@ final class LoopDataManager {
     }
 
     // Confined to dataAccessQueue
-    private var lastRetrospectiveCorrectionEnabled: Bool?
+    private var lastIntegralRetrospectiveCorrectionEnabled: Bool?
     private var cachedRetrospectiveCorrection: RetrospectiveCorrection?
-    
+
     var retrospectiveCorrection: RetrospectiveCorrection {
-        let currentRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
+        let currentIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
         
-        if lastRetrospectiveCorrectionEnabled != currentRetrospectiveCorrectionEnabled || cachedRetrospectiveCorrection == nil {
-            lastRetrospectiveCorrectionEnabled = currentRetrospectiveCorrectionEnabled
-            if currentRetrospectiveCorrectionEnabled {
+        if lastIntegralRetrospectiveCorrectionEnabled != currentIntegralRetrospectiveCorrectionEnabled || cachedRetrospectiveCorrection == nil {
+            lastIntegralRetrospectiveCorrectionEnabled = currentIntegralRetrospectiveCorrectionEnabled
+            if currentIntegralRetrospectiveCorrectionEnabled {
                 cachedRetrospectiveCorrection = IntegralRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)
             } else {
                 cachedRetrospectiveCorrection = StandardRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -123,8 +123,6 @@ final class LoopDataManager {
 
         self.trustedTimeOffset = trustedTimeOffset
 
-        retrospectiveCorrection = settings.enabledRetrospectiveCorrectionAlgorithm
-
         overrideIntentObserver = UserDefaults.appGroup?.observe(\.intentExtensionOverrideToSet, options: [.new], changeHandler: {[weak self] (defaults, change) in
             guard let name = change.newValue??.lowercased(), let appGroup = UserDefaults.appGroup else {
                 return
@@ -435,7 +433,23 @@ final class LoopDataManager {
     }
 
     // Confined to dataAccessQueue
-    private var retrospectiveCorrection: RetrospectiveCorrection
+    private var lastRetrospectiveCorrectionEnabled: Bool?
+    private var cachedRetrospectiveCorrection: RetrospectiveCorrection?
+    
+    var retrospectiveCorrection: RetrospectiveCorrection {
+        let currentRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
+        
+        if lastRetrospectiveCorrectionEnabled != currentRetrospectiveCorrectionEnabled || cachedRetrospectiveCorrection == nil {
+            lastRetrospectiveCorrectionEnabled = currentRetrospectiveCorrectionEnabled
+            if currentRetrospectiveCorrectionEnabled {
+                cachedRetrospectiveCorrection = IntegralRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)
+            } else {
+                cachedRetrospectiveCorrection = StandardRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)
+            }
+        }
+        
+        return cachedRetrospectiveCorrection!
+    }
 
     // MARK: - Background task management
 

--- a/Loop/Models/LoopSettings+Loop.swift
+++ b/Loop/Models/LoopSettings+Loop.swift
@@ -20,19 +20,4 @@ extension LoopSettings {
 
     static let retrospectiveCorrectionEffectDuration = TimeInterval(hours: 1)
     
-    /// Creates an instance of the enabled retrospective correction implementation    
-    var enabledRetrospectiveCorrectionAlgorithm: RetrospectiveCorrection {
-        var enabledRetrospectiveCorrectionAlgorithm: RetrospectiveCorrection
-        
-        let isIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
-        
-        if isIntegralRetrospectiveCorrectionEnabled {
-            enabledRetrospectiveCorrectionAlgorithm = IntegralRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)
-        } else {
-            enabledRetrospectiveCorrectionAlgorithm = StandardRetrospectiveCorrection(effectDuration: LoopSettings.retrospectiveCorrectionEffectDuration)
-        }
-        
-        return enabledRetrospectiveCorrectionAlgorithm
-    }
-    
 }


### PR DESCRIPTION
This pull request solves the issue with toggling IRC On/Off without re-starting the app.

I did not want to re-create the RetrospectiveCorrection class for each evaluation or loop, therefore a new computed property retrospectiveCorrection is added in LoopDataManager. This property checks the integralRetrospectiveCorrectionEnabled flag in UserDefaults, and based on its state, it creates an instance of IntegralRetrospectiveCorrection or StandardRetrospectiveCorrection. This instance is then cached and reused unless the flag's value changes. 

Two new private variables, lastIntegralRetrospectiveCorrectionEnabled and cachedRetrospectiveCorrection, have been added to support the caching mechanism.

By removing the instance creation logic from the "Static configuration" block in LoopSettings, it recognizes that this process is, in fact, not static. Moreover, the LoopSettings class adheres to the Equatable protocol, which makes it unsuitable for holding a cache of the RetrospectiveCorrection instance.