### PR TITLE
add effect of suspending insulin delivery

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -372,6 +372,8 @@ final class LoopDataManager {
     }
 
     private var retrospectiveGlucoseDiscrepanciesSummed: [GlucoseChange]?
+    
+    private var suspendInsulinDeliveryEffect: [GlucoseEffect] = []
 
     fileprivate var predictedGlucose: [PredictedGlucoseValue]? {
         didSet {
@@ -1112,6 +1114,12 @@ extension LoopDataManager {
                 warnings.append(.fetchDataWarning(.retrospectiveGlucoseEffect(error: error)))
             }
         }
+        
+        do {
+            try updateSuspendInsulinDeliveryEffect()
+        } catch let error {
+            logger.error("%{public}@", String(describing: error))
+        }
 
         dosingDecision.appendWarnings(warnings.value)
 
@@ -1309,6 +1317,11 @@ extension LoopDataManager {
             } else {
                 effects.append(retrospectiveGlucoseEffect)
             }
+        }
+        
+        // Append effect of suspending insulin delivery when selected by the user on the Predicted Glucose screen (for information purposes only)
+        if inputs.contains(.suspend) {
+            effects.append(suspendInsulinDeliveryEffect)
         }
 
         var prediction = LoopMath.predictGlucose(startingAt: glucose, momentum: momentum, effects: effects)
@@ -1573,6 +1586,61 @@ extension LoopDataManager {
             glucoseCorrectionRangeSchedule: settings.glucoseTargetRangeSchedule,
             retrospectiveCorrectionGroupingInterval: LoopConstants.retrospectiveCorrectionGroupingInterval
         )
+    }
+
+    /// Generates a glucose prediction effect of suspending insulin delivery over duration of insulin action starting at current date
+    ///
+    /// - Throws: LoopError.configurationError
+    private func updateSuspendInsulinDeliveryEffect() throws {
+        dispatchPrecondition(condition: .onQueue(dataAccessQueue))
+
+        // Get settings, otherwise clear effect and throw error
+        guard
+            let insulinSensitivity = insulinSensitivityScheduleApplyingOverrideHistory
+        else {
+            suspendInsulinDeliveryEffect = []
+            throw LoopError.configurationError(.insulinSensitivitySchedule)
+        }
+        guard
+            let basalRateSchedule = basalRateScheduleApplyingOverrideHistory
+        else {
+            suspendInsulinDeliveryEffect = []
+            throw LoopError.configurationError(.basalRateSchedule)
+        }
+        
+        let insulinModel = doseStore.insulinModelProvider.model(for: pumpInsulinType)
+        let insulinActionDuration = insulinModel.effectDuration
+
+        let startSuspend = now()
+        let endSuspend = startSuspend.addingTimeInterval(insulinActionDuration)
+        
+        var suspendDoses: [DoseEntry] = []
+        let basalItems = basalRateSchedule.between(start: startSuspend, end: endSuspend)
+        
+        // Iterate over basal entries during suspension of insulin delivery
+        for (index, basalItem) in basalItems.enumerated() {
+            var startSuspendDoseDate: Date
+            var endSuspendDoseDate: Date
+
+            if index == 0 {
+                startSuspendDoseDate = startSuspend
+            } else {
+                startSuspendDoseDate = basalItem.startDate
+            }
+
+            if index == basalItems.count - 1 {
+                endSuspendDoseDate = endSuspend
+            } else {
+                endSuspendDoseDate = basalItems[index + 1].startDate
+            }
+
+            let suspendDose = DoseEntry(type: .tempBasal, startDate: startSuspendDoseDate, endDate: endSuspendDoseDate, value: -basalItem.value, unit: DoseUnit.unitsPerHour)
+            
+            suspendDoses.append(suspendDose)
+        }
+        
+        // Calculate predicted glucose effect of suspending insulin delivery
+        suspendInsulinDeliveryEffect = suspendDoses.glucoseEffects(insulinModelProvider: doseStore.insulinModelProvider, longestEffectDuration: doseStore.longestEffectDuration, insulinSensitivity: insulinSensitivity).filterDateRange(startSuspend, endSuspend)
     }
 
     /// Runs the glucose prediction on the latest effect data.

--- a/Loop/Models/PredictionInputEffect.swift
+++ b/Loop/Models/PredictionInputEffect.swift
@@ -17,6 +17,7 @@ struct PredictionInputEffect: OptionSet {
     static let insulin          = PredictionInputEffect(rawValue: 1 << 1)
     static let momentum         = PredictionInputEffect(rawValue: 1 << 2)
     static let retrospection    = PredictionInputEffect(rawValue: 1 << 3)
+    static let suspend          = PredictionInputEffect(rawValue: 1 << 4)
 
     static let all: PredictionInputEffect = [.carbs, .insulin, .momentum, .retrospection]
 
@@ -30,6 +31,8 @@ struct PredictionInputEffect: OptionSet {
             return NSLocalizedString("Glucose Momentum", comment: "Title of the prediction input effect for glucose momentum")
         case [.retrospection]:
             return NSLocalizedString("Retrospective Correction", comment: "Title of the prediction input effect for retrospective correction")
+        case [.suspend]:
+            return NSLocalizedString("Suspension of Insulin Delivery", comment: "Title of the prediction input effect for suspension of insulin delivery")
         default:
             return nil
         }
@@ -45,6 +48,8 @@ struct PredictionInputEffect: OptionSet {
             return NSLocalizedString("15 min glucose regression coefficient (b₁), continued with decay over 30 min", comment: "Description of the prediction input effect for glucose momentum")
         case [.retrospection]:
             return NSLocalizedString("30 min comparison of glucose prediction vs actual, continued with decay over 60 min", comment: "Description of the prediction input effect for retrospective correction")
+        case [.suspend]:
+             return NSLocalizedString("Glucose effect of suspending insulin delivery", comment: "Description of the prediction input effect for suspension of insulin delivery")
         default:
             return nil
         }

--- a/Loop/View Controllers/PredictionTableViewController.swift
+++ b/Loop/View Controllers/PredictionTableViewController.swift
@@ -197,7 +197,7 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
 
     private var eventualGlucoseDescription: String?
 
-    private var availableInputs: [PredictionInputEffect] = [.carbs, .insulin, .momentum, .retrospection]
+    private var availableInputs: [PredictionInputEffect] = [.carbs, .insulin, .momentum, .retrospection, .suspend]
 
     private var selectedInputs = PredictionInputEffect.all
 


### PR DESCRIPTION
Allows users to view the predicted effect of suspending insulin delivery on the Predicted Glucose screen. This is for information purposes only and does not affect dosing in any manner. An immediate use case is to assist users decide on their own if a carb correction might be needed to mitigate a potential low in the future. 

The Precited Glucose screen starts as usual, with only carbs, insulin, momentum, and retrospection enabled. 
![IMG_2859](https://github.com/LoopKit/Loop/assets/12002177/e79e749a-3be9-4d3e-9d00-36d73fc230af)

In this example, an eventual glucose below the correction range is predicted. Manually selecting the Suspension of Insulin Delivery shows the effect and, in this case, shows that Loop should be able to easily correct the predicted glucose without the need for any carb corrections. 
![IMG_2860](https://github.com/LoopKit/Loop/assets/12002177/c16db924-b2e2-410f-846b-ee43db03eb55)

Future (more ambitious) use cases for the effect of suspending insulin delivery may include:
- Assessments of dosing risks, potentially in deciding how large the partial application factor should be;
- Development of an automated carb correction notification feature.
