### PR TITLE
mitigate irc and momentum stacking

### DIFF
--- a/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
+++ b/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
@@ -179,7 +179,7 @@ class IntegralRetrospectiveCorrection: RetrospectiveCorrection {
             
             // Overall glucose effect calculated as a sum of propotional, integral and differential effects
             proportionalCorrection = IntegralRetrospectiveCorrection.proportionalGain * currentDiscrepancyValue
-            // Differential effect added only when negative, to avoid upward stacking with momentum, while still mitigating slugeshness of retrospective correction when discrepancies start decreasing
+            // Differential effect added only when negative, to avoid upward stacking with momentum, while still mitigating sluggishness of retrospective correction when discrepancies start decreasing
             if differentialDiscrepancy < 0 {
                 differentialCorrection = IntegralRetrospectiveCorrection.differentialGain * differentialDiscrepancy
             }

--- a/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
+++ b/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
@@ -180,8 +180,10 @@ class IntegralRetrospectiveCorrection: RetrospectiveCorrection {
             // Overall glucose effect calculated as a sum of propotional, integral and differential effects
             proportionalCorrection = IntegralRetrospectiveCorrection.proportionalGain * currentDiscrepancyValue
             // Differential effect added only when negative, to avoid upward stacking with momentum, while still mitigating sluggishness of retrospective correction when discrepancies start decreasing
-            if differentialDiscrepancy < 0 {
+            if differentialDiscrepancy < 0.0 {
                 differentialCorrection = IntegralRetrospectiveCorrection.differentialGain * differentialDiscrepancy
+            } else {
+                differentialCorrection = 0.0
             }
             let totalCorrection = proportionalCorrection + integralCorrection + differentialCorrection
             totalGlucoseCorrectionEffect = HKQuantity(unit: unit, doubleValue: totalCorrection)

--- a/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
+++ b/Loop/Models/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift
@@ -179,7 +179,10 @@ class IntegralRetrospectiveCorrection: RetrospectiveCorrection {
             
             // Overall glucose effect calculated as a sum of propotional, integral and differential effects
             proportionalCorrection = IntegralRetrospectiveCorrection.proportionalGain * currentDiscrepancyValue
-            differentialCorrection = IntegralRetrospectiveCorrection.differentialGain * differentialDiscrepancy
+            // Differential effect added only when negative, to avoid upward stacking with momentum, while still mitigating slugeshness of retrospective correction when discrepancies start decreasing
+            if differentialDiscrepancy < 0 {
+                differentialCorrection = IntegralRetrospectiveCorrection.differentialGain * differentialDiscrepancy
+            }
             let totalCorrection = proportionalCorrection + integralCorrection + differentialCorrection
             totalGlucoseCorrectionEffect = HKQuantity(unit: unit, doubleValue: totalCorrection)
             integralCorrectionEffectDuration = TimeInterval(minutes: integralCorrectionEffectMinutes)


### PR DESCRIPTION
This update mitigates the upward stacking of IRC and momentum effects, which may occur when retrospective correction is active and glucose is increasing rapidly, as [reported on Zulip](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Algorithm.20Experiments/near/376540452).