### PR TITLE
Remove Loop Dependencies from Charts

### DIFF
--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -43,7 +43,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
                 axisLabel: .axisLabelColor,
                 grid: .gridColor,
                 glucoseTint: .glucoseTintColor,
-                insulinTint: .insulinTintColor
+                insulinTint: .insulinTintColor,
+                carbTint: .carbTintColor
             ),
             settings: {
                 var settings = ChartSettings()

--- a/Loop/Extensions/ChartColorPalette+Loop.swift
+++ b/Loop/Extensions/ChartColorPalette+Loop.swift
@@ -12,6 +12,6 @@ import LoopKitUI
 
 extension ChartColorPalette {
     static var primary: ChartColorPalette {
-        return ChartColorPalette(axisLine: .axisLineColor, axisLabel: .axisLabelColor, grid: .gridColor, glucoseTint: .glucoseTintColor, insulinTint: .insulinTintColor)
+        return ChartColorPalette(axisLine: .axisLineColor, axisLabel: .axisLabelColor, grid: .gridColor, glucoseTint: .glucoseTintColor, insulinTint: .insulinTintColor, carbTint: .carbTintColor)
     }
 }

--- a/LoopUI/Charts/COBChart.swift
+++ b/LoopUI/Charts/COBChart.swift
@@ -55,10 +55,10 @@ public extension COBChart {
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
         // The COB area
-        let lineModel = ChartLineModel(chartPoints: cobPoints, lineColor: UIColor.carbTintColor, lineWidth: 2, animDuration: 0, animDelay: 0)
+        let lineModel = ChartLineModel(chartPoints: cobPoints, lineColor: colors.carbTint, lineWidth: 2, animDuration: 0, animDelay: 0)
         let cobLine = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, lineModels: [lineModel])
 
-        let cobArea = ChartPointsFillsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, fills: [ChartPointsFill(chartPoints: cobPoints, fillColor: UIColor.carbTintColor.withAlphaComponent(0.5))])
+        let cobArea = ChartPointsFillsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, fills: [ChartPointsFill(chartPoints: cobPoints, fillColor: colors.carbTint.withAlphaComponent(0.5))])
 
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
@@ -69,7 +69,7 @@ public extension COBChart {
                 yAxisLayer: yAxisLayer,
                 axisLabelSettings: axisLabelSettings,
                 chartPoints: cobPoints,
-                tintColor: UIColor.carbTintColor,
+                tintColor: colors.carbTint,
                 gestureRecognizer: gestureRecognizer
             )
         }

--- a/LoopUI/Charts/CarbEffectChart.swift
+++ b/LoopUI/Charts/CarbEffectChart.swift
@@ -74,7 +74,7 @@ extension CarbEffectChart {
 
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
-        let carbFillColor = UIColor.carbTintColor.withAlphaComponent(0.5)
+        let carbFillColor = colors.carbTint.withAlphaComponent(0.5)
         let carbBlendMode: CGBlendMode
         switch traitCollection.userInterfaceStyle {
         case .dark:
@@ -121,7 +121,7 @@ extension CarbEffectChart {
                 yAxisLayer: yAxisLayer,
                 axisLabelSettings: axisLabelSettings,
                 chartPoints: allCarbEffectPoints,
-                tintColor: UIColor.carbTintColor,
+                tintColor: colors.carbTint,
                 gestureRecognizer: gestureRecognizer
             )
         }

--- a/LoopUI/Charts/CarbEffectChart.swift
+++ b/LoopUI/Charts/CarbEffectChart.swift
@@ -187,7 +187,7 @@ extension CarbEffectChart {
     /// - Parameter effects: A timeline of glucose velocity values
     public func setInsulinCounteractionEffects(_ effects: [GlucoseEffectVelocity]) {
         let unit = glucoseUnit.unitDivided(by: .minute())
-        let unitString = String(format: NSLocalizedString("%1$@/min", comment: "Format string describing glucose units per minute (1: glucose unit string)"), glucoseUnit.localizedShortUnitString)
+        let unitString = String(format: NSLocalizedString("%1$@/min", comment: "Format string describing glucose units per minute (1: glucose unit string)"), glucoseUnit.shortLocalizedUnitString())
 
         var insulinCounteractionEffectPoints: [ChartPoint] = []
         var allCarbEffectPoints: [ChartPoint] = []

--- a/LoopUI/Charts/IOBChart.swift
+++ b/LoopUI/Charts/IOBChart.swift
@@ -58,10 +58,10 @@ public extension IOBChart {
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
         // The IOB area
-        let lineModel = ChartLineModel(chartPoints: iobPoints, lineColor: UIColor.insulinTintColor, lineWidth: 2, animDuration: 0, animDelay: 0)
+        let lineModel = ChartLineModel(chartPoints: iobPoints, lineColor: colors.insulinTint, lineWidth: 2, animDuration: 0, animDelay: 0)
         let iobLine = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, lineModels: [lineModel])
 
-        let iobArea = ChartPointsFillsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, fills: [ChartPointsFill(chartPoints: iobPoints, fillColor: UIColor.insulinTintColor.withAlphaComponent(0.5))])
+        let iobArea = ChartPointsFillsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, fills: [ChartPointsFill(chartPoints: iobPoints, fillColor: colors.insulinTint.withAlphaComponent(0.5))])
 
         // Grid lines
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: guideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
@@ -73,7 +73,7 @@ public extension IOBChart {
             let viewFrame = CGRect(x: chart.contentView.bounds.minX, y: chartPointModel.screenLoc.y - width / 2, width: chart.contentView.bounds.size.width, height: width)
 
             let v = UIView(frame: viewFrame)
-            v.layer.backgroundColor = UIColor.insulinTintColor.cgColor
+            v.layer.backgroundColor = colors.insulinTint.cgColor
             return v
         })
 
@@ -83,7 +83,7 @@ public extension IOBChart {
                 yAxisLayer: yAxisLayer,
                 axisLabelSettings: axisLabelSettings,
                 chartPoints: iobPoints,
-                tintColor: UIColor.insulinTintColor,
+                tintColor: colors.insulinTint,
                 gestureRecognizer: gestureRecognizer
             )
         }

--- a/LoopUI/Charts/IOBChart.swift
+++ b/LoopUI/Charts/IOBChart.swift
@@ -110,7 +110,7 @@ public extension IOBChart {
         iobPoints = iobValues.map {
             return ChartPoint(
                 x: ChartAxisValueDate(date: $0.startDate, formatter: dateFormatter),
-                y: ChartAxisValueDoubleUnit($0.value, unitString: Self.chartUnit.localizedShortUnitString, formatter: doseFormatter)
+                y: ChartAxisValueDoubleUnit($0.value, unitString: Self.chartUnit.shortLocalizedUnitString(), formatter: doseFormatter)
             )
         }
     }


### PR DESCRIPTION
In order to remove Caregiver's dependency on the Loop repo, I need to move certain charts from Loop to LoopKit. This PR will not move those charts yet but instead updates some chart APIs in prep for that.

* Use `ChartColorPalette` for chart colors: Charts use UIColor extension methods, like `insulinTintColor` which are not available in LoopKit. `ChartColorPalette` is available to LoopKit so this switches to using that. Additionally, I added `carbTint` to `ChartColorPalette` which was missing.
* Certain `HKUnit` extensions are not available to LoopKit. This will update the charts to use the `QuantityFormatter` for unit labels.
* This needs to merge with https://github.com/LoopKit/LoopKit/pull/498