### PR TITLE
Override warning fix

### DIFF
--- a/Loop/View Models/CarbEntryViewModel.swift
+++ b/Loop/View Models/CarbEntryViewModel.swift
@@ -290,13 +290,14 @@ final class CarbEntryViewModel: ObservableObject {
     }
     
     private func checkIfOverrideEnabled() {
-        if let managerSettings = delegate?.settings {
-            if let overrideSettings = managerSettings.scheduleOverride?.settings, overrideSettings.effectiveInsulinNeedsScaleFactor != 1.0 {
-                self.warnings.insert(.overrideInProgress)
-            }
-            else {
-                self.warnings.remove(.overrideInProgress)
-            }
+        if let managerSettings = delegate?.settings,
+           managerSettings.scheduleOverrideEnabled(at: Date()),
+           let overrideSettings = managerSettings.scheduleOverride?.settings,
+           overrideSettings.effectiveInsulinNeedsScaleFactor != 1.0 {
+            self.warnings.insert(.overrideInProgress)
+        }
+        else {
+            self.warnings.remove(.overrideInProgress)
         }
     }
     


### PR DESCRIPTION
After an override is complete, the warning that an override is enabled is still present in the carb entry screen (described in Zulip [here](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Active.20Override.20warning.20on.20Carb.20Entry)). I was not able to reproduce this issue, but still suspect that this change will fix it, as the new code now matches the [old UIKit code](https://github.com/LoopKit/Loop/blob/befcbcbe6733e52b315cb29904f7893e39da3514/Loop/View%20Controllers/CarbEntryViewController.swift#L242).