### PR TITLE
✨🔧 Refactor Widget Background Handling - Fix #2070

### DIFF
--- a/Loop Widget Extension/Helpers/WidgetBackground.swift
+++ b/Loop Widget Extension/Helpers/WidgetBackground.swift
@@ -11,6 +11,10 @@ import SwiftUI
 extension View {
     @ViewBuilder
     func widgetBackground() -> some View {
-        self.background { Color("WidgetBackground") }
+        if #available(watchOS 10.0, iOSApplicationExtension 17.0, iOS 17.0, macOSApplicationExtension 14.0, *) {
+            self.containerBackground(for: .widget) { Color("WidgetBackground") }
+        } else {
+            self.background { Color("WidgetBackground") }
+        }
     }
 }


### PR DESCRIPTION
## Summary

The code changes refactor the widget background handling in the Loop Widget Extension. Instead of using `self.background`, it now checks for availability and uses `self.containerBackground` for newer versions, falling back to `self.background` for older versions. This improves compatibility across different platforms and ensures consistent widget backgrounds.

Fix for #2070 

![Screenshot 2023-09-26 at 16 38 25](https://github.com/LoopKit/Loop/assets/8299486/eddee8fc-2722-459a-adde-832a14fe51e9)

