### PR TITLE
Fix logic error for TestFlight expiration

### DIFF
--- a/Loop/Managers/AppExpirationAlerter.swift
+++ b/Loop/Managers/AppExpirationAlerter.swift
@@ -152,7 +152,7 @@ class AppExpirationAlerter {
         if isTestFlight, let buildDate = buildDate() {
             let testflightExpiration = Calendar.current.date(byAdding: .day, value: 90, to: buildDate)!
             
-            return profileExpiration < testflightExpiration ? profileExpiration : testflightExpiration
+            return testflightExpiration
         } else {
             return profileExpiration
         }


### PR DESCRIPTION
Now that some users of Browser Build method have profile expirations that are shorter than 90 days after the build, we see that the TestFlight expiration continues to be 90 days after build date.

In other words, TestFlight expiration is independent of profile expiration.

Remove the logic that considers profile expiration for a TestFlight build.

This has been tested with a Mac-Xcode build.