### PR TITLE
Modify maxCarbEntryFutureTime to 4 hours

### DIFF
--- a/Loop/Models/LoopConstants.swift
+++ b/Loop/Models/LoopConstants.swift
@@ -25,7 +25,7 @@ enum LoopConstants {
     static let maxCarbAbsorptionTime = TimeInterval(hours: 8)
     
     static let maxCarbEntryPastTime = TimeInterval(hours: (-12))
-    static let maxCarbEntryFutureTime = TimeInterval(hours: 1)
+    static let maxCarbEntryFutureTime = TimeInterval(hours: 4)
 
     static let maxOverrideDurationTime = TimeInterval(hours: 24)
     


### PR DESCRIPTION
Many people use future carb entry to handle fat and protein rise.
I believe increasing this value from 1 hour to 4 hours is a reasonable compromise between safety and convenience.

Note:
* This is a personal opinion
* I use 4 hours when dosing for my evening meal
   * I enter a prompt meal entry and future fat/protein rise entry at the same time
   * I am able to do this because I customized my code