### PR TITLE
remove shaking phone as trigger for presentDebugMenu

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1865,15 +1865,6 @@ final class StatusTableViewController: LoopChartsTableViewController {
         lastOrientation = UIDevice.current.orientation
     }
 
-    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        guard FeatureFlags.allowDebugFeatures else {
-            return
-        }
-        if motion == .motionShake {
-            presentDebugMenu()
-        }
-    }
-
     private func presentDebugMenu() {
         guard FeatureFlags.allowDebugFeatures else {
             return


### PR DESCRIPTION
It is too easy to trigger the debug menu during daily phone use now that allowDebugFeatures is enabled for DIY loop.
Remove the shaking option, but keep the rotate phone between landscape and portrait 6 times with no more than 2 sec between rotations.