### PR TITLE
Use full ICE history for displaying estimated carbohydrate effects

### DIFF
--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -173,7 +173,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
                 }
 
                 reloadGroup.enter()
-                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: insulinCounteractionEffects!) { (result) in
+                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
                     switch result {
                     case .success((_, let effects)):
                         carbEffects = effects


### PR DESCRIPTION
The 'predicted' dataset on the 'glucose change' graph was calculated using insulin counteraction effects that had been truncated to the width of the chart. This meant that carb entries early in the timeline may not have dynamic carb absorption applied as the implied ICE was zero for the first part of the carb entry's history.

Addresses the different behaviour in landscape and portrait view of the glucose change graph in the carbohydrate screen. so that dynamic carb effects are always shown when they are in effect.

For discussion (but not included in this pull request), for clarity the graph dataset label could be changed from 'Predicted' to 'Estimated and predicted' given that it already incorporates dynamic glucose effects (when these are in effect), so is partly based on observation.

Does not address what I described as 'desired' behaviour of showing a static prediction for the 'predicted' dataset; I am not sure how you would achieve that.

Closes #2159 