### PR TITLE
Swedish translations

### DIFF
--- a/Common/sv.lproj/Localizable.strings
+++ b/Common/sv.lproj/Localizable.strings
@@ -4,54 +4,20 @@
 /* Title of the user activity for adding carbs */
 "Add Carb Entry" = "Lägg till kolhydrater";
 
-/* Lesson subtitle */
-"Computes the percentage of glucose measurements within a specified range" = "Beräknar procentandelen glukosmätningar inom ett specifikt målvärde";
-
-/* Title of the button to begin lesson execution */
-"Continue" = "Fortsätt";
-
 /* The short unit display string for decibles */
 "dB" = "dB";
 
 /* The short unit display string for grams */
 "g" = "g";
 
-/* Placeholder for upper range entry */
-"Maximum" = "Maximum";
-
 /* The short unit display string for milligrams of glucose per decilter */
 "mg/dL" = "mg/dl";
-
-/* Placeholder for lower range entry */
-"Minimum" = "Minimum";
 
 /* The short unit display string for millimoles of glucose per liter */
 "mmol/L" = "mmol/l";
 
-/* Lesson title */
-"Modal Day" = "Genomsnittlig dag";
-
-/* Lesson result text for no data */
-"No data available" = "Ingen data tillgänglig";
-
 /* Format string for combining localized numeric value and unit. (1: numeric value)(2: unit) */
 "QUANTITY_VALUE_AND_UNIT" = "%1$@ %2$@";
 
-/* Section title for glucose range */
-"Range" = "Målvärde";
-
-/* Title of config entry */
-"Start Date" = "Starttid";
-
-/* Lesson title */
-"Time in Range" = "Tid inom målvärde";
-
 /* The short unit display string for international units of insulin */
 "U" = "E";
-
-/* Lesson subtitle */
-"Visualizes the most frequent glucose values by time of day" = "Visar de vanligaste glukosvärdena under olika tider på dagen";
-
-/* Unit string for a count of calendar weeks */
-"Weeks" = "Veckor";
-

--- a/Loop Intent Extension/sv.lproj/Localizable.strings
+++ b/Loop Intent Extension/sv.lproj/Localizable.strings
@@ -1,3 +1,0 @@
-/* The format string for the app name and version number. (1: bundle name)(2: bundle version) */
-"%1$@ v%2$@" = "%1$@ v%2$@";
-

--- a/Loop Status Extension/sv.lproj/Localizable.strings
+++ b/Loop Status Extension/sv.lproj/Localizable.strings
@@ -10,36 +10,8 @@
 /* The subtitle format describing units of active insulin. (1: localized insulin value description) */
 "%1$@ U" = "%1$@ E";
 
-/* The format string for the app name and version number. (1: bundle name)(2: bundle version) */
-"%1$@ v%2$@" = "%1$@ v%2$@";
-
 /* Widget label title describing the active carbs */
 "Active Carbs" = "Aktiva kolhydrater";
 
 /* Widget label title describing the active insulin */
 "Active Insulin" = "Aktivt insulin";
-
-/* The short unit display string for decibles */
-"dB" = "dB";
-
-/* The subtitle format describing eventual glucose.  (1: localized glucose value description) */
-"Eventually %1$@" = "Förväntat %1$@";
-
-/* The short unit display string for grams */
-"g" = "g";
-
-/* The subtitle format describing units of active insulin. (1: localized insulin value description) */
-"IOB %1$@ U" = "IOB %1$@ E";
-
-/* The short unit display string for milligrams of glucose per decilter */
-"mg/dL" = "mg/dl";
-
-/* The short unit display string for millimoles of glucose per liter */
-"mmol/L" = "mmol/L";
-
-/* Format string for combining localized numeric value and unit. (1: numeric value)(2: unit) */
-"QUANTITY_VALUE_AND_UNIT" = "%1$@ %2$@";
-
-/* The short unit display string for international units of insulin */
-"U" = "E";
-

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -1335,7 +1335,6 @@
 		C1004DFC2981F5B700B8CF94 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C1004DFD2981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C1004DFE2981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1004DFF2981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1004E002981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C1004E012981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1004E022981F67A00B8CF94 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -4683,7 +4682,6 @@
 			isa = PBXVariantGroup;
 			children = (
 				C1004DF42981F5B700B8CF94 /* da */,
-				C1004DFF2981F67A00B8CF94 /* sv */,
 				C1004E072981F6A100B8CF94 /* ro */,
 				C1004E0F2981F6E200B8CF94 /* nl */,
 				C1004E172981F6F500B8CF94 /* nb */,

--- a/Loop/Views/AddEditFavoriteFoodView.swift
+++ b/Loop/Views/AddEditFavoriteFoodView.swift
@@ -44,7 +44,7 @@ struct AddEditFavoriteFoodView: View {
                             saveButton
                         }
                     }
-                    .navigationBarTitle("New Favorite Food", displayMode: .inline)
+                    .navigationBarTitle(NSLocalizedString("New Favorite Food", comment: "Title of new favorite food screen"), displayMode: .inline)
                     .onAppear {
                         expandedRow = .name
                     }
@@ -92,20 +92,20 @@ struct AddEditFavoriteFoodView: View {
             let carbQuantityFocused: Binding<Bool> = Binding(get: { expandedRow == .carbQuantity }, set: { expandedRow = $0 ? .carbQuantity : nil })
             let foodTypeFocused: Binding<Bool> = Binding(get: { expandedRow == .foodType }, set: { expandedRow = $0 ? .foodType : nil })
             let absorptionTimeFocused: Binding<Bool> = Binding(get: { expandedRow == .absorptionTime }, set: { expandedRow = $0 ? .absorptionTime : nil })
-            
-            TextFieldRow(text: $viewModel.name, isFocused: nameFocused, title: "Name", placeholder: "Apple")
-            
+
+            TextFieldRow(text: $viewModel.name, isFocused: nameFocused, title: NSLocalizedString("Name", comment: "Label for name row on add favorite food screen"), placeholder: NSLocalizedString("Apple", comment: "Default name on add favorite food screen"))
+
             CardSectionDivider()
 
-            CarbQuantityRow(quantity: $viewModel.carbsQuantity, isFocused: carbQuantityFocused, title: "Carb Quantity", preferredCarbUnit: viewModel.preferredCarbUnit)
-            
-            CardSectionDivider()
-            
-            EmojiRow(text: $viewModel.foodType, isFocused: foodTypeFocused, emojiType: .food, title: "Food Type")
-            
+            CarbQuantityRow(quantity: $viewModel.carbsQuantity, isFocused: carbQuantityFocused, title: NSLocalizedString("Carb Quantity", comment: "Label for carb quantity row on add favorite food screen"), preferredCarbUnit: viewModel.preferredCarbUnit)
+
             CardSectionDivider()
 
-            AbsorptionTimePickerRow(absorptionTime: $viewModel.absorptionTime, isFocused: absorptionTimeFocused, validDurationRange: viewModel.absorptionRimesRange, showHowAbsorptionTimeWorks: $showHowAbsorptionTimeWorks)
+            EmojiRow(text: $viewModel.foodType, isFocused: foodTypeFocused, emojiType: .food, title: NSLocalizedString("Food Type", comment: "Label for food type entry on add favorite food screen"))
+
+            CardSectionDivider()
+
+            AbsorptionTimePickerRow(absorptionTime: $viewModel.absorptionTime, isFocused: absorptionTimeFocused, title: NSLocalizedString("Absorption Time", comment: "Label for absorption time entry row on add favorite food screen"), validDurationRange: viewModel.absorptionRimesRange, showHowAbsorptionTimeWorks: $showHowAbsorptionTimeWorks)
                 .padding(.bottom, 2)
         }
         .padding(.vertical, 12)
@@ -145,13 +145,13 @@ struct AddEditFavoriteFoodView: View {
 extension AddEditFavoriteFoodView {
     private var dismissButton: some View {
         Button(action: dismiss.callAsFunction) {
-            Text("Cancel")
+            Text(NSLocalizedString("Cancel", comment: "Favorite food cancel button"))
         }
     }
     
     private var saveActionButton: some View {
         Button(action: viewModel.save) {
-            Text("Save")
+            Text(NSLocalizedString("Save", comment: "Favorite food save button"))
         }
         .buttonStyle(ActionButtonStyle())
         .padding()
@@ -160,7 +160,7 @@ extension AddEditFavoriteFoodView {
     
     private var saveButton: some View {
         Button(action: viewModel.save) {
-            Text("Save")
+            Text(NSLocalizedString("Save", comment: "Favorite food save button"))
         }
         .disabled(viewModel.updatedFavoriteFood == nil)
     }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -311,7 +311,7 @@ struct BolusEntryView: View {
             let suspendThresholdString = displayGlucosePreference.format(suspendThreshold)
             return WarningView(
                 title: Text("No Bolus Recommended", comment: "Title for bolus screen notice when no bolus is recommended"),
-                caption: Text("Your glucose is below or predicted to go below your glucose safety limit, \(suspendThresholdString).", comment: "Caption for bolus screen notice when no bolus is recommended due to prediction dropping below glucose safety limit")
+                caption: Text(String(format: NSLocalizedString("Your glucose is below or predicted to go below your glucose safety limit, \(suspendThresholdString).", comment: "Caption for bolus screen notice when no bolus is recommended due to prediction dropping below glucose safety limit")))
             )
         case .staleGlucoseData:
             return WarningView(

--- a/Loop/Views/CarbEntryView.swift
+++ b/Loop/Views/CarbEntryView.swift
@@ -106,15 +106,15 @@ struct CarbEntryView: View, HorizontalSizeClassOverride {
 
             CardSectionDivider()
             
-            DatePickerRow(date: $viewModel.time, isFocused: timeFocused, minimumDate: viewModel.minimumDate, maximumDate: viewModel.maximumDate)
+            DatePickerRow(date: $viewModel.time, isFocused: timeFocused, title: NSLocalizedString("Time", comment: "Label for time entry row on carb entry screen"), minimumDate: viewModel.minimumDate, maximumDate: viewModel.maximumDate)
             
             CardSectionDivider()
             
-            FoodTypeRow(foodType: $viewModel.foodType, absorptionTime: $viewModel.absorptionTime, selectedDefaultAbsorptionTimeEmoji: $viewModel.selectedDefaultAbsorptionTimeEmoji, usesCustomFoodType: $viewModel.usesCustomFoodType, absorptionTimeWasEdited: $viewModel.absorptionTimeWasEdited, isFocused: foodTypeFocused, defaultAbsorptionTimes: viewModel.defaultAbsorptionTimes)
+            FoodTypeRow(foodType: $viewModel.foodType, absorptionTime: $viewModel.absorptionTime, selectedDefaultAbsorptionTimeEmoji: $viewModel.selectedDefaultAbsorptionTimeEmoji, usesCustomFoodType: $viewModel.usesCustomFoodType, absorptionTimeWasEdited: $viewModel.absorptionTimeWasEdited, isFocused: foodTypeFocused, title: NSLocalizedString("Food Type", comment: "Label for food type entry row on carb entry screen"), defaultAbsorptionTimes: viewModel.defaultAbsorptionTimes)
             
             CardSectionDivider()
             
-            AbsorptionTimePickerRow(absorptionTime: $viewModel.absorptionTime, isFocused: absorptionTimeFocused, validDurationRange: viewModel.absorptionRimesRange, showHowAbsorptionTimeWorks: $showHowAbsorptionTimeWorks)
+            AbsorptionTimePickerRow(absorptionTime: $viewModel.absorptionTime, isFocused: absorptionTimeFocused, title: NSLocalizedString("Absorption Time", comment: "Label for absorption time entry row on carb entry screen"), validDurationRange: viewModel.absorptionRimesRange, showHowAbsorptionTimeWorks: $showHowAbsorptionTimeWorks)
                 .padding(.bottom, 2)
         }
         .padding(.vertical, 12)

--- a/Loop/Views/FavoriteFoodsView.swift
+++ b/Loop/Views/FavoriteFoodsView.swift
@@ -61,7 +61,7 @@ struct FavoriteFoodsView: View {
                     dismissButton
                 }
             }
-            .navigationBarTitle("Favorite Foods", displayMode: .large)
+            .navigationBarTitle(NSLocalizedString("Favorite Foods", comment: "Favorite Foods view title"), displayMode: .large)
         }
         .sheet(isPresented: $viewModel.isAddViewActive) {
             AddEditFavoriteFoodView(onSave: viewModel.onFoodSave(_:))

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -369,8 +369,8 @@ extension SettingsView {
             LargeButton(action: { sheet = .favoriteFoods },
                         includeArrow: true,
                         imageView: Image("Favorite Foods Icon").renderingMode(.template).foregroundColor(carbTintColor),
-                        label: "Favorite Foods",
-                        descriptiveText: "Simplify Carb Entry")
+                        label: NSLocalizedString("Favorite Foods", comment: "Button title for entering Favorite Foods settings"),
+                        descriptiveText: NSLocalizedString("Simplify Carb Entry", comment: "Descriptive text for Favorite Foods setting button"))
         }
     }
     

--- a/Loop/sv.lproj/Localizable.strings
+++ b/Loop/sv.lproj/Localizable.strings
@@ -1,8 +1,14 @@
-/* The string format appended to active insulin that describes pending insulin. (1: pending insulin) */
-" (pending: %@)" = " (återstår: %@)";
+/* No comment provided by engineer. */
+"" = "";
 
 /* Status row title for premeal override enabled (leading space is to separate from symbol) */
 " Pre-meal Preset" = " Preprandiellt förval";
+
+/* remaining time in setting's profile expiration section */
+" remaining" = " återstår";
+
+/* Warning text for when Notifications or Critical Alerts Permissions is disabled */
+" Safety Notifications are OFF" = "Säkerhetsnotiser är AV";
 
 /* Status row title for workout override enabled (leading space is to separate from symbol) */
 " Workout Preset" = " Träningsförval";
@@ -16,7 +22,10 @@
 /* No glucose value representation (3 dashes for mg/dL) */
 "– – –" = "– – –";
 
-/* The format for an active override preset. (1: preset symbol)(2: preset name) */
+/* Full stop character */
+"." = ".";
+
+/* The format for an active custom preset. (1: preset symbol)(2: preset name) */
 "%@ %@" = "%1$@ %2$@";
 
 /* Formats absorbed carb value */
@@ -28,38 +37,42 @@
 /* The subtitle format describing total insulin. (1: localized insulin total) */
 "%@ U Total" = "%@ E totalt";
 
-/* Appends a full-stop to a statement */
-"%@." = "%@.";
+/* Alert text for failing to cancel temp basal (1: reason description, 2: app name) */
+"%@%@ was unable to cancel your current temporary basal rate, which is higher than the new Max Basal limit you have set. This may result in higher insulin delivery than desired.\n\nConsider suspending insulin delivery manually and then immediately resuming to enact basal delivery with the new limit in place." = "%@%@ kunde inte avbryta din nuvarande temporära basal som är högre än den nya maxgränsen du har ställt in. Detta kan resultera i högre insulintillförsel än önskat.\n\nÖverväg att manuellt pausa insulintillförseln och sedan omedelbart återuppta för att genomföra basaldoseringen med den nya gränsen.";
 
-/* Format string for glucose target range. (1: Min target)(2: Max target)(3: glucose unit) */
-"%1$@ – %2$@ %3$@" = "%1$@ – %2$@ %3$@";
+/* Adds a full-stop to a statement (1: statement, 2: full stop character) */
+"%1@%2@" = "%1@%2@";
 
 /* Format string combining carb entry quantity and absorption time emoji */
 "%1$@ %2$@" = "%1$@ %2$@";
 
-/* Format string for carb ratio average. (1: value)(2: carb unit) */
-"%1$@ %2$@/U" = "%1$@ %2$@/E";
-
-/* Formats (1: carb start time) and (2: carb absorption duration) */
+/* Format string combining carb entry time and absorption time
+   Formats (1: carb start time) and (2: carb absorption duration) */
 "%1$@ + %2$@" = "%1$@ + %2$@";
+
+/* App sounds title text (1: app name) */
+"%1$@ APP SOUNDS" = "%1$@ APP-LJUD";
+
+/* Alert message for closed loop off informational modal. (1: app name) */
+"%1$@ is operating with Closed Loop in the OFF position. Your pump and CGM will continue operating, but the app will not adjust dosing automatically." = "%1$@ har sluten loop i AV-läge. Din pump och CGM kommer att fortsätta fungera, men appen kommer inte att justera insulintillförseln automatiskt.";
+
+/* Message for alert shown when alert acknowledgement fails for a device, and the device does not provide a LocalizedError. (1: app name) */
+"%1$@ is unable to clear the alert from your device" = "%1$@ kan inte rensa varningen från din enhet";
 
 /* Message for alert shown when delivery status is uncertain. (1: app name) */
 "%1$@ is unable to communicate with your insulin pump. The app will continue trying to reach your pump, but insulin delivery information cannot be updated and no automation can continue.\nYou can wait several minutes to see if the issue resolves or tap the button below to learn more about other options." = "%1$@ kan inte kommunicera med din insulinpump. Appen kommer att fortsätta att försöka nå din pump, men under tiden kan information om insulintillförsel inte uppdateras och automatisering inte fortsätta.\nDu kan vänta flera minuter för att se om problemet löser sig eller klicka på knappen nedan för att läsa mer om andra alternativ.";
 
+/* Time change alert title */
+"%1$@ Time Settings Need Attention" = "%1$@s tidsinställningarna behöver ses över";
+
 /* Reservoir entry (1: volume value) */
 "%1$@ U" = "%1$@ E";
 
-/* Low reservoir alert format string. (1: Number of units remaining) */
-"%1$@ U left" = "%1$@ E kvar";
+/* Format string for body for notification of upcoming expiration. (1: app name) (2: amount of time until expiration */
+"%1$@ will stop working in %2$@. You will need to rebuild before that." = "%1$@ kommer att sluta fungera om %2$@. Du måste bygga om %1$@ innan dess.";
 
-/* Low reservoir alert with time remaining format string. (1: Number of units remaining)(2: approximate time remaining) */
-"%1$@ U left: %2$@" = "%1$@ E kvar: %2$@";
-
-/* The format for recommended temp basal rate and time. (1: localized rate number)(2: localized time) */
-"%1$@ U/hour @ %2$@" = "%1$@ E/h @ %2$@";
-
-/* The format string for the app name and version number. (1: bundle name)(2: bundle version) */
-"%1$@ v%2$@" = "%1$@ v%2$@";
+/* Format string for body for notification of upcoming provisioning profile expiration. (1: app name) (2: amount of time until expiration */
+"%1$@ will stop working in %2$@. You will need to update before that, with a new provisioning profile." = "%1$@ kommer att sluta fungera om %2$@. Du måste uppdatera %1$@ innan dess med en ny provisioning-profil.";
 
 /* Formats (1: carb value) and (2: food type) */
 "%1$@: %2$@" = "%1$@: %2$@";
@@ -67,6 +80,9 @@
 /* Description of a basal temp basal dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit)
    Description of a bolus dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: unit) */
 "%1$@: <b>%2$@</b> %3$@" = "%1$@: <b>%2$@</b> %3$@";
+
+/* No comment provided by engineer. */
+"⚠️" = "⚠️";
 
 /* Description of the prediction input effect for glucose momentum */
 "15 min glucose regression coefficient (b₁), continued with decay over 30 min" = "15 minuters glukosregressionskoefficient (b₁), fortsatt med 30 minuters avklingande";
@@ -78,64 +94,93 @@
 "A few seconds remaining" = "Några sekunder återstår";
 
 /* Alert message for a manual glucose entry out of range error */
-"A manual glucose entry must be between %@ and %@" = "Det manuellt inmatade blodsockervärdet måste vara mellan %1$@ och %2$@";
+"A manual glucose entry must be between \(acceptableLowerBound) and \(acceptableUpperBound)" = "Ett manuellt inmatat blodsockervärde måste vara mellan \(acceptableLowerBound) och \(acceptableUpperBound)";
 
-/* Subtitle of Fiasp preset */
-"A model based on the published absorption of Fiasp insulin." = "Insulinmodell baserad på publicerade studier av absorption av Fiasp-insulin.";
+/* Warning for simple bolus when glucose entry is out of range. (1: upper bound) (2: lower bound) */
+"A manual glucose entry must be between %1$@ and %2$@." = "Ett manuellt inmatat blodsockervärde måste vara mellan %1$@ och %2$@.";
 
-/* Subtitle of Rapid-Acting – Adult preset */
-"A model based on the published absorption of Humalog, Novolog, and Apidra insulin in adults." = "Insulinmodell baserad på publicerade studier av absorption av Humalog-, Novolog- samt Apidra-insulin hos vuxna.";
+/* Software update available section footer (1: app name) */
+"A new version of %@ is available and is recommended to continue using the app." = "En ny version av %@ är tillgänglig och rekommenderas för fortsatt användning av appen.";
+
+/* Required software update section footer (1: app name) */
+"A new version of %@ is available." = "En ny version av %@ är tillgänglig.";
 
 /* Alert message for a missing pump error */
 "A pump must be configured before a bolus can be delivered." = "En pump måste ha lagts till och konfigurerats innan en bolus ge ges.";
 
-/* Action to copy the recommended Bolus value to the actual Bolus Field */
-"AcceptRecommendedBolus" = "AcceptRecommendedBolus";
+/* Label for absorption time entry row on add favorite food screen
+   Label for absorption time entry row on carb entry screen */
+"Absorption Time" = "Absorptionstid";
 
 /* The title of the Carbs On-Board graph */
 "Active Carbohydrates" = "Aktiva kolhydrater";
 
-/* The string format describing active carbohydrates. (1: localized glucose value description) */
-"Active Carbohydrates: %@" = "Aktiva kolhydrater: %@";
-
 /* Title describing quantity of still-absorbing carbohydrates */
 "Active Carbs" = "Aktiva kolhydrater";
 
-/* The title of the Insulin On-Board graph */
+/* Details for missing data error when active insulin amount is missing
+   The title of the Insulin On-Board graph
+   Title describing quantity of still-absorbing insulin */
 "Active Insulin" = "Aktivt insulin";
 
-/* The string format describing active insulin. (1: localized insulin value description) */
-"Active Insulin: %@" = "Aktivt insulin: %@";
-
-/* Title of the user activity for adding carbs */
-"Add Carb Entry" = "Lägg till kolhydrater";
+/* No comment provided by engineer. */
+"Add a new favorite food" = "Lägg till en ny favoritmat";
 
 /* Action sheet title selecting CGM
+   The title of the CGM chooser in settings
+   Title text for button to add CGM device
    Title text for button to set up a CGM */
 "Add CGM" = "Lägg till CGM";
 
-/* The label of the meal button */
+/* The label of the carb entry button */
 "Add Meal" = "Lägg till måltid";
 
 /* Action sheet title selecting Pump
-   Title text for button to set up a new pump */
+   The title of the pump chooser in settings
+   Title text for button to add pump device
+   Title text for button to set up a Pump */
 "Add Pump" = "Lägg till pump";
 
-/* Title text for button to set up a service */
+/* Action sheet title selecting service
+   The title of the add service action sheet in settings
+   The title of the add service button in settings */
 "Add Service" = "Lägg till tjänst";
 
 /* No comment provided by engineer. */
 "Adjusted for" = "Justerad för";
 
 /* Alert Permissions button text
+   Title of alert management screen */
+"Alert Management" = "Hantera varningar";
+
+/* Alert Permissions button text
    Notification & Critical Alert Permissions screen title */
-"Alert Permissions" = "Behörigheter för Varningar";
+"Alert Permissions" = "Behörigheter för varningar";
 
-/* The title of the section containing algorithm settings */
-"Algorithm Settings" = "Algoritminställningar";
+/* Alert Permissions descriptive text */
+"Alert Permissions and Mute Alerts" = "Behörigheter för varningar och tysta varningar";
 
-/* The title of the Amplitude service */
-"Amplitude" = "Amplitude";
+/* Navigation title for algorithms experiments screen
+   The title of the Algorithm Experiments section in settings */
+"Algorithm Experiments" = "Algoritmexperiment";
+
+/* Algorithm Experiments description. */
+"Algorithm Experiments are optional modifications to the Loop Algorithm. These modifications are less tested than the standard Loop Algorithm, so please use carefully." = "Algoritmexperiment är valfria modifieringar av Loop-algoritmen. Dessa modifieringar är mindre testade än den standardiserade Loop-algoritmen, så använd dem med försiktighet.";
+
+/* Warning text for when alerts are muted */
+"All Alerts Muted" = "Alla varningar är tystade";
+
+/* Label for when mute alert will end */
+"All alerts muted until" = "Alla varningar tystade till";
+
+/* No comment provided by engineer. */
+"All Favorites" = "Alla favoriter";
+
+/* Label for carb quantity entry row on carb entry screen */
+"Amount Consumed" = "Mängd";
+
+/* Warning to ensure the carb entry is accurate during an override */
+"An active override is modifying your carb ratio and insulin sensitivity. If you don't want this to affect your bolus calculation and projected glucose, consider turning off the override." = "En aktiv åsidosättning ändrar din kolhydratkvot och insulinkänslighet. Om du inte vill att detta ska påverka din bolusberäkning och förväntade glukos, överväg att stänga av åsidosättningen.";
 
 /* Alert message for a carb entry persistence error */
 "An error occurred while trying to save your carb entry." = "Ett fel uppstod när du skulle spara dina kolhydrater.";
@@ -143,14 +188,17 @@
 /* Alert message for a manual glucose entry persistence error */
 "An error occurred while trying to save your manual glucose entry." = "Ett fel uppstod när du skulle spara ditt blodsockervärde.";
 
+/* Invalid onboarding state */
+"An unexpected onboarding error state occurred." = "Ett oväntat fel inträffade vid onboarding.";
+
 /* Alert message when glucose data returns while on bolus screen */
 "An updated bolus recommendation is available." = "Det finns nu en ny bolusrekommendation.";
 
-/* The title of the amplitude API key credential */
-"API Key" = "API Key";
+/* Settings app profile section */
+"App Profile" = "App-profil";
 
-/* The title of the nightscout API secret credential */
-"API Secret" = "API Secret";
+/* Default name on add favorite food screen */
+"Apple" = "Äpple";
 
 /* Action sheet confirmation message for pump history deletion */
 "Are you sure you want to delete all history entries?" = "Säkert att du vill radera all händelsehistorik?";
@@ -162,13 +210,13 @@
 "Are you sure you want to delete all reservoir values?" = "Säkert att du vill radera alla reservoarvärden?";
 
 /* No comment provided by engineer. */
-"Are you sure you want to delete all your %@ Data?\n(This action is not reversible)" = "Vill du ta bort alla dina %@data?\n(Denna åtgärd är inte reversibel)";
+"Are you sure you want to delete all your \(model.name()) Data?\n(This action is not reversible)" = "Är du säker på att du vill radera all din \(model.name()) data?\n(Denna åtgärd kan inte ångras)";
 
 /* Confirmation message for deleting a CGM */
 "Are you sure you want to delete this CGM?" = "Är du säker på att du vill radera denna CGM?";
 
-/* Confirmation message for deleting a service */
-"Are you sure you want to delete this service?" = "Vill du ta bort den här tjänsten?";
+/* No comment provided by engineer. */
+"Are you sure you want to delete this food?" = "Är du säker på att du vill radera denna mat?";
 
 /* Format fragment for a specific time */
 "at %@" = "kl. %@";
@@ -182,9 +230,8 @@
 /* Details for configuration error when basal rate schedule is missing */
 "Basal Rate Schedule" = "Basaldosschema";
 
-/* The title of the basal rate profile screen
-   The title text for the basal rate schedule */
-"Basal Rates" = "Basaldoser";
+/* Caption for bolus screen notice when no bolus is recommended for the predicted glucose */
+"Based on your predicted glucose, no bolus is recommended." = "Baserat på ditt förväntade glukosvärde rekommenderas ingen bolus.";
 
 /* Message to the user to that the bluetooth is off */
 "Bluetooth\nOff" = "Bluetooth Av";
@@ -198,9 +245,14 @@
 /* Bluetooth unavailable alert title */
 "Bluetooth Unavailable Alert" = "Varning Bluetooth är inte tillgänglig";
 
-/* The label of the bolus entry button
-   The notification title for a bolus failure */
+/* Label for bolus entry row on bolus screen
+   Label for bolus entry row on simple bolus screen
+   The label of the bolus entry button
+   Title for bolus entry screen */
 "Bolus" = "Bolus";
+
+/* The notification title for a bolus issue */
+"Bolus Issue" = "Bolusfel";
 
 /* Alert title for an updated bolus recommendation */
 "Bolus Recommendation Updated" = "Det finns en ny bolusrekommendation";
@@ -208,13 +260,19 @@
 /* Title for card displaying carb entry and bolus recommendation */
 "Bolus Summary" = "Bolus sammanfattning";
 
+/* Alert title for a bolus too small validation error */
+"Bolus Too Small" = "Bolus för liten";
+
 /* The format string for bolus progress. (1: delivered volume)(2: total volume) */
 "Bolused %1$@ of %2$@" = "Givit bolus %1$@ av %2$@";
 
 /* The format string for bolus in progress showing total volume. (1: total volume) */
 "Bolusing %1$@" = "Ger bolus %1$@ ";
 
-/* The title of the cancel action in an action sheet */
+/* Cancel button for reset loop alert
+   Cancel export button title
+   Favorite food cancel button
+   The title of the cancel action in an action sheet */
 "Cancel" = "Avbryt";
 
 /* The title of the cell indicating a bolus is being canceled */
@@ -226,49 +284,55 @@
 /* Label for carb entry row on bolus screen */
 "Carb Entry" = "Kolhydrater";
 
-/* The title of the carb ratios schedule screen
-   The title text for the carb ratio schedule */
-"Carb Ratios" = "Insulinkvoter";
+/* Label for carb quantity row on add favorite food screen */
+"Carb Quantity" = "Mängd";
+
+/* Details for configuration error when carb ratio schedule is missing */
+"Carb Ratio Schedule" = "Kolhydratkvotsschema";
 
 /* The title of the view controller to create a new carb entry */
 "carb-entry-title-add" = "Lägg till kolhydrater";
 
-/* Title of the prediction input effect for carbohydrates */
+/* Title for bolus screen warning when carbohydrate entry is too large */
+"Carbohydrate Entry Too Large" = "Kolhydratinmatning för stor";
+
+/* Label for carbohydrates entry row on simple bolus screen
+   Title of the prediction input effect for carbohydrates */
 "Carbohydrates" = "Kolhydrater";
 
 /* Description of the prediction input effect for carbohydrates. (1: The glucose unit string) */
 "Carbs Absorbed (g) ÷ Carb Ratio (g/U) × Insulin Sensitivity (%1$@/U)" = "Absorberade kolhydrater (g) ÷ Insulinkvot (g/E) × Insulinkänslighet (%1$@/E)";
 
-/* The notification alert describing a low pump battery */
-"Change the pump battery immediately" = "Byt pumpbatteri nu";
-
-/* The notification alert describing an empty pump reservoir */
-"Change the pump reservoir now" = "Byt pumpreservoar nu";
-
-/* Details for configuration error when one or more loop settings are missing */
-"Check settings" = "Kontrollera inställningarna";
-
-/* Recovery suggestion when reservoir data is missing */
-"Check that your pump is in range" = "Kontrollera att pumpen är inom räckhåll";
+/* No comment provided by engineer. */
+"Caution" = "Varning";
 
 /* Recovery suggestion when glucose data is missing */
 "Check your CGM data source" = "Kontrollera din CGM:s datakälla";
 
+/* Caption for bolus screen notice when glucose data is in the future */
+"Check your device time and/or remove any invalid data from Apple Health." = "Kontrollera din enhets tid och/eller ta bort eventuell ogiltig data från appen Hälsa.";
+
 /* Carb entry section footer text explaining absorption time */
 "Choose a longer absorption time for larger meals, or those containing fats and proteins. This is only guidance to the algorithm and need not be exact." = "Välj en längre absorptionstid för måltid med mycket fett eller protein. Ofta är det bäst att dela upp måltiden i snabba och långsamma kolhydrater och mata in dessa var för sig.";
+
+/* No comment provided by engineer. */
+"Choose Favorite:" = "Välj favorit:";
 
 /* Button title to close view
    The button label of the action used to dismiss the unsafe notification permission alert */
 "Close" = "Stäng";
 
 /* The title text for the looping enabled switch cell */
-"Closed Loop" = "Sluten loop";
+"Closed Loop" = "Sluten Loop";
 
 /* Alert title for closed loop off informational modal */
 "Closed Loop OFF" = "Sluten Loop är AV";
 
 /* The description text for the looping enabled switch cell when closed loop is not allowed because the sensor is inactive */
 "Closed Loop requires an active CGM Sensor Session" = "Sluten Loop kräver en aktiv CGM-sensor";
+
+/* The description text for the looping enabled switch cell when onboarding is not complete */
+"Closed Loop requires Setup to be Complete" = "Sluten Loop kräver att inställningen är slutförd";
 
 /* The format string describing the date of an IOB value. The first format argument is the localized date. */
 "com.loudnate.InsulinKit.IOBDateLabel" = "kl %1$@";
@@ -279,7 +343,10 @@
 /* The title of the action used to dismiss an error alert */
 "com.loudnate.LoopKit.errorAlertActionTitle" = "OK";
 
-/* The title of the configuration section in settings */
+/* Title text for button to complete setup */
+"Complete Setup" = "Slutför inställning";
+
+/* The title of the Configuration section in settings */
 "Configuration" = "Konfiguration";
 
 /* The error message displayed for configuration errors. (1: configuration error details) */
@@ -288,12 +355,14 @@
 /* Default alert dismissal */
 "Continue" = "Fortsätt";
 
-/* The title of the continuous glucose monitor section in settings */
+/* Descriptive text for Continuous Glucose Monitor */
 "Continuous Glucose Monitor" = "Kontinuerlig glukosmätning";
 
-/* The title of the glucose target range schedule screen
-   The title text for the glucose target range schedule */
-"Correction Range" = "Målvärde";
+/* Format string for title of reset loop alert. (1: App name) */
+"Could Not Restart %1$@" = "Kunde inte starta om %1$@";
+
+/* Critical Alerts Status text */
+"Critical Alerts" = "Kritiska varningar";
 
 /* Critical event log ready text */
 "Critical Event Log Ready" = "Kritisk händelselogg klar";
@@ -310,23 +379,14 @@
 /* Message when offering bolus recommendation even though bg is below range. (1: glucose value) */
 "Current glucose of %1$@ is below correction range." = "Nuvarande glukosvärde %1$@ är under målvärde.";
 
-/* The title of the cell indicating a generic temporary override is enabled */
-"Custom Override" = "Anpassad Override";
-
 /* The title of the cell indicating a generic custom preset is enabled */
 "Custom Preset" = "Anpassad förinställning";
 
 /* Date picker label */
 "Date" = "Tid";
 
-/* The short unit display string for decibles */
-"dB" = "dB";
-
 /* No comment provided by engineer. */
 "Delete" = "Ta bort";
-
-/* The title of the button to remove the credentials for a service */
-"Delete Account" = "Radera konto";
 
 /* Button title to delete all objects */
 "Delete All" = "Radera allt";
@@ -334,8 +394,8 @@
 /* Button title to delete CGM */
 "Delete CGM" = "Radera CGM";
 
-/* Button title to delete a service */
-"Delete Service" = "Ta bort tjänst";
+/* No comment provided by engineer. */
+"Delete Food" = "Radera mat";
 
 /* No comment provided by engineer. */
 "Delete Testing CGM Data" = "Ta bort simulerade testvärden från CGM";
@@ -346,14 +406,17 @@
 /* No comment provided by engineer. */
 "Delete Testing Pump Data" = "Ta bort simulerade pumpvärden";
 
+/* No comment provided by engineer. */
+"Delete “\(food.name)”?" = "Radera “\(food.name)”?";
+
 /* Button text to deliver a bolus */
 "Deliver" = "Ge bolus";
 
-/* Title text for delivery limits */
-"Delivery Limits" = "Maxdoser";
-
 /* Descriptive text for Therapy Settings */
 "Diabetes Treatment" = "Diabetesbehandling";
+
+/* Alert body when entered carbohydrates is greater than threshold (1: entered quantity in grams) */
+"Did you intend to enter %1$@ grams as the amount of carbohydrates for this meal?" = "Avsåg du att ange %1$@ gram som mängden kolhydrater för denna måltid?";
 
 /* The action hint of the workout mode toggle button when enabled */
 "Disables" = "Stänger av";
@@ -363,7 +426,7 @@
 "Dismiss" = "Avfärda";
 
 /* No comment provided by engineer. */
-"Done" = "Färdig";
+"Done" = "Klar";
 
 /* Title for card to log dose */
 "Dose Summary" = "Sammanfattning av dos";
@@ -371,8 +434,17 @@
 /* The title of the Dosing Strategy section in settings */
 "Dosing Strategy" = "Strategi för insulinbehandling";
 
+/* Override error description: duration exceed max (1: max duration in hours). */
+"Duration exceeds: %1$.1f hours" = "Varaktigheten överstiger: %1$.1f timmar";
+
 /* Message to the user to enable bluetooth */
-"Enable\nBluetooth" = "Aktivera Bluetooth";
+"Enable\nBluetooth" = "Aktivera\nBluetooth";
+
+/* Title for Glucose Based Partial Application toggle */
+"Enable Glucose Based Partial Application" = "Aktivera glukosbaserad partiell tillämpning";
+
+/* Title for Integral Retrospective Correction toggle */
+"Enable Integral Retrospective Correction" = "Aktivera integrerad restrospektiv korrigering";
 
 /* The action hint of the workout mode toggle button when disabled */
 "Enables" = "Slår på";
@@ -389,17 +461,11 @@
 /* The placeholder text instructing users to enter a glucose safety limit */
 "Enter glucose safety limit" = "Ange tröskelvärde för blodsocker";
 
-/* The placeholder text instructing users to enter a suspend treshold */
-"Enter suspend threshold" = "Ange tröskelvärde";
-
 /* The alert title for an error while canceling a bolus */
 "Error Canceling Bolus" = "Fel vid försök att avbryta bolus";
 
 /* Critical event log export error alert title */
 "Error Exporting Logs" = "Fel vid export av loggar";
-
-/* The alert title for a resume error */
-"Error Resuming" = "Fel vid återupptagande";
 
 /* Segmented button title for insulin delivery log event history */
 "Event History" = "Händelsehistorik";
@@ -407,7 +473,13 @@
 /* The subtitle format describing eventual glucose. (1: localized glucose value description) */
 "Eventually %@" = "Förväntat %@";
 
-/* The title of the alert describing a maximum bolus validation error */
+/* Bolus error description: bolus exceeds maximum bolus in settings. */
+"Exceeds maximum allowed bolus in settings" = "Överstiger maximalt tillåten bolus i inställningarna";
+
+/* Carb error description: carbs exceed maximum amount. */
+"Exceeds maximum allowed carbs" = "Överstiger maximalt tillåten mängd kolhydrater";
+
+/* Alert title for a maximum bolus validation error */
 "Exceeds Maximum Bolus" = "Överstiger maxbolusdos";
 
 /* The title of the export critical event logs in support */
@@ -419,20 +491,48 @@
 /* The alert title for a resume error */
 "Failed to Resume Insulin Delivery" = "Misslyckades att återuppta insulintillförsel";
 
-/* Title of insulin model preset */
-"Fiasp" = "Fiasp";
+/* Button title for entering Favorite Foods settings
+   Favorite Foods view title */
+"Favorite Foods" = "Favoritmat";
+
+/* No comment provided by engineer. */
+"FAVORITE FOODS" = "FAVORITMAT";
 
 /* Label for manual glucose entry row on bolus screen */
 "Fingerstick Glucose" = "Kapillärt blodsocker";
 
+/* Secondary text for alerts disabled warning, which appears on the main status screen. */
+"Fix now by turning Notifications, Critical Alerts and Time Sensitive Notifications ON." = "Åtgärda nu genom att slå på notiser, kritiska varningar och tidskänsliga notiser.";
+
+/* Label for food type entry on add favorite food screen
+   Label for food type entry row on carb entry screen */
+"Food Type" = "Typ av mat";
+
 /* The format string used to describe a finite workout targets duration */
 "For %1$@" = "I %1$@";
 
-/* The short unit display string for grams */
-"g" = "g";
+/* Description text for silencing time sensitive and non-critical alerts (1: app name) */
+"For safety purposes, you should allow Critical Alerts, Time Sensitive and Notification Permissions (non-critical alerts) on your device to continue using %1$@ and cannot turn off individual alarms." = "Av säkerhetsskäl bör du tillåta kritiska varningar, tidskänsliga och notisbehörigheter (icke-kritiska varningar) på din enhet för att fortsätta använda %1$@ och du kan inte stänga av enskilda larm.";
 
-/* The title of the glucose and prediction graph */
+/* No comment provided by engineer. */
+"Forecasted blood glucose may still be higher than target range." = "Förväntat blodsocker kan fortfarande vara högre än målintervallet.";
+
+/* Title for forecast explanation modal on bolus view */
+"Forecasted Glucose" = "Förväntat blodsocker";
+
+/* Label for link to see frequently asked questions */
+"Frequently asked questions about alerts" = "Vanliga frågor om varningar";
+
+/* Get help with Alert Permissions support button text */
+"Get help with Alert Permissions" = "Få hjälp med behörigheter för varningar";
+
+/* The title of the glucose and prediction graph
+   Title for predicted glucose chart on bolus screen */
 "Glucose" = "Glukos";
+
+/* Title for glucose based partial application experiment description
+   Title of glucose based partial application experiment */
+"Glucose Based Partial Application" = "Glukosbaserad partiell tillämpning";
 
 /* The error message when glucose data is too old to be used. (1: glucose data age in minutes) */
 "Glucose data is %1$@ old" = "Glukosvärde är %1$@ gammalt";
@@ -443,6 +543,9 @@
 /* Alert title when glucose data returns while on bolus screen */
 "Glucose Data Now Available" = "Blodglukosvärde finns nu tillgängligt";
 
+/* Description of the prediction input effect for suspension of insulin delivery */
+"Glucose effect of suspending insulin delivery" = "Glukoseffekt av att pausa insulintillförsel";
+
 /* Alert title for a manual glucose entry out of range error
    Title for bolus screen warning when glucose entry is out of range */
 "Glucose Entry Out of Range" = "Det manuellt inmatade blodsockervärdet utanför gränsvärden";
@@ -450,8 +553,38 @@
 /* Title of the prediction input effect for glucose momentum */
 "Glucose Momentum" = "Glukosförändring";
 
-/* The title of a target alert action specifying an indefinitely long workout targets duration */
-"Indefinitely" = "Oändligt";
+/* Details for configuration error when glucose target range schedule is missing */
+"Glucose Target Range Schedule" = "Målintervallsschema för blodsocker";
+
+/* No comment provided by engineer. */
+"HARDWARE SOUNDS" = "HÅRDVARULJUD";
+
+/* No comment provided by engineer. */
+"High Glucose" = "Högt blodsocker";
+
+/* No comment provided by engineer. */
+"How can I silence non-Critical Alerts?" = "Hur kan jag tysta icke-kritiska varningar?";
+
+/* No comment provided by engineer. */
+"How can I silence only Time Sensitive and Non-Critical alerts?" = "Hur kan jag tysta endast tidskänsliga och icke-kritiska varningar?";
+
+/* Title text for temporarily silencing all sounds (1: app name) */
+"How can I temporarily silence all %1$@ app sounds?" = "Hur kan jag tillfälligt tysta alla ljud i %1$@-appen?";
+
+/* The title text for how to update */
+"How to update (LoopDocs)" = "Hur man uppdaterar (LoopDocs)";
+
+/* Focus modes descriptive text (1: app name) */
+"If iOS Focus Mode is ON and Mute Alerts is OFF, Critical Alerts will still be delivered and non-Critical Alerts will be silenced until %1$@ is added to each Focus mode as an Allowed App." = "Om iOS Fokusläge är PÅ och Tysta Varningar är AV, kommer kritiska varningar fortfarande att levereras och icke-kritiska varningar kommer att tystas tills %1$@ läggs till som en tillåten app i varje fokusläge.";
+
+/* Immediate Delivery status text */
+"Immediate" = "Omedelbart";
+
+/* Algorithm Experiments description second paragraph. */
+"In future versions of Loop these experiments may change, end up as standard parts of the Loop Algorithm, or be removed from Loop entirely. Please follow along in the Loop Zulip chat to stay informed of possible changes to these features." = "I framtida versioner av Loop kan dessa experiment förändras, bli standarddelar av Loop-algoritmen, eller tas bort från Loop helt och hållet. Följ gärna med i Loop Zulip-chatten för att hålla dig informerad om eventuella förändringar av dessa funktioner.";
+
+/* No comment provided by engineer. */
+"Information" = "Information";
 
 /* Title of the prediction input effect for insulin */
 "Insulin" = "Insulin";
@@ -459,22 +592,21 @@
 /* Description of the prediction input effect for insulin */
 "Insulin Absorbed (U) × Insulin Sensitivity (%1$@/U)" = "Insulin absorberat (E) × Insulinkänslighet (%1$@/E)";
 
+/* Notification body for crash recovery alert */
+"Insulin adjustments have been disabled!" = "Insulinkorrigeringar har inaktiverats!";
+
 /* The title of the insulin delivery graph */
 "Insulin Delivery" = "Insulin doserat";
 
-/* Details for missing data error when insulin effects are missing */
+/* Details for missing data error when insulin effects are missing
+   Details for missing data error when insulin effects including pending insulin are missing */
 "Insulin effects" = "Insulineffekter";
-
-/* Details for configuration error when insulin model is missing
-   The title text for the insulin model setting row */
-"Insulin Model" = "Insulinmodell";
 
 /* Descriptive text for Insulin Pump */
 "Insulin Pump" = "Insulinpump";
 
-/* The title of the insulin sensitivities schedule screen
-   The title text for the insulin sensitivity schedule */
-"Insulin Sensitivities" = "Insulinkänslighet";
+/* Details for configuration error when insulin sensitivity schedule is missing */
+"Insulin Sensitivity Schedule" = "Schema för insulinkänslighet";
 
 /* The title of the cell indicating the pump is suspended */
 "Insulin Suspended" = "Insulintillförsel pausad";
@@ -482,17 +614,46 @@
 /* Insulin type label */
 "Insulin Type" = "Insulintyp";
 
+/* Title for integral retrospective correction experiment description
+   Title of integral retrospective correction experiment */
+"Integral Retrospective Correction" = "Integrerad retrospektiv korrigering";
+
+/* Description of Integral Retrospective Correction toggle. */
+"Integral Retrospective Correction (IRC) is an extension of the standard Retrospective Correction (RC) algorithm component in Loop, which adjusts the forecast based on the history of discrepancies between predicted and actual glucose levels.\n\nIn contrast to RC, which looks at discrepancies over the last 30 minutes, with IRC, the history of discrepancies adds up over time. So continued positive discrepancies over time will result in increased dosing. If the discrepancies are negative over time, Loop will reduce dosing further." = "Integrerad retrospektiv korrigering (IRC) är en utvidgning av den vanliga retrospektiv korrigering (RC) algoritmkomponenten i Loop, som justerar prognosen baserat på historiken av avvikelser mellan förutsagda och faktiska glukosnivåer.\n\nTill skillnad från RC, som tittar på avvikelser under de senaste 30 minuterna, summerar IRC avvikelsernas historik över tid. Så fortsatta positiva avvikelser över tid kommer att resultera i ökad dosering. Om avvikelserna är negativa över tid, kommer Loop att minska doseringen ytterligare.";
+
 /* Description of an interrupted bolus dose entry (1: title for dose type, 2: value (? if no value) in bold, 3: programmed value (? if no value), 4: unit) */
 "Interrupted %1$@: <b>%2$@</b> of %3$@ %4$@" = "Avbruten %1$@: <b>%2$@</b> av %3$@ %4$@";
 
-/* The error message when invalid data was encountered. (1: details of invalid data) */
-"Invalid data: %1$@" = "Ogiltigt värde: %1$@";
+/* Carb error description: invalid absorption time. (1: Input duration in hours). */
+"Invalid absorption time: %1$@ hours" = "Ogiltig absorptionstid: %1$@ timmar";
 
-/* The title text for the issue report cell */
+/* Bolus error description: invalid bolus amount. */
+"Invalid Bolus Amount" = "Ogiltig bolusmängd";
+
+/* Carb error description: invalid carb amount. */
+"Invalid carb amount" = "Ogiltig kolhydratmängd";
+
+/* Title for bolus screen notice when glucose data is in the future */
+"Invalid Future Glucose" = "Ogiltigt framtida blodsocker";
+
+/* The error message when glucose data is in the future. (1: glucose data time in future in minutes) */
+"Invalid glucose reading with a timestamp that is %1$@ in the future" = "Ogiltig blodsockermätning med en tidsstämpel som är %1$@ i framtiden";
+
+/* No comment provided by engineer. */
+"iOS Critical Alerts and Time Sensitive Alerts are types of Apple notifications. They are used for high-priority events. Some examples include:" = "iOS Kritiska Varningar och Tidskänsliga Varningar är typer av Apple-notifikationer. De används för högprioriterade händelser. Några exempel inkluderar:";
+
+/* No comment provided by engineer. */
+"IOS FOCUS MODES" = "IOS FOKUSLÄGEN";
+
+/* The title text for the issue report menu item
+   The view controller title for the issue report screen */
 "Issue Report" = "Skapa felrapport";
 
-/* Glucose HUD accessibility hint */
-"Launches CGM app" = "Startar CGM-app";
+/* The notification description for a meal that was possibly not logged in Loop. */
+"It looks like you may not have logged a meal you ate. Tap to log it now." = "Det verkar som att du kanske inte har loggat en måltid du åt. Tryck för att logga den nu.";
+
+/* Title of the warning shown when a large meal was entered */
+"Large Meal Entered" = "Stor måltid inmatad";
 
 /* OK button title for alert shown when delivery status is uncertain */
 "Learn More" = "Lär dig mer";
@@ -510,48 +671,91 @@
 /* The title of the screen displaying a manually entered insulin dose */
 "Logged Insulin Dose" = "Loggad insulindos";
 
+/* Title for crash recovery alert */
+"Loop Crashed" = "Loop krashade";
+
 /* The notification title for a loop failure */
 "Loop Failure" = "Loopfel";
 
 /* Bluetooth unavailable alert body. */
 "Loop has detected an issue with your Bluetooth settings, and will not work successfully until Bluetooth is enabled. You will not receive glucose readings, or be able to bolus." = "Loop har upptäckt ett problem med dina Bluetooth-inställningar och kommer inte att fungera förrän Bluetooth är aktiverat. Du kommer varken att kunna se dina blodsockervärden eller att kunna ge någon bolus.";
 
+/* Warning displayed when user is adding a meal from an missed meal notification */
+"Loop has detected an missed meal and estimated its size. Edit the carb amount to match the amount of any carbs you may have eaten." = "Loop har upptäckt en missad måltid och uppskattat dess storlek. Redigera mängden kolhydrater för att matcha mängden du kan ha ätit.";
+
 /* The notification alert describing a long-lasting loop failure. The substitution parameter is the time interval since the last loop */
 "Loop has not completed successfully in %@" = "Loop har inte lyckats köra på %@";
+
+/* Description of Glucose Based Partial Application toggle. */
+"Loop normally gives 40% of your predicted insulin needs each dosing cycle.\n\nWhen the Glucose Based Partial Application experiment is enabled, Loop will vary the percentage of recommended bolus delivered each cycle with glucose level.\n\nNear correction range, it will use 20% (similar to Temp Basal), and gradually increase to a maximum of 80% at high glucose (200 mg/dL, 11.1 mmol/L).\n\nPlease be aware that during fast rising glucose, such as after an unannounced meal, this feature, combined with velocity and retrospective correction effects, may result in a larger dose than your ISF would call for." = "Loop ger normalt 40 % av ditt förväntade insulinbehov vid varje doseringscykel.\n\nNär glukosbaserad partiell tillämpning är aktiverad, kommer Loop att variera procentandelen av den rekommenderade bolusdosen som ges vid varje cykel beroende på glukosnivån.\n\nNära korrigeringsintervallet kommer den att använda 20 % (liknande en temporär basal), och gradvis öka till maximalt 80 % vid höga glukosnivåer (200 mg/dL, 11,1 mmol/L).\n\nVar medveten om att vid snabbt stigande glukosnivåer, såsom efter en oregistrerad måltid, kan denna funktion, i kombination med hastighets- och retrospektiva korrigeringar, resultera i en större dos än vad din ISF skulle ange.";
 
 /* Description string for automatic bolus dosing strategy */
 "Loop will automatically bolus when insulin needs are above scheduled basal, and will use temporary basal rates when needed to reduce insulin delivery below scheduled basal." = "Loop kommer att ge bolus automatiskt när insulinbehovet är större än ordinarie basal och kommer, vid behov, att minska din ordinarie basal med temporära basaldoser för att minska insulintillförseln.";
 
+/* Bluetooth off background alert body. */
+"Loop will not work successfully until Bluetooth is enabled. You will not receive glucose readings, or be able to bolus." = "Loop kommer inte att fungera förrän Bluetooth är aktiverat. Du kommer inte att få glukosavläsningar eller kunna ge bolus.";
+
 /* Description string for temp basal only dosing strategy */
 "Loop will set temporary basal rates to increase and decrease insulin delivery." = "Loop kommer att ställa in tillfälliga basalnivåer för att öka eller minska insulintillförsel.";
+
+/* Title for bolus screen warning when glucose is below glucose warning limit.
+   Title for bolus screen warning when glucose is below suspend threshold, but a bolus is recommended */
+"Low Glucose" = "Lågt blodsocker";
+
+/* Manage Permissions in Settings button text */
+"Manage Permissions in Settings" = "Hantera behörigheter i inställningar";
+
+/* View title for how mute alerts work */
+"Managing Alerts" = "Hantera varningar";
+
+/* Description of a bolus dose entry (1: value (? if no value) in bold, 2: unit) */
+"Manual Dose: <b>%1$@</b> %2$@" = "Manuell dos: <b>%1$@</b> %2$@";
+
+/* Details for configuration error when maximum basal rate per hour is missing */
+"Maximum Basal Rate Per Hour" = "Maximal basal per timme";
 
 /* Details for configuration error when maximum bolus is missing */
 "Maximum Bolus" = "Maximal bolus";
 
+/* Title for bolus screen warning when max bolus is exceeded */
+"Maximum Bolus Exceeded" = "Maximal bolus överskriden";
+
 /* Title for bolus entry screen when also entering carbs */
 "Meal Bolus" = "Måltidsbolus";
 
-/* The short unit display string for milligrams of glucose per decilter */
-"mg/dL" = "mg/dl";
+/* Title for missed meal notifications toggle */
+"Missed Meal Notifications" = "Varningar om glömd måltid";
 
 /* The error message for missing data. (1: missing data details) */
 "Missing data: %1$@" = "Saknar data: %1$@";
 
-/* The short unit display string for millimoles of glucose per liter */
-"mmol/L" = "mmol/L";
+/* Bolus error description: missing maximum bolus in settings. */
+"Missing maximum allowed bolus in settings" = "Saknar maximal tillåten bolus i inställningarna";
 
 /* Details for missing data error when momentum effects are missing */
 "Momentum effects" = "Momentumeffekter";
 
-/* Text for more info action on notification of upcoming profile expiration
-   Text for more info action on notification of upcoming TestFlight expiration */
+/* Text for more info action on notification of upcoming TestFlight expiration
+   Text for more info action on notification of upcoming profile expiration */
 "More Info" = "Mer info";
 
-/* Sensor state description for the non-valid state */
-"Needs Attention" = "Kräver uppmärksamhet";
+/* Label for button to mute all alerts */
+"Mute All Alerts" = "Tysta alla varningar";
 
-/* The title of the Nightscout service */
-"Nightscout" = "Nightscout";
+/* Title for mute alert duration selection action sheet */
+"Mute All Alerts Temporarily" = "Tysta alla varningar temporärt";
+
+/* Label for name row on add favorite food screen */
+"Name" = "Namn";
+
+/* Override error description: negative duration error. */
+"Negative duration not allowed" = "Negativ varaktighet är inte tillåten";
+
+/* Title of new favorite food screen */
+"New Favorite Food" = "Ny favoritmat";
+
+/* Message for mute alert duration selection action sheet */
+"No alerts or alarms will sound while muted. Select how long you would you like to mute for." = "Inga varningar eller larm kommer att ljuda medan de är tystade. Välj hur länge du vill tysta dem.";
 
 /* Title for bolus screen notice when no bolus is recommended
    Title for bolus screen warning when glucose is below suspend threshold, and a bolus is not recommended
@@ -568,7 +772,7 @@
 "No Pump Configured" = "Ingen pump konfigurerad";
 
 /* The title of the cell indicating that there is no recent glucose */
-"No Recent Glucose" = "Inga senaste blodglukosvärde";
+"No Recent Glucose" = "Glukosvärde saknas";
 
 /* Title for bolus screen notice when glucose data is missing or stale */
 "No Recent Glucose Data" = "Inget aktuellt blodsockervärde";
@@ -576,23 +780,41 @@
 /* Title for bolus screen notice when pump data is missing or stale */
 "No Recent Pump Data" = "Det finns inga aktuella pumpdata";
 
+/* The title of the action used when rejecting the the amount of carbohydrates entered. */
+"No, edit amount" = "Nej, redigera mängd";
+
+/* Notification Delivery Status text */
+"Notification Delivery" = "Leverans av notiser";
+
+/* Notifications Status text */
+"Notifications" = "Notiser";
+
+/* Scheduled Delivery Enabled alert title */
+"Notifications Delayed" = "Notifications Delayed";
+
+/* Alert Permissions descriptive text (1: app name) */
+"Notifications give you important %1$@ app information without requiring you to open the app." = "Notiser ger dig viktig information om %1$@-appen utan att du behöver öppna appen.";
+
 /* Notification Setting Status is Off */
 "Off" = "Av";
+
+/* Modal body for crash recovery alert */
+"Oh no! Loop crashed while dosing, and insulin adjustments have been paused until this dialog is closed. Dosing history may not be accurate. Please review Insulin Delivery charts, and monitor your blood glucose carefully." = "Åh nej! Loop kraschade under insulintillförsel, och insulinjusteringar har pausats tills denna dialog stängs. Doseringshistoriken kan vara felaktig. Vänligen granska insulintillförselns diagram och övervaka ditt blodsocker noggrant.";
 
 /* Alert acknowledgment OK button
    Critical Alert permissions disabled alert button
    Default action for alert when alert acknowledgment fails
    Notifications permissions disabled alert button
-   Text for ok action on notification of upcoming profile expiration
    Text for ok action on notification of upcoming TestFlight expiration
+   Text for ok action on notification of upcoming profile expiration
    The title of the notification action to acknowledge a device alert */
 "OK" = "OK";
 
 /* Notification Setting Status is On */
 "On" = "På";
 
-/* The title text for the override presets */
-"Override Presets" = "Override förinställningar";
+/* The notification title for a meal that was possibly not logged in Loop. */
+"Possible Missed Meal" = "Möjligt missad måltid";
 
 /* The label of the pre-meal mode toggle button */
 "Pre-Meal Targets" = "Målvärden före måltid";
@@ -600,23 +822,29 @@
 /* Message when offering bolus recommendation even though bg is below range and minBG is in future. (1: glucose time)(2: glucose number) */
 "Predicted glucose at %1$@ is %2$@." = "Förväntat glukosvärde vid %1$@ är %2$@.";
 
+/* Notice when predicted glucose for bolus recommendation is in range */
+"Predicted glucose is in range." = "Förväntat blodsocker ligger inom intervallet.";
+
 /* Notice message when recommending bolus when BG is below the glucose safety limit. (1: glucose value) */
 "Predicted glucose of %1$@ is below your glucose safety limit setting." = "Förväntat blodsocker på %1$@ är under ditt tröskelvärde.";
-
-/* Notice message when recommending bolus when BG is below the suspend threshold. (1: glucose value) */
-"Predicted glucose of %1$@ is below your suspend threshold setting." = "Förväntat glukosvärde %1$@ är under ditt tröskelvärde.";
 
 /* Format string describing retrospective glucose prediction comparison. (1: Predicted glucose)(2: Actual glucose)(3: difference) */
 "Predicted: %1$@\nActual: %2$@ (%3$@)" = "Förväntat: %1$@\nFaktiskt: %2$@ (%3$@)";
 
+/* Format string describing integral retrospective correction. (1: Integral glucose effect)(2: Total glucose effect) */
+"prediction-description-integral-retrospective-correction" = "prognos-beskrivning-integral-retrospektiv-korrigering";
+
 /* Preparing critical event log text */
 "Preparing Critical Event Logs" = "Förbereder kritiska händelseloggar";
 
-/* The title of the pump section in settings */
-"Pump" = "Pump";
+/* Settings App Profile expiration view */
+"Profile Expiration" = "Profilens utgång";
 
-/* The notification title for a low pump battery */
-"Pump Battery Low" = "Låg batterinivå i pump";
+/* Time that profile expires */
+"Profile expires " = "Profilen går ut ";
+
+/* The title for notification of upcoming profile expiration */
+"Profile Expires Soon" = "Profilen går snart ut";
 
 /* The error message when pump data is too old to be used. (1: pump data age in minutes) */
 "Pump data is %1$@ old" = "Pumpvärdena är %1$@ gamla";
@@ -624,63 +852,79 @@
 /* The title of the screen displaying a pump event */
 "Pump Event" = "Pumphändelse";
 
+/* No comment provided by engineer. */
+"Pump Expired" = "Pumpen har gått ut";
+
 /* Details for configuration error when pump manager is missing */
 "Pump Manager" = "Pumphantering";
 
-/* The notification title for an empty pump reservoir */
-"Pump Reservoir Empty" = "Pumpreservoaren är tom";
-
-/* The notification title for a low pump reservoir */
-"Pump Reservoir Low" = "Pumpreservoaren har låg nivå";
-
-/* The title of the cell indicating the pump is suspended */
-"Pump Suspended" = "Pumpen är pausad";
+/* The error message displayed for pump manager errors. (1: pump manager error) */
+"Pump Manager Error: %1$@" = "Pumphanteringsfel: %1$@";
 
 /* The error message displayed for pumpSuspended errors. */
 "Pump Suspended. Automatic dosing is disabled." = "Pump pausad. Automatisk dosering är inaktiverad.";
 
-/* Format string for combining localized numeric value and unit. (1: numeric value)(2: unit) */
-"QUANTITY_VALUE_AND_UNIT" = "%1$@ %2$@";
-
-/* Title of insulin model preset */
-"Rapid-Acting – Adults" = "Snabbverkande – vuxna";
-
-/* Title of insulin model preset */
-"Rapid-Acting – Children" = "Snabbverkande – barn";
-
 /* The error message when a recommendation has expired. (1: age of recommendation in minutes) */
 "Recommendation expired: %1$@ old" = "Rekommendationen gick ut för %1$@ sedan";
-
-/* The title of the cell displaying a recommended temp basal value */
-"Recommended Basal" = "Rekommenderad basaldos";
 
 /* Label for recommended bolus row on bolus screen
    Label for recommended bolus row on simple bolus screen */
 "Recommended Bolus" = "Rekommenderad bolus";
 
-/* Accessibility hint describing recommended bolus units */
-"Recommended Bolus: %@ Units" = "Rekommenderad bolus: %@ enheter";
+/* Title for bolus screen warning when recommended bolus exceeds max bolus */
+"Recommended Bolus Exceeds Maximum Bolus" = "Recommended Bolus Exceeds Maximum Bolus";
 
-/* Details for missing data error when reservoir data is missing */
+/* The notification title for a remote bolus. (1: Bolus amount)
+   The notification title for a remote failure. (1: Bolus amount) */
+"Remote Bolus Entry: %@ U" = "Fjärrbolusinmatning: %@ E";
+
+/* The carb amount message for a remote carbs entry notification. (1: Carb amount in grams) */
+"Remote Carbs Entry: %d grams" = "Fjärrkolhydratinmatning: %d gram";
+
+/* Segmented button title for insulin delivery log reservoir history */
 "Reservoir" = "Reservoar";
+
+/* No comment provided by engineer. */
+"Reservoir Empty" = "Reservoar tom";
 
 /* Title of the prediction input effect for retrospective correction */
 "Retrospective Correction" = "Retrospektiv korrigering";
 
-/* The title of the notification action to retry a bolus command */
+/* The button text for attempting a manual loop
+   The title of the notification action to retry a bolus command */
 "Retry" = "Försök igen";
+
+/* Favorite food save button */
+"Save" = "Spara";
 
 /* Button text to save carbs and/or manual glucose entry and deliver a bolus */
 "Save and Deliver" = "Spara och ge";
 
+/* No comment provided by engineer. */
+"Save as favorite food" = "Spara som favoritmat";
+
 /* Button text to save carbs and/or manual glucose entry without a bolus */
 "Save without Bolusing" = "Spara utan att ge bolus";
+
+/* Scheduled Delivery status text */
+"Scheduled" = "Schemalagd";
+
+/* No comment provided by engineer. */
+"Selecting a favorite food in the carb entry screen automatically fills in the carb quantity, food type, and absorption time fields! Tap the add button below to create your first favorite food!" = "När du väljer en favoritmat på kolhydratinmatningsskärmen fylls automatiskt kolhydratmängd, livsmedelstyp och absorptionstid i! Tryck på lägg till-knappen nedan för att skapa din första favoritmat!";
+
+/* No comment provided by engineer. */
+"Sensor Failed" = "Sensorn har misslyckats";
 
 /* The title of the services section in settings */
 "Services" = "Tjänster";
 
-/* The label of the settings button */
+/* Label of button that navigation user to iOS Settings
+   Settings screen title
+   The label of the settings button */
 "Settings" = "Inställningar";
+
+/* The title of the cell indicating that onboarding is suspended */
+"Setup Incomplete" = "Inställning ej slutförd";
 
 /* Loop Completion HUD accessibility hint */
 "Shows last loop error" = "Visar senaste loopfelet";
@@ -691,13 +935,19 @@
 /* Title of simple bolus view when displaying meal entry */
 "Simple Meal Calculator" = "Förenklad bolusdoskalkylator";
 
+/* Descriptive text for Favorite Foods setting button */
+"Simplify Carb Entry" = "Förenkla kolhydratinmatning";
+
 /* Format fragment for a start time */
 "since %@" = "sedan %@";
 
-/* The title of the nightscout site URL credential */
-"Site URL" = "Nightscout-URL";
+/* Software update button link text */
+"Software Update" = "Mjukvaruuppdatering";
 
-/* The format for the description of a temporary override start date */
+/* Carb error description: invalid start time is out of range. */
+"Start time is out of range: %@" = "Starttiden är utanför tillåtet intervall: %@";
+
+/* The format for the description of a custom preset start date */
 "starting at %@" = "Börjar kl.  %@";
 
 /* The title of the cell indicating a bolus is being sent */
@@ -707,8 +957,8 @@
    The title of the support section in settings */
 "Support" = "Support";
 
-/* The title text in settings */
-"Suspend Threshold" = "Tröskelvärde";
+/* Title of the prediction input effect for suspension of insulin delivery */
+"Suspension of Insulin Delivery" = "Paus av insulintillförsel";
 
 /* Descriptive text for button to add CGM device */
 "Tap here to set up a CGM" = "Tryck här för att ställa in en CGM";
@@ -722,23 +972,48 @@
 /* The subtitle of the cell displaying an action to add a manually measurement glucose value */
 "Tap to Add" = "Tryck för att ange";
 
-/* The subtitle of the cell displaying an action to resume insulin delivery */
+/* The subtitle of the cell displaying an action to resume insulin delivery
+   The subtitle of the cell displaying an action to resume onboarding */
 "Tap to Resume" = "Tryck för att återuppta";
 
 /* Message presented in the status row instructing the user to tap this row to stop a bolus */
 "Tap to Stop" = "Tryck för att stoppa";
 
+/* Label for button to unmute all alerts */
+"Tap to Unmute Alerts" = "Slå på varningsljud";
+
+/* The alert body for unmute alert confirmation */
+"Tap Unmute to resume sound for your alerts and alarms." = "Tryck på Slå på varningsljud för att återuppta ljudet för dina varningar och larm.";
+
+/* Settings app TestFlight section */
+"TestFlight" = "TestFlight";
+
+/* Settings TestFlight expiration view */
+"TestFlight Expiration" = "TestFlight går ut";
+
+/* Time that build expires */
+"TestFlight expires " = "TestFlight går ut ";
+
+/* The title for notification of upcoming TestFlight expiration */
+"TestFlight Expires Soon" = "TestFlight går ut snart";
+
+/* Alert message for a bolus too small validation error */
+"The bolus amount entered is smaller than the minimum deliverable." = "Den angivna bolusmängden är mindre än den minsta levererbara.";
+
+/* Forecast explanation modal on bolus view */
+"The bolus dosing algorithm uses a more conservative estimate of forecasted blood glucose than what is used to adjust your basal rate.\n\nAs a result, your forecasted blood glucose after a bolus may still be higher than your target range." = "Bolusdosalgoritmen använder en mer konservativ uppskattning av förväntat blodsocker än vad som används för att justera din basaldos.\n\nDetta kan göra att ditt förväntade blodsocker efter en bolus fortfarande kan vara högre än ditt målområde.";
+
 /* Alert message for an updated bolus recommendation */
 "The bolus recommendation has updated. Please reconfirm the bolus amount." = "Bolusrekommendationen har uppdaterats. Konfirmera bolus";
 
-/* Subtitle description of Walsh insulin model setting */
-"The legacy model used by Loop, allowing customization of action duration." = "Äldre modell använd av Loop, vilken tillåter anpassning av insulinets verkningstid.";
+/* Alert body displayed for quantity greater than max (1: maximum quantity in grams) */
+"The maximum allowed amount is %@ grams." = "Den maximalt tillåtna mängden är %@ gram.";
+
+/* Warning for simple bolus when carbohydrate entry is too large. (1: maximum carbohydrate entry) */
+"The maximum amount allowed is %1$@." = "Den maximalt tillåtna mängden är %1$@.";
 
 /* Alert message for a maximum bolus validation error (1: max bolus value) */
-"The maximum bolus amount is %@ U." = "Den högst tillåtna bolusmängden är %@ E.";
-
-/* Body of the alert describing a maximum bolus validation error. (1: The localized max bolus value) */
-"The maximum bolus amount is %@ Units" = "Den maximala bolusdosen är %@ enheter";
+"The maximum bolus amount is \(maximumBolusAmountString) U." = "Den maximala bolusmängden är \(maximumBolusAmountString) E.";
 
 /* Alert message for a missing maximum bolus setting error */
 "The maximum bolus setting must be configured before a bolus can be delivered." = "Den högst tillåtna bolusmängden måste ställas in innan en bolus kan ges.";
@@ -746,14 +1021,32 @@
 /* Title text for button to Therapy Settings */
 "Therapy Settings" = "Behandlingsinställningar";
 
+/* String shown when glucose based partial application cannot be enabled because dosing strategy is not set to Automatic Bolus */
+"This option only applies when Loop's Dosing Strategy is set to Automatic Bolus." = "Detta alternativ gäller endast när Loops doseringsstrategi är inställd på automatisk bolus.";
+
+/* Label for time entry row on carb entry screen */
+"Time" = "Tid";
+
+/* No comment provided by engineer. */
+"Time Sensitive Alerts" = "Tidskänsliga varningar";
+
+/* Time Sensitive Status text */
+"Time Sensitive Notifications" = "Tidskänsliga notiser";
+
+/* No comment provided by engineer. */
+"Transmitter Low Battery" = "Sändarens batteri är lågt";
+
 /* Critical event log export error alert try again button */
 "Try Again" = "Försök igen";
+
+/* Description text for temporarily silencing non-critical alerts (1: app name) */
+"Turn off the volume on your iOS device or add %1$@ as an allowed app to each Focus Mode. Time Sensitive and Critical Alerts will still sound, but non-Critical Alerts will be silenced." = "Stäng av ljudet på din iOS-enhet eller lägg till %1$@ som en tillåten app i varje fokusläge. Tidskänsliga och kritiska varningar kommer fortfarande att ljuda, men icke-kritiska varningar kommer att tystas.";
 
 /* Bluetooth off foreground alert body */
 "Turn on Bluetooth to receive alerts, alarms or sensor glucose readings." = "Aktivera Bluetooth för att ta emot varningar, larm eller blodglukosavläsningar.";
 
-/* The short unit display string for international units of insulin */
-"U" = "E";
+/* Title for alert shown when alert acknowledgement fails */
+"Unable To Clear Alert" = "Det går inte att rensa varning";
 
 /* Title for alert shown when delivery status is uncertain */
 "Unable To Reach Pump" = "Det går inte att nå pump";
@@ -768,13 +1061,34 @@
 "Unable to stop the bolus in progress. Move your iPhone closer to the pump and try again. Check your insulin delivery history for details, and monitor your glucose closely." = "Det går inte att stoppa pågående bolus. Flytta din iPhone närmare din pump och försök igen. Kontrollera händelsehistorik för insulin för mer detaljerad information och var vaksam på sjunkande blodsocker.";
 
 /* Event title displayed when StoredPumpEvent.title is not set
+   The default description to use when an entry has no dose description
    label for when the alert mute end time is unknown
-   result when time cannot be formatted
-   The default description to use when an entry has no dose description */
+   result when time cannot be formatted */
 "Unknown" = "Okänd";
 
-/* The format for the description of a temporary override end date */
+/* The error message displayed for unknown errors. (1: unknown error) */
+"Unknown Error: %1$@" = "Okänt fel: %1$@";
+
+/* Override error description: unknown preset (1: preset name). */
+"Unknown preset: %1$@" = "Okänd förinställning: %1$@";
+
+/* Unknown amount of time in settings' profile expiration section */
+"Unknown time" = "Okänd tid";
+
+/* The title of the action used to unmute alerts */
+"Unmute" = "Slå på ljud";
+
+/* The alert title for unmute alert confirmation */
+"Unmute Alerts?" = "Slå på varningsljud?";
+
+/* Error message when a service can't be found to handle a push notification. (1: Service Identifier) */
+"Unsupported Notification Service: %1$@" = "Ej stödd notifikationstjänst: %1$@";
+
+/* The format for the description of a custom preset end date */
 "until %@" = "fram till %@";
+
+/* indication of when alerts will be unmuted (1: time when alerts unmute) */
+"Until %1$@" = "Fram till %1$@";
 
 /* The title of a target alert action specifying pre-meal targets duration for 1 hour or until the user enters carbs (whichever comes first). */
 "Until I enter carbs" = "Tills jag anger kolhydrater";
@@ -782,26 +1096,41 @@
 /* The title of a target alert action specifying workout targets duration until it is turned off by the user */
 "Until I turn off" = "Tills jag stänger av";
 
+/* No comment provided by engineer. */
+"Urgent Low" = "Kritiskt låg";
+
 /* The title of the alert controller used to select a duration for pre-meal targets */
 "Use Pre-Meal Preset" = "Använd förval 'Före måltid'";
 
-/* The title of the alert controller used to select a duration for workout targets */
-"Use Workout Glucose Targets" = "Använd målvärden för träning";
+/* Description text for temporarily silencing all sounds (1: app name) */
+"Use the Mute Alerts feature. It allows you to temporarily silence all of your alerts and alarms via the %1$@ app, including Critical Alerts and Time Sensitive Alerts." = "Använd funktionen Tysta varningar. Den låter dig tillfälligt tysta alla dina varningar och larm via %1$@-appen, inklusive kritiska varningar och tidskänsliga varningar.";
 
 /* The title of the alert controller used to select a duration for workout targets */
 "Use Workout Preset" = "Använd förval 'Träning'";
 
-/* Title of insulin model setting */
-"Walsh" = "Walsh";
+/* Alert Permissions Need Attention alert title */
+"Warning! Safety notifications are turned OFF" = "Varning! Säkerhetsnotiser är avstängda";
+
+/* No comment provided by engineer. */
+"What are examples of Critical and Time Sensitive alerts?" = "Vilka är exempel på kritiska och tidskänsliga varningar?";
 
 /* Explanation of glucose safety limit */
 "When current or forecasted glucose is below the glucose safety limit, Loop will not recommend a bolus, and will always recommend a temporary basal rate of 0 units per hour." = "När nuvarande eller förväntat blodglukosvärde är under tröskelvärde kommer Loop inte att rekommendera en bolus, och kommer också alltid att föreslå en temporär basal på 0 enheter per timme.";
 
-/* Explanation of suspend threshold */
-"When current or forecasted glucose is below the suspend threshold, Loop will not recommend a bolus, and will always recommend a temporary basal rate of 0 units per hour." = "När nuvarande eller förväntat slutglukosvärde är under tröskelvärdet kommer Loop inte att rekommendera en bolus, utan kommer alltid att föreslå en temporär basal på 0 enheter per timme.";
+/* Description of missed meal notifications. */
+"When enabled, Loop can notify you when it detects a meal that wasn't logged." = "När aktiverad kan Loop meddela dig när den detekterar en måltid som inte har registrerats.";
 
 /* No comment provided by engineer. */
 "When out of Closed Loop mode, the app uses a simplified bolus calculator like a typical pump." = "När läget sluten Loop inte används, kommer appen använda en förenklad bolusdoskalkylator likt den en vanlig pump använder.";
+
+/* App sounds descriptive text (1: app name) */
+"While mute alerts is on, all alerts from your %1$@ app including Critical and Time Sensitive alerts will temporarily display without sounds and will vibrate only." = "När tysta varningar är på, kommer alla varningar från din %1$@-app, inklusive kritiska och tidskänsliga varningar, tillfälligt visas utan ljud och endast vibrera.";
+
+/* No comment provided by engineer. */
+"While mute alerts is on, your insulin pump and CGM hardware may still sound." = "Medan tysta varningar är på, kan din insulinpump och CGM-hårdvara fortfarande ljuda.";
+
+/* Format string for message of reset loop alert. (1: App name) (2: error description) */
+"While trying to restart %1$@ an error occured.\n\n%2$@" = "Ett fel uppstod när %1$@ försökte starta om.\n\n%2$@";
 
 /* The label of the workout mode toggle button */
 "Workout Targets" = "Målvärden för träning";
@@ -812,9 +1141,38 @@
 /* Workout override still on reminder alert title */
 "Workout Temp Adjust Still On" = "Träningsförval fortfarande på";
 
+/* The title of the action used when confirming entered amount of carbohydrates. */
+"Yes" = "Ja";
+
+/* Format for Notifications permissions disabled alert body. (1: app name) */
+"You may not get sound, visual or vibration alerts regarding critical safety information.\n\nTo fix the issue, tap ‘Settings’ and make sure Notifications, Critical Alerts and Time Sensitive Notifications are turned ON." = "Du kanske inte får ljud-, visuella eller vibrationsvarningar angående kritisk säkerhetsinformation.\n\nFör att åtgärda problemet, tryck på 'Inställningar' och se till att Notiser, Kritiska varningar och Tidskänsliga notiser är påslagna.";
+
+/* Time change alert body. (1: app name) */
+"Your %1$@’s time has been changed. %2$@ needs accurate time records to make predictions about your glucose and adjust your insulin accordingly.\n\nCheck in your %1$@ Settings (General / Date & Time) and verify that 'Set Automatically' is turned ON. Failure to resolve could lead to serious under-delivery or over-delivery of insulin." = "Tiden på din %1$@ har ändrats. %2$@ behöver exakta tidsuppgifter för att göra förutsägelser om ditt blodsocker och justera ditt insulin därefter.\n\nKontrollera i dina %1$@-inställningar (Allmänt / Datum & Tid) och verifiera att 'Ställ in automatiskt' är påslaget. Om detta in rättas till kan det leda till allvarlig under- eller överdosering av insulin.";
+
+/* Format string for simple bolus screen warning when glucose is below glucose warning limit. */
+"Your glucose is below %1$@. Are you sure you want to bolus?" = "Ditt blodsocker är under %1$@. Är du säker på att du vill ge bolus?";
+
 /* Caption for bolus screen notice when no bolus is recommended due to prediction dropping below glucose safety limit */
-"Your glucose is below or predicted to go below your glucose safety limit, %@." = "Ditt blodsocker är lägre än eller förväntas bli lägre än ditt inställda tröskelvärde, %@.";
+"Your glucose is below or predicted to go below your glucose safety limit, \(suspendThresholdString)." = "Ditt blodsocker är under eller förväntas gå under ditt tröskelvärde, \(suspendThresholdString).";
 
 /* Format string for bolus screen warning when no bolus is recommended due input value below glucose safety limit. (1: suspendThreshold) */
 "Your glucose is below your glucose safety limit, %1$@." = "Ditt blodsocker är lägre än ditt tröskelvärde, %1$@.";
 
+/* Format string for meal bolus screen warning when no bolus is recommended due to glucose input value below recommendation threshold */
+"Your glucose is low. Eat carbs and consider waiting to bolus until your glucose is in a safe range." = "Ditt blodsocker är lågt. Ät kolhydrater och överväg att vänta med att ge bolus tills ditt blodsocker är inom ett säkert intervall.";
+
+/* Bolus screen warning when no bolus is recommended due to glucose input value below recommendation threshold for meal bolus */
+"Your glucose is low. Eat carbs and monitor closely." = "Ditt blodsocker är lågt. Ät kolhydrater och övervaka noggrant.";
+
+/* Warning for simple bolus when max bolus is exceeded. (1: maximum bolus) */
+"Your maximum bolus amount is %1$@." = "Din maximala bolusmängd är %1$@.";
+
+/* Caption for bolus screen notice when pump data is missing or stale */
+"Your pump data is stale. %1$@ cannot recommend a bolus amount." = "Dina pumpdata är inaktuella. %1$@ kan inte rekommendera en bolusmängd.";
+
+/* The description text for the looping enabled switch cell when closed loop is not allowed because the pump is delivering a manual temp basal. */
+"Your pump is delivering a manual temporary basal rate." = "Din pump levererar en manuell temporär basaldos.";
+
+/* Warning for simple bolus when recommended bolus exceeds max bolus. (1: maximum bolus) */
+"Your recommended bolus exceeds your maximum bolus amount of %1$@." = "Din rekommenderade bolus överstiger din maximala bolusmängd på %1$@.";

--- a/Loop/sv.lproj/Main.strings
+++ b/Loop/sv.lproj/Main.strings
@@ -59,7 +59,7 @@
 "Rse-x8-amW.text" = "Förväntat 5,1 mmol/l";
 
 /* Class = "UILabel"; text = "g Active Carbs"; ObjectID = "SQx-au-ZcM"; */
-"SQx-au-ZcM.text" = "g Active Carbs";
+"SQx-au-ZcM.text" = "g aktiva kolhydrater";
 
 /* Class = "UILabel"; text = "Glucose"; ObjectID = "tuw-av-A3x"; */
 "tuw-av-A3x.text" = "Glukos";

--- a/LoopCore/sv.lproj/Localizable.strings
+++ b/LoopCore/sv.lproj/Localizable.strings
@@ -1,9 +1,5 @@
-/* The format string for the app name and version number. (1: bundle name)(2: bundle version) */
-"%1$@ v%2$@" = "%1$@ v%2$@";
-
 /* Title string for automatic bolus dosing strategy */
 "Automatic Bolus" = "Automatisk bolus";
 
 /* Title string for temp basal only dosing strategy */
 "Temp Basal Only" = "Endast temporär basal";
-

--- a/LoopUI/sv.lproj/Localizable.strings
+++ b/LoopUI/sv.lproj/Localizable.strings
@@ -1,3 +1,15 @@
+/* Green closed loop ON message (1: last loop string) (2: app name) */
+"\n%1$@\n\n%2$@ is operating with Closed Loop in the ON position." = "\n%1$@\n\n%2$@ är i drift med sluten loop i PÅ-läge.";
+
+/* Red loop message (1: last loop  string) (2: app name) */
+"\n%1$@\n\nTap your CGM and insulin pump status icons for more information. %2$@ will continue trying to complete a loop, but check for potential communication issues with your pump and CGM." = "\n%1$@\n\nTryck på dina CGM- och insulinpumpsikoner för mer information. %2$@ kommer att fortsätta försöka slutföra en loop, men kontrollera för potentiella kommunikationsproblem med din pump och CGM.";
+
+/* Yellow loop message (1: last loop string) (2: app name) */
+"\n%1$@\n\nTap your CGM and insulin pump status icons for more information. %2$@ will continue trying to complete a loop, but watch for potential communication issues with your pump and CGM." = "\n%1$@\n\nTryck på dina CGM- och insulinpumpsikoner för mer information. %2$@ kommer att fortsätta försöka slutföra en loop, men var uppmärksam på potentiella kommunikationsproblem med din pump och CGM.";
+
+/* Green closed loop OFF message (1: app name)(2: reason for open loop) */
+"\n%1$@ is operating with Closed Loop in the OFF position. Your pump and CGM will continue operating, but the app will not adjust dosing automatically.\n\n%2$@" = "\n%1$@ är i drift med sluten loop i AV-läge. Din pump och CGM kommer att fortsätta fungera, men appen kommer inte att justera doseringen automatiskt.\n\n%2$@";
+
 /* No glucose value representation (3 dashes for mg/dL) */
 "– – –" = "– – –";
 
@@ -7,35 +19,35 @@
 /* The format string describing the basal rate. */
 "%@ U" = "%@ E";
 
+/* Format string describing last completion. (1: time ago */
+"%1$@ ago" = "%1$@ sedan";
+
+/* Format string describing last completion. (1: time ago, (2: the date */
+"%1$@ ago at %2$@" = "för %1$@ sedan kl %2$@";
+
 /* Accessbility format value describing glucose: (1: glucose number)(2: glucose time) */
-"%1$@ at %2$@" = "%1$@ at %2$@";
+"%1$@ at %2$@" = "%1$@ kl %2$@";
 
 /* Accessibility format string describing the basal rate. (1: localized basal rate value)(2: last updated time) */
 "%1$@ units per hour at %2$@" = "%1$@ enheter/h kl. %2$@";
 
-/* The format string for the app name and version number. (1: bundle name)(2: bundle version) */
-"%1$@ v%2$@" = "%1$@ v%2$@";
-
-/* Format string describing glucose units per minute (1: glucose unit string) */
-"%1$@/min" = "%1$@/min";
+/* Format string describing last completion */
+"<1 min ago" = "<1 min sedan";
 
 /* Accessibility hint describing completion HUD for a closed loop */
 "Closed loop" = "Sluten loop";
 
 /* Title of green open loop OFF message */
-"Closed Loop OFF" = "Sluten Loop är AV";
+"Closed Loop OFF" = "Sluten Loop AV";
 
 /* Title of green closed loop ON message */
-"Closed Loop ON" = "Sluten Loop är PÅ";
-
-/* The short unit display string for decibles */
-"dB" = "dB";
-
-/* The short unit display string for grams */
-"g" = "g";
+"Closed Loop ON" = "Sluten Loop PÅ";
 
 /* String displayed instead of a glucose value above the CGM range */
 "HIGH" = "HÖGT";
+
+/* Last loop time completed message (1: last loop time string) */
+"Last completed loop %1$@." = "Senaste avslutade loop %1$@.";
 
 /* Title of red loop message */
 "Loop Failure" = "Loopfel";
@@ -43,14 +55,11 @@
 /* Accessbility format label describing the time interval since the last completion date. (1: The localized date components) */
 "Loop ran %@ ago" = "Loop kördes för %@ sedan";
 
+/* Title of yellow loop message */
+"Loop Warning" = "Loop varning";
+
 /* String displayed instead of a glucose value below the CGM range */
 "LOW" = "LÅGT";
-
-/* The short unit display string for milligrams of glucose per decilter */
-"mg/dL" = "mg/dl";
-
-/* The short unit display string for millimoles of glucose per liter */
-"mmol/L" = "mmol/L";
 
 /* Accessibility label component for glucose HUD describing an invalid state */
 "Needs attention" = "Kräver åtgärd";
@@ -58,15 +67,14 @@
 /* Accessbility hint describing completion HUD for an open loop */
 "Open loop" = "Öppen loop";
 
-/* Format string for combining localized numeric value and unit. (1: numeric value)(2: unit) */
-"QUANTITY_VALUE_AND_UNIT" = "%1$@ %2$@";
-
-/* The short unit display string for international units of insulin */
-"U" = "E";
+/* Instructions for user to close loop if it is allowed. */
+"Tap Settings to toggle Closed Loop ON if you wish for the app to automate your insulin." = "Gå in i inställningar och slå på sluten loop om du vill att appen ska automatisera din insulindosering.";
 
 /* Accessibility value for an unknown value */
 "Unknown" = "Okänd";
 
-/* Acessibility label describing completion HUD waiting for first run */
+/* Accessibility label describing completion HUD waiting for first run */
 "Waiting for first run" = "Väntar på första körning";
 
+/* Format string describing last completion. (1: the date */
+"was at %1$@" = "var kl %1$@";

--- a/WatchApp Extension/sv.lproj/Localizable.strings
+++ b/WatchApp Extension/sv.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* No comment provided by engineer. */
+"\(date, formatter: Self.dateFormatter)" = "\(date, formatter: Self.dateFormatter)";
+
 /* No glucose value representation (3 dashes for mg/dL; no spaces as this will get truncated in the watch complication) */
 "---" = "---";
 
@@ -16,9 +19,6 @@
 /* HUD row title for IOB */
 "Active Insulin" = "Aktivt insulin";
 
-/* Title of the user activity for adding carbs */
-"Add Carb Entry" = "Lägg till kolhydrater";
-
 /* Button text to confirm manual bolus on Apple Watch */
 "Bolus" = "Bolus";
 
@@ -31,30 +31,18 @@
 /* Button text to continue from carb entry to bolus entry on Apple Watch */
 "Continue" = "Fortsätt";
 
-/* The short unit display string for decibles */
-"dB" = "dB";
-
 /* The action button title to dismiss an error message */
 "Dismiss" = "Avfärda";
 
-/* Short unit label for gram measurement
-   The short unit display string for grams */
+/* Short unit label for gram measurement */
 "g" = "g";
 
-/* The recovery message displayed after a bolus attempt fails
-   The recovery message displayed after a carb entry send attempt fails
-   The recovery message displayed after a glucose range override send attempt fails */
+/* The recovery message displayed after a glucose range override send attempt fails */
 "Make sure your iPhone is nearby and try again" = "Säkerställ att telefonen är inom räckhåll och försök igen";
 
 /* The recovery message displayed after a bolus attempt fails
    The recovery message displayed after a potential carb entry send attempt fails */
 "Make sure your iPhone is nearby and try again." = "Säkerställ att din telefon är inom räckhåll och försök igen.";
-
-/* The short unit display string for milligrams of glucose per decilter */
-"mg/dL" = "mg/dl";
-
-/* The short unit display string for millimoles of glucose per liter */
-"mmol/L" = "mmol/L";
 
 /* HUD row title for Net Basal Rate */
 "Net Basal Rate" = "Nettobasaldos";
@@ -68,9 +56,6 @@
 /* Label for on button */
 "On" = "På";
 
-/* The text for the Watch button for enabling a temporary override */
-"Override" = "Override";
-
 /* Alert message for updated bolus recommendation on Apple Watch */
 "Please reconfirm the bolus amount." = "Bekräfta bolusmängd.";
 
@@ -80,14 +65,8 @@
 /* The text for the Watch button for enabling a custom preset */
 "Preset" = "Förinställning";
 
-/* Format string for combining localized numeric value and unit. (1: numeric value)(2: unit) */
-"QUANTITY_VALUE_AND_UNIT" = "%1$@ %2$@";
-
-/* The label and value showing the recommended bolus */
-"Rec: %@ U" = "Rek: %@ E";
-
 /* Recommended bolus amount label on Apple Watch */
-"REC: %@ U" = "Rek: %@ E";
+"REC: \(valueString) U" = "Rek: \(valueString) E";
 
 /* Indicator that recommended bolus computation is in progress on Apple Watch */
 "REC: Calculating..." = "Rek: Beräknar...";
@@ -101,14 +80,13 @@
 /* Button text to confirm carb entry and bolus on Apple Watch */
 "Save & Bolus" = "Spara & Bolus";
 
-/* The title of the alert controller displayed after a carb entry send attempt fails
-   The title of the alert controller displayed after a glucose range override send attempt fails */
+/* The title of the alert controller displayed after a glucose range override send attempt fails */
 "Send Failed" = "Sändning misslyckades";
 
 /* Help text for bolus confirmation on Apple Watch */
 "Turn Digital Crown\nto bolus" = "Vrid på krona för att ge bolus";
 
-/* The short unit display string for international units of insulin */
+/* No comment provided by engineer. */
 "U" = "E";
 
 /* The short unit display string for international units of insulin delivery per hour */
@@ -117,6 +95,6 @@
 /* The title of the alert controller displayed after a potential carb entry send attempt fails */
 "Unable to Reach iPhone" = "Det går inte att nå iPhone";
 
-/* The text for the Watch button for enabling workout mode */
+/* The text for the Watch button for enabling workout mode
+   Title for sheet to enable/disable workout mode on watch */
 "Workout" = "Träning";
-


### PR DESCRIPTION
I noticed that there were a lot of missing Swedish translations in general for the Loop app. This PR addresses this in the Loop repository.

- Added missing Swedish translations in the respective `Localizable.strings` files.
- Added `NSLocalizedString` calls where needed, which will help with other translations as well.
- Removed outdated translations that are no longer needed.