### PR TITLE
Provisioning profile support for Xcode 16

### DIFF
--- a/Common/Models/BuildDetails.swift
+++ b/Common/Models/BuildDetails.swift
@@ -13,6 +13,7 @@ class BuildDetails {
     static var `default` = BuildDetails()
 
     let dict: [String: Any]
+    private var cachedProfileExpirationDate: Date?
 
     init() {
         guard let url = Bundle.main.url(forResource: "BuildDetails", withExtension: ".plist"),
@@ -23,6 +24,7 @@ class BuildDetails {
             return
         }
         dict = parsed
+        cachedProfileExpirationDate = loadProfileExpirationDate()
     }
 
     var buildDateString: String? {
@@ -46,11 +48,11 @@ class BuildDetails {
     }
 
     var profileExpiration: Date? {
-        return dict["com-loopkit-Loop-profile-expiration"] as? Date
+        return cachedProfileExpirationDate
     }
 
     var profileExpirationString: String {
-        if let profileExpiration = profileExpiration {
+        if let profileExpiration = cachedProfileExpirationDate {
             return "\(profileExpiration)"
         } else {
             return "N/A"
@@ -65,5 +67,39 @@ class BuildDetails {
     var workspaceGitBranch: String? {
        return dict["com-loopkit-LoopWorkspace-git-branch"] as? String
    }
+
+    private func loadProfileExpirationDate() -> Date? {
+        guard
+            let profilePath = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision"),
+            let profileData = try? Data(contentsOf: URL(fileURLWithPath: profilePath)),
+            let profileNSString = NSString(data: profileData, encoding: String.Encoding.ascii.rawValue)
+        else {
+            print(
+                "WARNING: Could not find or read `embedded.mobileprovision`. If running on Simulator, there are no provisioning profiles."
+            )
+            return nil
+        }
+
+        let regexPattern = "<key>ExpirationDate</key>[\\W]*?<date>(.*?)</date>"
+        guard let regex = try? NSRegularExpression(pattern: regexPattern, options: []),
+              let match = regex.firstMatch(
+                in: profileNSString as String,
+                options: [],
+                range: NSRange(location: 0, length: profileNSString.length)
+              ),
+              let range = Range(match.range(at: 1), in: profileNSString as String)
+        else {
+            print("Warning: Could not create regex or find match.")
+            return nil
+        }
+
+        let dateString = String(profileNSString.substring(with: NSRange(range, in: profileNSString as String)))
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        return dateFormatter.date(from: dateString)
+    }
 }
 

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -25,17 +25,12 @@ info() {
 }
 
 info_plist_path="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/BuildDetails.plist"
-provisioning_profile_path="${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
 xcode_build_version=${XCODE_PRODUCT_BUILD_VERSION:-$(xcodebuild -version | grep version | cut -d ' ' -f 3)}
 while [[ $# -gt 0 ]]
 do
   case $1 in
     -i|--info-plist-path)
       info_plist_path="${2}"
-      shift 2
-      ;;
-    -p|--provisioning-profile-path)
-      provisioning_profile_path="${2}"
       shift 2
       ;;
   esac
@@ -66,15 +61,6 @@ fi
 plutil -replace com-loopkit-Loop-srcroot -string "${PWD}" "${info_plist_path}"
 plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
 plutil -replace com-loopkit-Loop-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
-
-if [ -e "${provisioning_profile_path}" ]; then
-  profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
-  # Convert to plutil format
-  profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
-  plutil -replace com-loopkit-Loop-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
-else
-  warn "Invalid provisioning profile path ${provisioning_profile_path}"
-fi
 
 # determine if this is a workspace build
 # if so, fill out the git revision and branch


### PR DESCRIPTION
Xcode now stores the provisioning profile in a new location, which renders the hardcoded path in Scripts/capture-build-details.sh ineffective. This PR resolves the issue by reading the provisioning profile at runtime and storing it in a cached constant within the BuildDetails class.

Example of expire date using Xcode 16 and iOS 18.
![image](https://github.com/user-attachments/assets/a0fbba12-5df8-4232-b386-f22080aa8e84)
