### PR TITLE
Negative Insulin Damper

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		120490CB2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */; };
 		1419606428D9550400BA86E0 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437AFEE6203688CF008C4892 /* LoopKitUI.framework */; };
 		1419606928D9554E00BA86E0 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437AFEE6203688CF008C4892 /* LoopKitUI.framework */; };
 		1419606A28D955BC00BA86E0 /* MockKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C101947127DD473C004E7EB8 /* MockKitUI.framework */; };
@@ -743,6 +744,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NegativeInsulinDamperSelectionView.swift; sourceTree = "<group>"; };
 		142CB7582A60BF2E0075748A /* EditMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditMode.swift; sourceTree = "<group>"; };
 		142CB75A2A60BFC30075748A /* FavoriteFoodsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteFoodsView.swift; sourceTree = "<group>"; };
 		1452F4A82A851C9400F8B9E4 /* AddEditFavoriteFoodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditFavoriteFoodViewModel.swift; sourceTree = "<group>"; };
@@ -2276,6 +2278,7 @@
 				C1AF062229426300002C1B19 /* ManualGlucoseEntryRow.swift */,
 				DDC389FD2A2C4C830066E2E8 /* GlucoseBasedApplicationFactorSelectionView.swift */,
 				DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */,
+				120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3832,6 +3835,7 @@
 				895FE0952201234000FCF18A /* OverrideSelectionViewController.swift in Sources */,
 				C1EF747228D6A44A00C8C083 /* CrashRecoveryManager.swift in Sources */,
 				A9F66FC3247F451500096EA7 /* UIDevice+Loop.swift in Sources */,
+				120490CB2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift in Sources */,
 				439706E622D2E84900C81566 /* PredictionSettingTableViewCell.swift in Sources */,
 				430D85891F44037000AF2D4F /* HUDViewTableViewCell.swift in Sources */,
 				43A51E211EB6DBDD000736CC /* LoopChartsTableViewController.swift in Sources */,

--- a/Loop/Models/LoopSettings+Loop.swift
+++ b/Loop/Models/LoopSettings+Loop.swift
@@ -15,6 +15,9 @@ extension LoopSettings {
         if !LoopConstants.retrospectiveCorrectionEnabled {
             inputs.remove(.retrospection)
         }
+        if !UserDefaults.standard.negativeInsulinDamperEnabled {
+            inputs.remove(.damper)
+        }
         return inputs
     }    
 }

--- a/Loop/Models/PredictionInputEffect.swift
+++ b/Loop/Models/PredictionInputEffect.swift
@@ -18,8 +18,9 @@ struct PredictionInputEffect: OptionSet {
     static let momentum         = PredictionInputEffect(rawValue: 1 << 2)
     static let retrospection    = PredictionInputEffect(rawValue: 1 << 3)
     static let suspend          = PredictionInputEffect(rawValue: 1 << 4)
+    static let damper           = PredictionInputEffect(rawValue: 1 << 5)
 
-    static let all: PredictionInputEffect = [.carbs, .insulin, .momentum, .retrospection]
+    static let all: PredictionInputEffect = [.carbs, .insulin, .damper, .momentum, .retrospection]
 
     var localizedTitle: String? {
         switch self {
@@ -27,6 +28,8 @@ struct PredictionInputEffect: OptionSet {
             return NSLocalizedString("Carbohydrates", comment: "Title of the prediction input effect for carbohydrates")
         case [.insulin]:
             return NSLocalizedString("Insulin", comment: "Title of the prediction input effect for insulin")
+        case [.damper]:
+            return NSLocalizedString("Negative Insulin Damper", comment: "Title of the prediction input effect for negative insulin damper")
         case [.momentum]:
             return NSLocalizedString("Glucose Momentum", comment: "Title of the prediction input effect for glucose momentum")
         case [.retrospection]:
@@ -44,6 +47,8 @@ struct PredictionInputEffect: OptionSet {
             return String(format: NSLocalizedString("Carbs Absorbed (g) ÷ Carb Ratio (g/U) × Insulin Sensitivity (%1$@/U)", comment: "Description of the prediction input effect for carbohydrates. (1: The glucose unit string)"), unit.localizedShortUnitString)
         case [.insulin]:
             return String(format: NSLocalizedString("Insulin Absorbed (U) × Insulin Sensitivity (%1$@/U)", comment: "Description of the prediction input effect for insulin"), unit.localizedShortUnitString)
+        case [.damper]:
+            return String(format: NSLocalizedString("Glucose effect of applying a damper to reduce increases in glucose due to negative insulin", comment: "Description of the prediction input effect for negative insulin damper"), unit.localizedShortUnitString)
         case [.momentum]:
             return NSLocalizedString("15 min glucose regression coefficient (b₁), continued with decay over 30 min", comment: "Description of the prediction input effect for glucose momentum")
         case [.retrospection]:

--- a/Loop/View Controllers/PredictionTableViewController.swift
+++ b/Loop/View Controllers/PredictionTableViewController.swift
@@ -197,9 +197,16 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
 
     private var eventualGlucoseDescription: String?
 
-    private var availableInputs: [PredictionInputEffect] = [.carbs, .insulin, .momentum, .retrospection, .suspend]
+    private var availableInputs: [PredictionInputEffect] = getAvailableInputs()
 
     private var selectedInputs = PredictionInputEffect.all
+    
+    private static func getAvailableInputs() -> [PredictionInputEffect] {
+        if UserDefaults.standard.negativeInsulinDamperEnabled {
+            return [.carbs, .insulin, .damper, .momentum, .retrospection, .suspend]
+        }
+        return [.carbs, .insulin, .momentum, .retrospection, .suspend]
+    }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
         return Section.allCases.count

--- a/Loop/Views/NegativeInsulinDamperSelectionView.swift
+++ b/Loop/Views/NegativeInsulinDamperSelectionView.swift
@@ -1,0 +1,45 @@
+//
+//  NegativeInsulinDamperSelectionView.swift
+//  Loop
+//
+//  Created by Moti Nisenson-Ken on 16/10/2024.
+//  Copyright © 2024 LoopKit Authors. All rights reserved.
+//
+import Foundation
+import SwiftUI
+import LoopKit
+import LoopKitUI
+
+struct NegativeInsulinDamperSelectionView: View {
+   @Binding var isNegativeInsulinDamperEnabled: Bool
+   
+   public var body: some View {
+       ScrollView {
+           VStack(spacing: 10) {
+               Text(NSLocalizedString("Negative Insulin Damper", comment: "Title for negative insulin damper experiment description"))
+                   .font(.headline)
+                   .padding(.bottom, 20)
+
+               Divider()
+
+               Text(NSLocalizedString("Negative Insulin Damper (NID) is used to mitigate the effects negative insulin have on predicted glucose levels. After spending significant time beneath the correction range, there may be a build up of negative insulin which will result in larger predicted glucose values, and subsequently may result in too much insulin being given by Loop. NID reduces the magnitude of these predictions. The larger the total predicted rise in glucose due to negative insulin, the greater the reduction will be.", comment: "Description of Negative Insulin Damper toggle."))
+                   .foregroundColor(.secondary)
+               Divider()
+
+               Toggle(NSLocalizedString("Enable Negative Insulin Damper", comment: "Title for Negative Insulin Damper toggle"), isOn: $isNegativeInsulinDamperEnabled)
+                   .onChange(of: isNegativeInsulinDamperEnabled) { newValue in
+                       UserDefaults.standard.negativeInsulinDamperEnabled = newValue
+                   }
+                   .padding(.top, 20)
+           }
+           .padding()
+       }
+       .navigationBarTitleDisplayMode(.inline)
+   }
+
+   struct NegativeInsulinDamperSelectionView_Previews: PreviewProvider {
+       static var previews: some View {
+           NegativeInsulinDamperSelectionView(isNegativeInsulinDamperEnabled: .constant(true))
+       }
+   }
+}

--- a/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+++ b/Loop/Views/SettingsView+algorithmExperimentsSection.swift
@@ -41,6 +41,8 @@ public struct ExperimentRow: View {
 public struct ExperimentsSettingsView: View {
     @State private var isGlucoseBasedApplicationFactorEnabled = UserDefaults.standard.glucoseBasedApplicationFactorEnabled
     @State private var isIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
+    @State private var isNegativeInsulinDamperEnabled = UserDefaults.standard.negativeInsulinDamperEnabled
+
     var automaticDosingStrategy: AutomaticDosingStrategy
 
     public var body: some View {
@@ -70,6 +72,11 @@ public struct ExperimentsSettingsView: View {
                         name: NSLocalizedString("Integral Retrospective Correction", comment: "Title of integral retrospective correction experiment"),
                         enabled: isIntegralRetrospectiveCorrectionEnabled)
                 }
+                NavigationLink(destination: NegativeInsulinDamperSelectionView(isNegativeInsulinDamperEnabled: $isNegativeInsulinDamperEnabled)) {
+                    ExperimentRow(
+                        name: NSLocalizedString("Negative Insulin Damper", comment: "Title of negative insulin damper experiment"),
+                        enabled: isNegativeInsulinDamperEnabled)
+                }
                 Spacer()
             }
             .padding()
@@ -83,6 +90,7 @@ extension UserDefaults {
     private enum Key: String {
         case GlucoseBasedApplicationFactorEnabled = "com.loopkit.algorithmExperiments.glucoseBasedApplicationFactorEnabled"
         case IntegralRetrospectiveCorrectionEnabled = "com.loopkit.algorithmExperiments.integralRetrospectiveCorrectionEnabled"
+        case NegativeInsulinDamperEnabled = "com.loopkit.algorithmExperiments.negativeInsulinDamperEnabled"
     }
 
     var glucoseBasedApplicationFactorEnabled: Bool {
@@ -103,4 +111,12 @@ extension UserDefaults {
         }
     }
 
+    var negativeInsulinDamperEnabled: Bool {
+        get {
+            bool(forKey: Key.NegativeInsulinDamperEnabled.rawValue) as Bool
+        }
+        set {
+            set(newValue, forKey: Key.NegativeInsulinDamperEnabled.rawValue)
+        }
+    }
 }


### PR DESCRIPTION
See the discussion in zulip chat. The implementation relies on the idea described in [this message](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Handling.20Lows.20with.20Accumulated.20Negative.20IOB/near/476513827). The implementation in practice linearly scales alpha in an initial section (in practice until delta is 90), at which point the slop of alpha*delta is 0.1. This slope is then continued on in the second section.

The calibration done was based on alpha=0.75 at delta=50; this was estimated to be approximately an hour of withdrawn basal. Note that with an alpha=0.75, this means the result would have 37.5, or be 12.5 mg/dL lower than otherwise. With auto-bolusing, this would result in giving a bolus which would result in 5 mg/dL less effect, which is quite minimal. As negative IOB increases the resulting alpha gets significantly smaller.

Additional testing is necessary for this PR before merging.