### PR TITLE
tidepool-merge: Adjust provisioning profile path in script for Xcode 16 compatibility

### DIFF
--- a/Common/Models/BuildDetails.swift
+++ b/Common/Models/BuildDetails.swift
@@ -13,7 +13,6 @@ class BuildDetails {
     static var `default` = BuildDetails()
 
     let dict: [String: Any]
-    private var cachedProfileExpirationDate: Date?
 
     init() {
         guard let url = Bundle.main.url(forResource: "BuildDetails", withExtension: ".plist"),
@@ -24,7 +23,6 @@ class BuildDetails {
             return
         }
         dict = parsed
-        cachedProfileExpirationDate = loadProfileExpirationDate()
     }
 
     var buildDateString: String? {
@@ -48,11 +46,11 @@ class BuildDetails {
     }
 
     var profileExpiration: Date? {
-        return cachedProfileExpirationDate
+        return dict["com-loopkit-Loop-profile-expiration"] as? Date
     }
 
     var profileExpirationString: String {
-        if let profileExpiration = cachedProfileExpirationDate {
+        if let profileExpiration = profileExpiration {
             return "\(profileExpiration)"
         } else {
             return "N/A"
@@ -65,41 +63,7 @@ class BuildDetails {
     }
 
     var workspaceGitBranch: String? {
-       return dict["com-loopkit-LoopWorkspace-git-branch"] as? String
-   }
-
-    private func loadProfileExpirationDate() -> Date? {
-        guard
-            let profilePath = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision"),
-            let profileData = try? Data(contentsOf: URL(fileURLWithPath: profilePath)),
-            let profileNSString = NSString(data: profileData, encoding: String.Encoding.ascii.rawValue)
-        else {
-            print(
-                "WARNING: Could not find or read `embedded.mobileprovision`. If running on Simulator, there are no provisioning profiles."
-            )
-            return nil
-        }
-
-        let regexPattern = "<key>ExpirationDate</key>[\\W]*?<date>(.*?)</date>"
-        guard let regex = try? NSRegularExpression(pattern: regexPattern, options: []),
-              let match = regex.firstMatch(
-                in: profileNSString as String,
-                options: [],
-                range: NSRange(location: 0, length: profileNSString.length)
-              ),
-              let range = Range(match.range(at: 1), in: profileNSString as String)
-        else {
-            print("Warning: Could not create regex or find match.")
-            return nil
-        }
-
-        let dateString = String(profileNSString.substring(with: NSRange(range, in: profileNSString as String)))
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-
-        return dateFormatter.date(from: dateString)
+        return dict["com-loopkit-LoopWorkspace-git-branch"] as? String
     }
 }
 

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -26,11 +26,16 @@ info() {
 
 info_plist_path="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/BuildDetails.plist"
 xcode_build_version=${XCODE_PRODUCT_BUILD_VERSION:-$(xcodebuild -version | grep version | cut -d ' ' -f 3)}
+
 while [[ $# -gt 0 ]]
 do
   case $1 in
     -i|--info-plist-path)
       info_plist_path="${2}"
+      shift 2
+      ;;
+    -p|--provisioning-profile-path)
+      provisioning_profile_path="${2}"
       shift 2
       ;;
   esac
@@ -42,7 +47,6 @@ fi
 
 if [ "${info_plist_path}" == "/" -o ! -e "${info_plist_path}" ]; then
   error "File does not exist: ${info_plist_path}"
-  #error "Must provide valid --info-plist-path, or have valid \${BUILT_PRODUCTS_DIR} and \${INFOPLIST_PATH} set."
 fi
 
 info "Gathering build details in ${PWD}"
@@ -61,6 +65,26 @@ fi
 plutil -replace com-loopkit-Loop-srcroot -string "${PWD}" "${info_plist_path}"
 plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
 plutil -replace com-loopkit-Loop-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
+
+# Determine the provisioning profile path
+if [ -z "${provisioning_profile_path}" ]; then
+  if [ -e "${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision" ]; then
+    provisioning_profile_path="${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
+  elif [ -e "${HOME}/Library/Developer/Xcode/UserData/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision" ]; then
+    provisioning_profile_path="${HOME}/Library/Developer/Xcode/UserData/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
+  else
+    warn "Provisioning profile not found in expected locations"
+  fi
+fi
+
+if [ -e "${provisioning_profile_path}" ]; then
+  profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
+  # Convert to plutil format
+  profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
+  plutil -replace com-loopkit-Loop-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
+else
+  warn "Invalid provisioning profile path ${provisioning_profile_path}"
+fi
 
 # determine if this is a workspace build
 # if so, fill out the git revision and branch


### PR DESCRIPTION
Make a new PR to `tidepool-merge` branch parallel to the one provided for `dev` branch.

See PR #2241 for full reference information.

In summary:
* Reverted Common/Models/BuildDetails.swift to its state before the “xcode16_profile_support” merge.
* Updated Scripts/capture-build-details.sh to search for .mobileprovision files in both Xcode 15.4 and Xcode 16 locations.

This was tested previously when testing [LoopWorkspace PR 214](https://github.com/LoopKit/LoopWorkspace/pull/214) but not with a formal branch that could be used as a PR.

