### PR TITLE
update progressCell for bolus display

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -240,10 +240,16 @@ final class StatusTableViewController: LoopChartsTableViewController {
         didSet {
             if oldValue != bolusState {
                 switch bolusState {
-                case .inProgress(_):
+                case .inProgress(let dose):
                     guard case .inProgress = oldValue else {
                         // Bolus starting
                         bolusProgressReporter = deviceManager.pumpManager?.createBolusProgressReporter(reportingOn: DispatchQueue.main)
+                        // If there is an existing bolus progressCell, update its dose values now in case the app is currently in the
+                        // background as otherwise these values won't get initialized and can contain stale data from some earlier bolus.
+                        if let progressCell = tableView.cellForRow(at: IndexPath(row: StatusRow.status.rawValue, section: Section.status.rawValue)) as? BolusProgressTableViewCell {
+                            progressCell.totalUnits = dose.programmedUnits
+                            progressCell.deliveredUnits = 0
+                        }
                         break
                     }
                 default:


### PR DESCRIPTION
## Purpose:
This PR fixes an intermittent bolus progress display error reported in these issues
* #2196
* #2195
* #2109

@itsmojo identified root cause for this intermittent display error and passed on a proposed fix for the `main` branch which is found in this PR.

> If a bolus progress is being displayed when the app is put into background and then the app is opened in the middle of a bolus, the progress bar shows a stale value of the expected total units; the stale value is the total units from the last time the bolus progress bar was displayed.

I tested the released Loop 3.4.4 using this [test method](https://github.com/LoopKit/Loop/issues/2196#issuecomment-2479431845) and demonstrated I could trigger the intermittent display error reliably.

## Test

This PR was applied to `main`. The same test method mentioned above was used and every instance of opening the app in the middle of a bolus showed the correct value for the total bolus units.