### PR TITLE
Force reload from UserDefaults

### DIFF
--- a/Loop/Views/GlucoseBasedApplicationFactorSelectionView.swift
+++ b/Loop/Views/GlucoseBasedApplicationFactorSelectionView.swift
@@ -44,9 +44,6 @@ public struct GlucoseBasedApplicationFactorSelectionView: View {
                 }
             }
             .padding()
-            .onChange(of: isGlucoseBasedApplicationFactorEnabled) { newValue in
-                UserDefaults.standard.glucoseBasedApplicationFactorEnabled = newValue
-            }
         }
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Loop/Views/IntegralRetrospectiveCorrectionSelectionView.swift
+++ b/Loop/Views/IntegralRetrospectiveCorrectionSelectionView.swift
@@ -27,9 +27,6 @@ public struct IntegralRetrospectiveCorrectionSelectionView: View {
                 Divider()
 
                 Toggle(NSLocalizedString("Enable Integral Retrospective Correction", comment: "Title for Integral Retrospective Correction toggle"), isOn: $isIntegralRetrospectiveCorrectionEnabled)
-                    .onChange(of: isIntegralRetrospectiveCorrectionEnabled) { newValue in
-                        UserDefaults.standard.integralRetrospectiveCorrectionEnabled = newValue
-                    }
                     .padding(.top, 20)
             }
             .padding()

--- a/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+++ b/Loop/Views/SettingsView+algorithmExperimentsSection.swift
@@ -39,8 +39,8 @@ public struct ExperimentRow: View {
 }
 
 public struct ExperimentsSettingsView: View {
-    @State private var isGlucoseBasedApplicationFactorEnabled = UserDefaults.standard.glucoseBasedApplicationFactorEnabled
-    @State private var isIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
+    @State private var isGlucoseBasedApplicationFactorEnabled = false
+    @State private var isIntegralRetrospectiveCorrectionEnabled = false
     var automaticDosingStrategy: AutomaticDosingStrategy
 
     public var body: some View {
@@ -75,6 +75,11 @@ public struct ExperimentsSettingsView: View {
             .padding()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            // force reloading of data from UserDefaults
+            isGlucoseBasedApplicationFactorEnabled = UserDefaults.standard.glucoseBasedApplicationFactorEnabled
+            isIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
+        }
     }
 }
 

--- a/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+++ b/Loop/Views/SettingsView+algorithmExperimentsSection.swift
@@ -39,8 +39,8 @@ public struct ExperimentRow: View {
 }
 
 public struct ExperimentsSettingsView: View {
-    @State private var isGlucoseBasedApplicationFactorEnabled = false
-    @State private var isIntegralRetrospectiveCorrectionEnabled = false
+    @AppStorage(UserDefaults.Key.GlucoseBasedApplicationFactorEnabled.rawValue) private var isGlucoseBasedApplicationFactorEnabled = false
+    @AppStorage(UserDefaults.Key.IntegralRetrospectiveCorrectionEnabled.rawValue) private var isIntegralRetrospectiveCorrectionEnabled = false
     var automaticDosingStrategy: AutomaticDosingStrategy
 
     public var body: some View {
@@ -75,17 +75,12 @@ public struct ExperimentsSettingsView: View {
             .padding()
         }
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            // force reloading of data from UserDefaults
-            isGlucoseBasedApplicationFactorEnabled = UserDefaults.standard.glucoseBasedApplicationFactorEnabled
-            isIntegralRetrospectiveCorrectionEnabled = UserDefaults.standard.integralRetrospectiveCorrectionEnabled
-        }
     }
 }
 
 
 extension UserDefaults {
-    private enum Key: String {
+    fileprivate enum Key: String {
         case GlucoseBasedApplicationFactorEnabled = "com.loopkit.algorithmExperiments.glucoseBasedApplicationFactorEnabled"
         case IntegralRetrospectiveCorrectionEnabled = "com.loopkit.algorithmExperiments.integralRetrospectiveCorrectionEnabled"
     }


### PR DESCRIPTION
Purpose: this fix a display issue whereby changing an Algorithm Experiment then backing out from Algorithm experiments section and back in (without closing settings) results in the data being displayed as it initially appeared. This issue is mentioned in this comment (https://github.com/LoopKit/Loop/issues/2267#issuecomment-2567019786) - note that issue 2267 (which also has similar behavior in terms of a view not being updated despite the underlying data being saved) is however unrelated and thus this PR doesn't address it.

This is caused by the view being discarded from the render tree and then being restored as it was initialized.

This fix addresses this and cleans up the code as well by using AppStorage - the selection views themselves then only work with the Bindings and not directly with UserDefaults.