### PR TITLE
update progressCell for bolus display, finish update for dev branch

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -247,7 +247,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
                         // If there is an existing bolus progressCell, update its dose values now in case the app is currently in the
                         // background as otherwise these values won't get initialized and can contain stale data from some earlier bolus.
                         if let progressCell = tableView.cellForRow(at: IndexPath(row: StatusRow.status.rawValue, section: Section.status.rawValue)) as? BolusProgressTableViewCell {
-                            progressCell.configuration = .bolusing(delivered: 0, ofTotalVolume: dose.programmedUnits)
+                            progressCell.totalUnits = dose.programmedUnits
+                            progressCell.deliveredUnits = 0
                         }
                         break
                     }


### PR DESCRIPTION
## Purpose:

This PR should resolve Issue #2196.

I failed to test PR #2295, which was supposed to resolve the issue, in a LoopWorkspace build.

As explained [here](https://github.com/LoopKit/Loop/pull/2295#issuecomment-2745521527), I was given a version of the patch that worked with `dev`, but had to modify it for tidepool-merge.

## LoopWorkspace Status

The dev branch of LoopWorkspace is still pointing to an earlier commit for Loop, so my mistake in PR 2295 does not affect LoopWorkspace dev.

## Tests

### Build and Run Tests

With the addition of this PR to Loop dev (commit 710182e2, resultant commit prior to merge: 46f7a49d):
* building LoopWorkspace to a phone simulator succeeds
* running the Tests all succeed

My next comment will cover testing using a Test Phone to demonstrate the UI glitch is resolved.
