### PR TITLE
Configure the version number in LoopWorkspace, not Loop

### DIFF
--- a/Loop/Managers/SupportManager.swift
+++ b/Loop/Managers/SupportManager.swift
@@ -227,7 +227,7 @@ extension SupportManager: SupportUIDelegate {
     }
     
     private var branchNameIfNotReleaseBranch: String? {
-        return BuildDetails.default.gitBranch.filter { branch in
+        return BuildDetails.default.workspaceGitBranch.filter { branch in
             return branch != "" &&
                 branch != "main" &&
                 branch != "master" &&

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -6,10 +6,11 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-// Version [DEFAULT]
-LOOP_MARKETING_VERSION = 3.5.0
-CURRENT_PROJECT_VERSION = 57
+// Version
+//   [for DIY Loop] configure the version number in LoopWorkspace
+LOOP_MARKETING_VERSION = 1.0
+CURRENT_PROJECT_VERSION = 1
 
-// Optional override
-#include? "VersionOverride.xcconfig"
+// Optional override (enables override of version)
 #include? "../VersionOverride.xcconfig"
+#include? "VersionOverride.xcconfig"

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -6,9 +6,6 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-// Version [DEFAULT]
-LOOP_MARKETING_VERSION = 3.5.0
-CURRENT_PROJECT_VERSION = 57
-
-// Optional override
-#include? "VersionOverride.xcconfig"
+// Loop is only built using LoopWorkspace, so read
+//   the version number from LoopWorkspace
+#include "../LoopVersion.xcconfig"

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -12,3 +12,4 @@ CURRENT_PROJECT_VERSION = 57
 
 // Optional override
 #include? "VersionOverride.xcconfig"
+#include? "../VersionOverride.xcconfig"

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -6,6 +6,9 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-// Loop is only built using LoopWorkspace, so read
-//   the version number from LoopWorkspace
-#include "../LoopVersion.xcconfig"
+// Version [DEFAULT]
+LOOP_MARKETING_VERSION = 3.5.0
+CURRENT_PROJECT_VERSION = 57
+
+// Optional override
+#include? "VersionOverride.xcconfig"


### PR DESCRIPTION
## Purpose:

Simplify release process
* add a version number file to the LoopWorkspace folder and point to it from Version.xcconfig in the Loop folder
* this requires coordinated PR for Loop and LoopWorkspace

## Details

The Version.xcconfig file in the Loop repository is modified to point to the new file, LoopVersion.xcconfig, in the LoopWorkspace repository.

## Associated PR

The [LoopWorkspace PR 241](https://github.com/LoopKit/LoopWorkspace/pull/241) requires an update to the new Loop SHA after this PR is merged.