### PR TITLE
Toggle for disabling the retrospective correction 

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		4FF4D0F81E1725B000846527 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F54561D287FDB002A9274 /* NibLoadable.swift */; };
 		4FF4D1001E18374700846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
 		4FF4D1011E18375000846527 /* WatchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4D0FF1E18374700846527 /* WatchContext.swift */; };
+		608ED1CC2DC38D9D00C73BAC /* DisableRetrospectiveCorrectionSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608ED1CB2DC38D9700C73BAC /* DisableRetrospectiveCorrectionSelectionView.swift */; };
 		63F5E17C297DDF3900A62D4B /* ckcomplication.strings in Resources */ = {isa = PBXBuildFile; fileRef = 63F5E17A297DDF3900A62D4B /* ckcomplication.strings */; };
 		7D23667D21250C7E0028B67D /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D23667C21250C7E0028B67D /* LocalizedString.swift */; };
 		7D7076351FE06EDE004AC8EA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D7076371FE06EDE004AC8EA /* Localizable.strings */; };
@@ -970,6 +971,7 @@
 		4FDDD23620DC51DF00D04B16 /* LoopDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopDataManager.swift; sourceTree = "<group>"; };
 		4FF4D0FF1E18374700846527 /* WatchContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchContext.swift; sourceTree = "<group>"; };
 		4FFEDFBE20E5CF22000BFC58 /* ChartHUDController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartHUDController.swift; sourceTree = "<group>"; };
+		608ED1CB2DC38D9700C73BAC /* DisableRetrospectiveCorrectionSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableRetrospectiveCorrectionSelectionView.swift; sourceTree = "<group>"; };
 		63F5E17B297DDF3900A62D4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/ckcomplication.strings; sourceTree = "<group>"; };
 		7D199D93212A067600241026 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		7D199D94212A067600241026 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/MainInterface.strings; sourceTree = "<group>"; };
@@ -2244,6 +2246,7 @@
 		43F5C2CF1B92A2ED003EB13D /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				608ED1CB2DC38D9700C73BAC /* DisableRetrospectiveCorrectionSelectionView.swift */,
 				1452F4AA2A851EDF00F8B9E4 /* AddEditFavoriteFoodView.swift */,
 				B4001CED28CBBC82002FB414 /* AlertManagementView.swift */,
 				897A5A9524C2175B00C4E71D /* BolusEntryView.swift */,
@@ -3768,6 +3771,7 @@
 				43785E982120E7060057DED1 /* Intents.intentdefinition in Sources */,
 				1D82E6A025377C6B009131FB /* TrustedTimeChecker.swift in Sources */,
 				A98556852493F901000FD662 /* AlertStore+SimulatedCoreData.swift in Sources */,
+				608ED1CC2DC38D9D00C73BAC /* DisableRetrospectiveCorrectionSelectionView.swift in Sources */,
 				899433B823FE129800FA4BEA /* OverrideBadgeView.swift in Sources */,
 				89D1503E24B506EB00EDE253 /* Dictionary.swift in Sources */,
 				C110888D2A3913C600BA4898 /* BuildDetails.swift in Sources */,

--- a/Loop/Models/PredictionInputEffect.swift
+++ b/Loop/Models/PredictionInputEffect.swift
@@ -19,7 +19,13 @@ struct PredictionInputEffect: OptionSet {
     static let retrospection    = PredictionInputEffect(rawValue: 1 << 3)
     static let suspend          = PredictionInputEffect(rawValue: 1 << 4)
 
-    static let all: PredictionInputEffect = [.carbs, .insulin, .momentum, .retrospection]
+    static var all: PredictionInputEffect {
+        var effects: PredictionInputEffect = [.carbs, .insulin, .momentum]
+        if !UserDefaults.standard.bool(forKey: "com.loopkit.algorithmExperiments.disableRetrospectiveCorrection") {
+            effects.insert(.retrospection)
+        }
+        return effects
+    }
 
     var localizedTitle: String? {
         switch self {

--- a/Loop/Views/DisableRetrospectiveCorrectionSelectionView.swift
+++ b/Loop/Views/DisableRetrospectiveCorrectionSelectionView.swift
@@ -1,0 +1,44 @@
+//
+//  DisableRetrospectiveCorrectionSelectionView.swift
+//  Loop
+//
+//  Created by Jonas Björkert on 2023-06-04.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import LoopKit
+import LoopKitUI
+
+public struct DisableRetrospectiveCorrectionSelectionView: View {
+    @Binding var isDisableRetrospectiveCorrectionEnabled: Bool
+    
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 10) {
+                Text(NSLocalizedString("Disable Retrospective Correction", comment: "Title for disable retrospective correction"))
+                    .font(.headline)
+                    .padding(.bottom, 20)
+
+                Divider()
+
+                Text(NSLocalizedString("This toggle allows the complete disabling of any form of retrospective correction (standard or integral).\n\nDisabling the retrospective correction can be particularly useful in specific scenarios, such as when setting or re-evaluating insulin sensitivity factors and carbohydrate ratios.\n\nThe change will take effect in the next 5-minute loop.", comment: "Description of Disable Retrospective Correction toggle."))
+                    .foregroundColor(.secondary)
+                Divider()
+
+                Toggle(NSLocalizedString("Disable Retrospective Correction", comment: "Title for Disable Retrospective Correction toggle"), isOn: $isDisableRetrospectiveCorrectionEnabled)
+                    .padding(.top, 20)
+            }
+            .padding()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+}
+
+struct DisableRetrospectiveCorrectionSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        DisableRetrospectiveCorrectionSelectionView(isDisableRetrospectiveCorrectionEnabled: .constant(true))
+    }
+}

--- a/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+++ b/Loop/Views/SettingsView+algorithmExperimentsSection.swift
@@ -41,6 +41,7 @@ public struct ExperimentRow: View {
 public struct ExperimentsSettingsView: View {
     @AppStorage(UserDefaults.Key.GlucoseBasedApplicationFactorEnabled.rawValue) private var isGlucoseBasedApplicationFactorEnabled = false
     @AppStorage(UserDefaults.Key.IntegralRetrospectiveCorrectionEnabled.rawValue) private var isIntegralRetrospectiveCorrectionEnabled = false
+    @AppStorage(UserDefaults.Key.DisableRetrospectiveCorrection.rawValue) private var isDisableRetrospectiveCorrectionEnabled = false
     var automaticDosingStrategy: AutomaticDosingStrategy
 
     public var body: some View {
@@ -70,6 +71,11 @@ public struct ExperimentsSettingsView: View {
                         name: NSLocalizedString("Integral Retrospective Correction", comment: "Title of integral retrospective correction experiment"),
                         enabled: isIntegralRetrospectiveCorrectionEnabled)
                 }
+                NavigationLink(destination: DisableRetrospectiveCorrectionSelectionView(isDisableRetrospectiveCorrectionEnabled: $isDisableRetrospectiveCorrectionEnabled)) {
+                    ExperimentRow(
+                        name: NSLocalizedString("Disable Retrospective Correction", comment: "Title of disable retrospective correction experiment"),
+                        enabled: isDisableRetrospectiveCorrectionEnabled)
+                }
                 Spacer()
             }
             .padding()
@@ -83,6 +89,7 @@ extension UserDefaults {
     fileprivate enum Key: String {
         case GlucoseBasedApplicationFactorEnabled = "com.loopkit.algorithmExperiments.glucoseBasedApplicationFactorEnabled"
         case IntegralRetrospectiveCorrectionEnabled = "com.loopkit.algorithmExperiments.integralRetrospectiveCorrectionEnabled"
+        case DisableRetrospectiveCorrection = "com.loopkit.algorithmExperiments.disableRetrospectiveCorrection"
     }
 
     var glucoseBasedApplicationFactorEnabled: Bool {
@@ -100,6 +107,15 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.IntegralRetrospectiveCorrectionEnabled.rawValue)
+        }
+    }
+
+    var disableRetrospectiveCorrectionEnabled: Bool {
+        get {
+            bool(forKey: Key.DisableRetrospectiveCorrection.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.DisableRetrospectiveCorrection.rawValue)
         }
     }
 


### PR DESCRIPTION
This PR adds a toggle in the algorithm experiments to disable the retrospective correction (standard or integral). It follows an explicit request from some patients and doctors, which are having troubles in understanding what is going on with ISFs and carb ratios because of the retrospective correction "masking" sub-optimal settings.

What is missing:

- No localizations
- No unit-tests

It would be also nice to rename the algorithm experiments section to “advanced” or something similar, shifting its purpose from a sort of parking lot for experimental features to a proper section for advanced features and options which are going to stay. This of course does not mean that one of them could become a new default, but it would be nice to have a bit of more control and variety of options.