### PR TITLE
Disable Liquid Glass

### DIFF
--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -84,6 +84,8 @@
 		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
This just prevents Liquid Glass from being used when built to iOS 26 from Xcode 26, to keep Loop's UI consistent with prior iOS versions.

More info on this Boolean: https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility