### PR TITLE
Clear bolus recommendation on initial edit

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -248,7 +248,11 @@ struct BolusEntryView: View {
                     .multilineTextAlignment(.trailing)
                     .foregroundColor(.loopAccent)
                     .focused($bolusFieldFocused)
-                    .onTapGesture { didBeginEditing() }
+                    .onChange(of: bolusFieldFocused) { focused in
+                        if focused {
+                            didBeginEditing()
+                        }
+                    }
                     .onChange(of: enteredBolusString) { newValue in
                         if newValue.count > 5 {
                             enteredBolusString = String(newValue.prefix(5))


### PR DESCRIPTION
The onTapGesture callback is not called on a TextField. Better to use focus anyways; that works with keyboard focus as well.