### PR TITLE
Prefer opening Loop cgmManagerUI over CGM app when tapping CGM in HUD

### DIFF
--- a/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
+++ b/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
@@ -82,12 +82,12 @@ extension DeviceDataManager {
     func didTapOnCGMStatus(_ view: BaseHUDView? = nil) -> HUDTapAction? {
         if let action = bluetoothProvider.bluetoothState.action {
             return action
+        } else if let cgmManagerUI = (cgmManager as? CGMManagerUI) {
+            return .presentViewController(cgmManagerUI.settingsViewController(bluetoothProvider: bluetoothProvider, displayGlucosePreference: displayGlucosePreference, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures))
         } else if let url = cgmManager?.appURL,
             UIApplication.shared.canOpenURL(url)
         {
             return .openAppURL(url)
-        } else if let cgmManagerUI = (cgmManager as? CGMManagerUI) {
-            return .presentViewController(cgmManagerUI.settingsViewController(bluetoothProvider: bluetoothProvider, displayGlucosePreference: displayGlucosePreference, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures))
         } else {
             return .setupNewCGM
         }


### PR DESCRIPTION
When the user taps the CGM info in the HUD, try to open the local interface for managing the CGM before trying to launch the separate CGM app.  Fixes a reported issue with Dexcom G6 no longer opening the Loop config page. 