### PR TITLE
Support audio for pump managers that use silent audio for keep-alive

### DIFF
--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -83,9 +83,10 @@
 		<string>bluetooth-central</string>
 		<string>processing</string>
 		<string>remote-notification</string>
+		<string>audio</string>
 	</array>
-    <key>UIDesignRequiresCompatibility</key>
-    <true/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
## Purpose

Enable the silent audio method to be used with Loop when needed.

## Background

The DanaKit enables users to select playing a silent tune while the app is in the background or the phone is locked.
* The allows the user to run with a CGM that does not provide a heartbeat
* The current DanaKit directions in LoopDocs have the user modify the Loop code to enable this feature, which is off by default

There is also a proposed change to OmniBLE which is under development
* It provides a pod-keep-alive option
* Users of iPhone 16 can select a silent tune (or RileyLink) for use with InPlay pods to keep the BLE connection between phone and pod alive so long at the two are within Bluetooth range by sending a getStatus to the pod before the 3-minute automatic BLE disconnect

## Test

Trick: While testing, a heartbeat.wav file is used to overwrite the blank.wav file. The tester can then hear the "silent" audio when it is active.

This modification was tested and was successful.
* Add DanaKit pump
* Long press pump name
* Choose silent audio
* put app in background and hear the heartbeat
* lock the phone and hear the heartbeat

Reverse the process with long press and disable silent audio.
No heartbeat is heard.

