### PR TITLE
Add submodule commit timestamps to build details

### DIFF
--- a/Common/Models/BuildDetails.swift
+++ b/Common/Models/BuildDetails.swift
@@ -67,16 +67,17 @@ class BuildDetails {
     }
 
     /// Returns a dictionary of submodule details.
-    /// The keys are the submodule names, and the values are tuples (branch, commitSHA).
-    var submodules: [String: (branch: String, commitSHA: String)] {
+    /// The keys are the submodule names, and the values are tuples (branch, commitSHA, commitTimestamp).
+    var submodules: [String: (branch: String, commitSHA: String, commitTimestamp: String)] {
         guard let subs = dict["com-loopkit-Loop-submodules"] as? [String: [String: Any]] else {
             return [:]
         }
-        var result = [String: (branch: String, commitSHA: String)]()
+        var result = [String: (branch: String, commitSHA: String, commitTimestamp: String)]()
         for (name, info) in subs {
             let branch = info["branch"] as? String ?? String(localized: "Unknown")
             let commitSHA = info["commit_sha"] as? String ?? String(localized: "Unknown")
-            result[name] = (branch: branch, commitSHA: commitSHA)
+            let commitTimestamp = info["commit_timestamp"] as? String ?? String(localized: "Unknown")
+            result[name] = (branch: branch, commitSHA: commitSHA, commitTimestamp: commitTimestamp)
         }
         return result
     }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1703,7 +1703,17 @@ extension DeviceDataManager: DeviceSupportDelegate {
                     let submodulesInfo = BuildDetails.default.submodules
                         .sorted(by: { $0.key < $1.key })
                         .map { key, value in
-                            "*   \(key): \(value.branch), \(value.commitSHA)"
+                            let dateStr: String
+                            if let timestamp = TimeInterval(value.commitTimestamp) {
+                                let date = Date(timeIntervalSince1970: timestamp)
+                                let formatter = DateFormatter()
+                                formatter.dateFormat = "yyyy-MM-dd"
+                                formatter.timeZone = TimeZone(identifier: "UTC")
+                                dateStr = formatter.string(from: date)
+                            } else {
+                                dateStr = "Unknown"
+                            }
+                            return "*   \(key): \(value.branch), \(value.commitSHA) (\(dateStr))"
                         }
                         .joined(separator: "\n")
 
@@ -1716,7 +1726,7 @@ extension DeviceDataManager: DeviceSupportDelegate {
                         "* xcodeVersion: \(BuildDetails.default.xcodeVersion ?? "N/A")",
                         "* Workspace branch: \(BuildDetails.default.workspaceGitBranch ?? "N/A")",
                         "* Workspace SHA: \(BuildDetails.default.workspaceGitRevision ?? "N/A")",
-                        "* Submodule name: branch, SHA",
+                        "* Submodule name: branch, SHA (date)",
                         "\(submodulesInfo)",
                         "",
                         "## FeatureFlags",

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -125,24 +125,26 @@ fi
 
 # Gather submodule details.
 # We use git submodule foreach to output lines in the form:
-#   submodule_name|branch_or_tag|commit_sha
+#   submodule_name|branch_or_tag|commit_sha|commit_timestamp
 submodules_info=$(git submodule foreach --quiet '
   sub_git_branch=$(git symbolic-ref --short -q HEAD || echo "")
   sub_git_tag=$(git describe --tags --exact-match 2>/dev/null || echo "")
   sub_git_commit_sha=$(git log -1 --format="%h" --abbrev=7)
+  sub_git_commit_timestamp=$(git log -1 --format="%ct")
   sub_git_branch_or_tag="${sub_git_branch:-${sub_git_tag}}"
   if [ -z "${sub_git_branch_or_tag}" ]; then
     sub_git_branch_or_tag="detached"
   fi
-  echo "$name|$sub_git_branch_or_tag|$sub_git_commit_sha"
+  echo "$name|$sub_git_branch_or_tag|$sub_git_commit_sha|$sub_git_commit_timestamp"
 ')
 
 # For each line, add a dictionary entry for that submodule.
-echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_sha; do
+echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_sha sub_timestamp; do
     # Create a dictionary for this submodule
     /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name} dict" "${info_plist_path}"
     /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:branch string ${sub_branch}" "${info_plist_path}"
     /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:commit_sha string ${sub_sha}" "${info_plist_path}"
+    /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:commit_timestamp string ${sub_timestamp}" "${info_plist_path}"
 done
 
 echo "BuildDetails.plist has been updated at: ${info_plist_path}"


### PR DESCRIPTION
Extends the submodule metadata from PR #2399 to also capture and display each submodule's commit timestamp. The timestamp is stored as a unix epoch string ("commit_timestamp") in the plist, and shown as a YYYY-MM-DD UTC date in parentheses after the SHA in the build details report.
