### PR TITLE
Fix Live activity plot: colors in prediction, override target, time-range and labels

### DIFF
--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -141,9 +141,9 @@ struct ChartView: View {
                 }
             }
             .chartForegroundStyleScale([
-                "Good": colorInRange,
-                "High": colorAboveRange,
-                "Low": colorBelowRange,
+                "Good": Self.colorInRange,
+                "High": Self.colorAboveRange,
+                "Low": Self.colorBelowRange,
                 "Default": Color("glucose")
             ])
             .chartPlotStyle { plotContent in

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -18,7 +18,11 @@ struct ChartView: View {
     private let preset: Preset?
     private let yAxisMarks: [Double]
     private let colorGradient: LinearGradient
-    
+
+    private static let colorInRange = Color.green
+    private static let colorBelowRange = Color.red
+    private static let colorAboveRange = Color.orange
+
     init(glucoseSamples: [GlucoseSampleAttributes], predicatedGlucose: [Double], predicatedStartDate: Date?, predicatedInterval: TimeInterval?, useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
         self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
         self.predicatedData = ChartValues.convert(
@@ -29,7 +33,7 @@ struct ChartView: View {
             lowerLimit: lowerLimit,
             upperLimit: upperLimit
         )
-        self.colorGradient = ChartView.getGradient(useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit, highestValue: yAxisMarks.max() ?? 1)
+        self.colorGradient = ChartView.getGradient(useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit, lowestValue: predicatedGlucose.min() ?? 1, highestValue: predicatedGlucose.max() ?? 1)
         self.preset = preset
         self.glucoseRanges = glucoseRanges
         self.yAxisMarks = yAxisMarks
@@ -41,22 +45,40 @@ struct ChartView: View {
         self.preset = preset
         self.glucoseRanges = glucoseRanges
         self.yAxisMarks = yAxisMarks
-        self.colorGradient = ChartView.getGradient(useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit, highestValue: yAxisMarks.max() ?? 1)
+        self.colorGradient = LinearGradient(colors: [], startPoint: .bottom, endPoint: .top)
     }
 
-    private static func getGradient(useLimits: Bool, lowerLimit: Double, upperLimit: Double, highestValue: Double) -> LinearGradient {
+    private static func getGradient(useLimits: Bool, lowerLimit: Double, upperLimit: Double, lowestValue: Double, highestValue: Double) -> LinearGradient {
+    
         var stops: [Gradient.Stop] = [Gradient.Stop(color: Color("glucose"), location: 0)]
         if useLimits {
-            let lowerStop = lowerLimit / highestValue
-            let upperStop = upperLimit / highestValue
-            stops = [
-                Gradient.Stop(color: .red, location: 0),
-                Gradient.Stop(color: .red, location: lowerStop - 0.01),
-                Gradient.Stop(color: .green, location: lowerStop),
-                Gradient.Stop(color: .green, location: upperStop),
-                Gradient.Stop(color: .orange, location: upperStop + 0.01),
-                Gradient.Stop(color: .orange, location: 600), // Just use the mg/dl limit for the most upper value
-            ]
+            // For applying a color gradient to line data, the range of the plotted
+            // data maps to the space 0 to 1 for setting gradient stops, so normalize:
+            // Normalize the transition points to 0-1 space of the plotted range:
+            let lowerStop = (lowerLimit - lowestValue) / (highestValue - lowestValue)
+            let upperStop = (upperLimit - lowestValue) / (highestValue - lowestValue)
+            // Build up a set of stops, only using those in the 0-1 range:
+            stops = []
+            var stopColor: Color
+            // Get the color for glucose at the minimum of the line:
+            if lowestValue < lowerLimit {
+                stopColor = colorBelowRange
+            } else if lowestValue < upperLimit {
+                stopColor = colorInRange
+            } else {
+                stopColor = colorAboveRange
+            }
+            stops.append(Gradient.Stop(color: stopColor, location: 0))
+            // Add the transition stops if they are in the visible range:
+            if lowerStop > 0, lowerStop < 1 {
+                stops.append(Gradient.Stop(color: colorBelowRange, location: lowerStop))
+                stops.append(Gradient.Stop(color: colorInRange, location: lowerStop + 0.01))
+            }
+            if upperStop > 0, upperStop < 1 {
+                stops.append(Gradient.Stop(color: colorInRange, location: upperStop))
+                stops.append(Gradient.Stop(color: colorAboveRange, location: upperStop + 0.01))
+            }
+            
         }
         return LinearGradient(
             gradient: Gradient(stops: stops),
@@ -107,9 +129,9 @@ struct ChartView: View {
                 }
             }
             .chartForegroundStyleScale([
-                "Good": .green,
-                "High": .orange,
-                "Low": .red,
+                "Good": colorInRange,
+                "High": colorAboveRange,
+                "Low": colorBelowRange,
                 "Default": Color("glucose")
             ])
             .chartPlotStyle { plotContent in

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -30,7 +30,7 @@ struct ChartView: View {
     // doubleRangeWithMinimumIncrement logic by expanding by one chartable increment each side.
     private func adjustedRange(min minValue: Double, max maxValue: Double) -> (min: Double, max: Double) {
         guard (maxValue - minValue) < .ulpOfOne else { return (minValue, maxValue) }
-        return (minValue - chartableIncrement, maxValue + chartableIncrement)
+        return (minValue - 3 * chartableIncrement, maxValue + 3 * chartableIncrement)
     }
 
     init(glucoseSamples: [GlucoseSampleAttributes], predicatedGlucose: [Double], predicatedStartDate: Date?, predicatedInterval: TimeInterval?, useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -23,6 +23,16 @@ struct ChartView: View {
     private static let colorBelowRange = Color.red
     private static let colorAboveRange = Color.orange
 
+    // Infer chartable increment from yAxisMarks: mmol/L values are always below 40, mg/dL above 54.
+    private var chartableIncrement: Double { (yAxisMarks.max() ?? 100) < 40 ? 1.0/25.0 : 1.0 }
+
+    // When min == max the rectangle has zero height and is invisible. Mirror the main app's
+    // doubleRangeWithMinimumIncrement logic by expanding by one chartable increment each side.
+    private func adjustedRange(min minValue: Double, max maxValue: Double) -> (min: Double, max: Double) {
+        guard (maxValue - minValue) < .ulpOfOne else { return (minValue, maxValue) }
+        return (minValue - chartableIncrement, maxValue + chartableIncrement)
+    }
+
     init(glucoseSamples: [GlucoseSampleAttributes], predicatedGlucose: [Double], predicatedStartDate: Date?, predicatedInterval: TimeInterval?, useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
         self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
         self.predicatedData = ChartValues.convert(
@@ -91,22 +101,24 @@ struct ChartView: View {
         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)){
             Chart {
                 if let preset = self.preset, predicatedData.count > 0, preset.endDate > Date.now.addingTimeInterval(.hours(-6)) {
+                    let (presetMin, presetMax) = adjustedRange(min: preset.minValue, max: preset.maxValue)
                     RectangleMark(
                         xStart: .value("Start", preset.startDate),
                         xEnd: .value("End", preset.endDate),
-                        yStart: .value("Preset override", preset.minValue),
-                        yEnd: .value("Preset override", preset.maxValue)
+                        yStart: .value("Preset override", presetMin),
+                        yEnd: .value("Preset override", presetMax)
                     )
                     .foregroundStyle(.primary)
                     .opacity(0.6)
                 }
                 
                 ForEach(glucoseRanges) { item in
+                    let (rangeMin, rangeMax) = adjustedRange(min: item.minValue, max: item.maxValue)
                     RectangleMark(
                         xStart: .value("Start", item.startDate),
                         xEnd: .value("End", item.endDate),
-                        yStart: .value("Glucose range", item.minValue),
-                        yEnd: .value("Glucose range", item.maxValue)
+                        yStart: .value("Glucose range", rangeMin),
+                        yEnd: .value("Glucose range", rangeMax)
                     )
                     .foregroundStyle(.primary)
                     .opacity(0.3)

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -100,7 +100,7 @@ struct ChartView: View {
     var body: some View {
         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)){
             Chart {
-                if let preset = self.preset, predicatedData.count > 0, preset.endDate > Date.now.addingTimeInterval(.hours(-6)) {
+                if let preset = self.preset, (preset.minValue > 0 || preset.maxValue > 0), predicatedData.count > 0, preset.endDate > Date.now.addingTimeInterval(.hours(-6)) {
                     let (presetMin, presetMax) = adjustedRange(min: preset.minValue, max: preset.maxValue)
                     RectangleMark(
                         xStart: .value("Start", preset.startDate),

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -194,10 +194,10 @@ struct ChartValues: Identifiable {
     }
     
     static func convert(data: [Double], startDate: Date, interval: TimeInterval, useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {
-        let twoHours = Date.now.addingTimeInterval(.hours(4))
-        
+        let cutoff = adjustedChartEnd(startDate.addingTimeInterval(.hours(4)))
+
         return data.enumerated().filter { (index, item) in
-            return startDate.addingTimeInterval(interval * Double(index)) < twoHours
+            return startDate.addingTimeInterval(interval * Double(index)) < cutoff
         }.map { (index, item) in
             return ChartValues(
                 x: startDate.addingTimeInterval(interval * Double(index)),
@@ -205,6 +205,13 @@ struct ChartValues: Identifiable {
                 color: "Default" // Color is handled by the gradient
             )
         }
+    }
+
+    private static func adjustedChartEnd(_ date: Date) -> Date {
+        let minute = Calendar.current.component(.minute, from: date)
+        guard minute < 30 else { return date }
+        let startOfHour = Calendar.current.dateInterval(of: .hour, for: date)!.start
+        return startOfHour.addingTimeInterval(.minutes(30))
     }
     
     static func convert(data: [GlucoseSampleAttributes], useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {

--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -121,7 +121,7 @@ struct ChartView: View {
                         yEnd: .value("Glucose range", rangeMax)
                     )
                     .foregroundStyle(.primary)
-                    .opacity(0.3)
+                    .opacity(item.isOverride ? 0.6 : 0.3)
                 }
                 
                 ForEach(glucoseSampleData) { item in

--- a/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift
+++ b/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift
@@ -64,6 +64,16 @@ public struct GlucoseRangeValue: Identifiable, Codable, Hashable {
     public let maxValue: Double
     public let startDate: Date
     public let endDate: Date
+    public let isOverride: Bool
+
+    public init(id: UUID, minValue: Double, maxValue: Double, startDate: Date, endDate: Date, isOverride: Bool = false) {
+        self.id = id
+        self.minValue = minValue
+        self.maxValue = maxValue
+        self.startDate = startDate
+        self.endDate = endDate
+        self.isOverride = isOverride
+    }
 }
 
 public struct BottomRowItem: Codable, Hashable {

--- a/Loop/Managers/Live Activity/LiveActivityManager.swift
+++ b/Loop/Managers/Live Activity/LiveActivityManager.swift
@@ -143,13 +143,21 @@ class LiveActivityManager : LiveActivityManagerProxy {
             
             var presetContext: Preset? = nil
             if let override = self.loopSettings.preMealOverride ?? self.loopSettings.scheduleOverride, let start = glucoseSamples.first?.startDate {
-                presetContext = Preset(
-                    title: override.getTitle(),
-                    startDate: max(override.startDate, start),
-                    endDate: override.duration.isInfinite ? endDateChart : min(override.actualEndDate, endDateChart),
-                    minValue: override.settings.targetRange?.lowerBound.doubleValue(for: unit) ?? 0,
-                    maxValue: override.settings.targetRange?.upperBound.doubleValue(for: unit) ?? 0
-                )
+                let presetStart = max(override.startDate, start)
+                let presetEnd = override.duration.isInfinite ? endDateChart : min(override.actualEndDate, endDateChart)
+                // Only create a preset if it overlaps the chart window. If the override ended
+                // before the chart window starts (e.g. spacious mode only shows 2h of history),
+                // presetEnd < presetStart and drawing a RectangleMark with those backwards dates
+                // forces SwiftUI Charts to expand the x-axis far into the past.
+                if presetStart <= presetEnd {
+                    presetContext = Preset(
+                        title: override.getTitle(),
+                        startDate: presetStart,
+                        endDate: presetEnd,
+                        minValue: override.settings.targetRange?.lowerBound.doubleValue(for: unit) ?? 0,
+                        maxValue: override.settings.targetRange?.upperBound.doubleValue(for: unit) ?? 0
+                    )
+                }
             }
             
             var glucoseRanges: [GlucoseRangeValue] = []

--- a/Loop/Managers/Live Activity/LiveActivityManager.swift
+++ b/Loop/Managers/Live Activity/LiveActivityManager.swift
@@ -156,7 +156,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
             if let glucoseRangeSchedule = self.loopSettings.glucoseTargetRangeSchedule, let start = glucoseSamples.first?.startDate {
                 glucoseRanges = getGlucoseRanges(
                     glucoseRangeSchedule: glucoseRangeSchedule,
-                    presetContext: presetContext,
+                    presetContext: presetContext?.minValue == 0 && presetContext?.maxValue == 0 ? nil : presetContext,
                     start: start,
                     end: endDateChart,
                     unit: unit

--- a/Loop/Managers/Live Activity/LiveActivityManager.swift
+++ b/Loop/Managers/Live Activity/LiveActivityManager.swift
@@ -165,8 +165,8 @@ class LiveActivityManager : LiveActivityManagerProxy {
                 glucoseRanges = getGlucoseRanges(
                     glucoseRangeSchedule: glucoseRangeSchedule,
                     presetContext: presetContext,
-                    start: start,
-                    end: endDateChart,
+                    start: adjustedChartStart(start),
+                    end: adjustedChartEnd(endDateChart),
                     unit: unit
                 )
             }
@@ -339,7 +339,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
         // In compact mode, we only want to show the history
         let timeInterval: TimeInterval = self.settings.addPredictiveLine ? .hours(-2) : .hours(-6)
         self.glucoseStore.getGlucoseSamples(
-            start: Date.now.addingTimeInterval(timeInterval),
+            start: adjustedChartStart(Date.now.addingTimeInterval(timeInterval)),
             end: Date.now
         ) { result in
             switch (result) {
@@ -357,6 +357,26 @@ class LiveActivityManager : LiveActivityManagerProxy {
         return samples
     }
     
+    // If the chart start falls past the half-hour mark (HH:31–HH:59), pull it back to HH:30
+    // so that the nearest hour label is never truncated at the left edge.
+    private func adjustedChartStart(_ date: Date) -> Date {
+        let calendar = Calendar.current
+        let minute = calendar.component(.minute, from: date)
+        guard minute > 30 else { return date }
+        let startOfHour = calendar.dateInterval(of: .hour, for: date)!.start
+        return startOfHour.addingTimeInterval(.minutes(30))
+    }
+
+    // If the chart end falls before the half-hour mark (HH:00–HH:29), push it forward to HH:30
+    // so that the nearest hour label is never truncated at the right edge.
+    private func adjustedChartEnd(_ date: Date) -> Date {
+        let calendar = Calendar.current
+        let minute = calendar.component(.minute, from: date)
+        guard minute < 30 else { return date }
+        let startOfHour = calendar.dateInterval(of: .hour, for: date)!.start
+        return startOfHour.addingTimeInterval(.minutes(30))
+    }
+
     private func getGlucoseRanges(glucoseRangeSchedule: GlucoseRangeSchedule, presetContext: Preset?, start: Date, end: Date, unit: HKUnit) -> [GlucoseRangeValue] {
         var glucoseRanges: [GlucoseRangeValue] = []
         for item in glucoseRangeSchedule.quantityBetween(start: start, end: end) {

--- a/Loop/Managers/Live Activity/LiveActivityManager.swift
+++ b/Loop/Managers/Live Activity/LiveActivityManager.swift
@@ -156,7 +156,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
             if let glucoseRangeSchedule = self.loopSettings.glucoseTargetRangeSchedule, let start = glucoseSamples.first?.startDate {
                 glucoseRanges = getGlucoseRanges(
                     glucoseRangeSchedule: glucoseRangeSchedule,
-                    presetContext: presetContext?.minValue == 0 && presetContext?.maxValue == 0 ? nil : presetContext,
+                    presetContext: presetContext,
                     start: start,
                     end: endDateChart,
                     unit: unit
@@ -358,8 +358,9 @@ class LiveActivityManager : LiveActivityManagerProxy {
             let endDate = min(item.endDate, end)
             
             if let presetContext = presetContext {
+                let noTargetRange = presetContext.minValue == 0 && presetContext.maxValue == 0
                 if presetContext.startDate > startDate, presetContext.endDate < endDate {
-                    // A preset is active during this schedule
+                    // Override entirely within this schedule segment
                     glucoseRanges.append(GlucoseRangeValue(
                         id: UUID(),
                         minValue: minValue,
@@ -367,6 +368,16 @@ class LiveActivityManager : LiveActivityManagerProxy {
                         startDate: startDate,
                         endDate: presetContext.startDate
                     ))
+                    if noTargetRange {
+                        glucoseRanges.append(GlucoseRangeValue(
+                            id: UUID(),
+                            minValue: minValue,
+                            maxValue: maxValue,
+                            startDate: presetContext.startDate,
+                            endDate: presetContext.endDate,
+                            isOverride: true
+                        ))
+                    }
                     glucoseRanges.append(GlucoseRangeValue(
                         id: UUID(),
                         minValue: minValue,
@@ -375,7 +386,17 @@ class LiveActivityManager : LiveActivityManagerProxy {
                         endDate: endDate
                     ))
                 } else if presetContext.endDate > startDate, presetContext.endDate < endDate {
-                    // Cut off the start of the glucose target
+                    // Override ends within this segment (started before)
+                    if noTargetRange {
+                        glucoseRanges.append(GlucoseRangeValue(
+                            id: UUID(),
+                            minValue: minValue,
+                            maxValue: maxValue,
+                            startDate: startDate,
+                            endDate: presetContext.endDate,
+                            isOverride: true
+                        ))
+                    }
                     glucoseRanges.append(GlucoseRangeValue(
                         id: UUID(),
                         minValue: minValue,
@@ -384,7 +405,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
                         endDate: endDate
                     ))
                 } else if presetContext.startDate < endDate, presetContext.startDate > startDate {
-                    // Cut off the end of the glucose target
+                    // Override starts within this segment (ends after)
                     glucoseRanges.append(GlucoseRangeValue(
                         id: UUID(),
                         minValue: minValue,
@@ -392,8 +413,30 @@ class LiveActivityManager : LiveActivityManagerProxy {
                         startDate: startDate,
                         endDate: presetContext.startDate
                     ))
+                    if noTargetRange {
+                        glucoseRanges.append(GlucoseRangeValue(
+                            id: UUID(),
+                            minValue: minValue,
+                            maxValue: maxValue,
+                            startDate: presetContext.startDate,
+                            endDate: endDate,
+                            isOverride: true
+                        ))
+                    }
                     if presetContext.endDate == end {
                         break
+                    }
+                } else if presetContext.startDate <= startDate, presetContext.endDate >= endDate {
+                    // Override completely covers this segment
+                    if noTargetRange {
+                        glucoseRanges.append(GlucoseRangeValue(
+                            id: UUID(),
+                            minValue: minValue,
+                            maxValue: maxValue,
+                            startDate: startDate,
+                            endDate: endDate,
+                            isOverride: true
+                        ))
                     }
                 } else {
                     // No overlap with target and override


### PR DESCRIPTION
This PR addresses two issues in the Live Activity plot: 

1. Correctly color-code the predicted line, addressing issue #2392; 
2. Make override and target range bars visible when min and max are the same. 