### PR TITLE
Add plist value to open Watch app on Smart Stack Live Activity tap

### DIFF
--- a/WatchApp/Info.plist
+++ b/WatchApp/Info.plist
@@ -33,6 +33,10 @@
 	</array>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
+	<key>WKSupportsLiveActivityLaunchAttributeTypes</key>
+	<array>
+		<string>GlucoseActivityAttributes</string>
+	</array>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>


### PR DESCRIPTION
This small change allows a tap on the Loop Live Activity in the Apple Watch Smart Stack to open the Watch Loop app, instead of prompting to open the app on the phone.