### PR TITLE
Fix Live Activity bottom row text getting cut off

### DIFF
--- a/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
+++ b/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
@@ -377,8 +377,14 @@ struct GlucoseLiveActivityConfiguration: Widget {
                 .foregroundStyle(.primary)
                 .fontWeight(.heavy)
                 .font(Font.body.leading(.tight))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .allowsTightening(true)
             Text(title)
                 .font(.caption2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .allowsTightening(true)
         }
     }
 
@@ -399,6 +405,9 @@ struct GlucoseLiveActivityConfiguration: Widget {
                     )
                     .fontWeight(.heavy)
                     .font(Font.body.leading(.tight))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .allowsTightening(true)
             }
         }
     }


### PR DESCRIPTION
Addresses #2423.

Some Live Activity bottom row text could get cut off on smaller screens. This lets the glucose value, labels, and updated time become a bit smaller so they fit better on the screen.