### PR TITLE
Show glucose predictions and allow bolus recommendations without pod

### DIFF
--- a/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
+++ b/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
@@ -75,6 +75,10 @@ extension DeviceDataManager: BolusEntryViewModelDelegate, ManualDoseViewModelDel
         return pumpManager != nil
     }
     
+    var shouldModelAsNoDelivery: Bool {
+        return pumpManager?.status.shouldModelAsNoDelivery ?? false
+    }
+
     var preferredGlucoseUnit: HKUnit {
         return displayGlucosePreference.unit
     }

--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -6453,6 +6453,9 @@
         }
       }
     },
+    "Always active when no pump is connected" : {
+      "comment" : "Subtitle for suspend prediction input when no pump is connected"
+    },
     "Amount Consumed" : {
       "comment" : "Label for carb quantity entry row on carb entry screen",
       "localizations" : {
@@ -27636,6 +27639,12 @@
         }
       }
     },
+    "No Pump Connected" : {
+      "comment" : "Title for bolus screen notice when no pump is connected"
+    },
+    "No pump is connected. Bolus delivery is unavailable." : {
+      "comment" : "Caption for bolus screen notice when no pump is connected"
+    },
     "No Recent Glucose" : {
       "comment" : "The title of the cell indicating that there is no recent glucose",
       "localizations" : {
@@ -41319,6 +41328,7 @@
     },
     "Your pump data is stale. %1$@ cannot recommend a bolus amount." : {
       "comment" : "Caption for bolus screen notice when pump data is missing or stale",
+      "extractionState" : "stale",
       "localizations" : {
         "da" : {
           "stringUnit" : {
@@ -41399,6 +41409,9 @@
           }
         }
       }
+    },
+    "Your pump data is stale. Bolus delivery may be unavailable." : {
+      "comment" : "Caption for bolus screen notice when pump data is stale"
     },
     "Your pump is delivering a manual temporary basal rate." : {
       "comment" : "The description text for the looping enabled switch cell when closed loop is not allowed because the pump is delivering a manual temp basal.",

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1235,7 +1235,8 @@ extension LoopDataManager {
         potentialCarbEntry: NewCarbEntry? = nil,
         replacingCarbEntry replacedCarbEntry: StoredCarbEntry? = nil,
         includingPendingInsulin: Bool = false,
-        includingPositiveVelocityAndRC: Bool = true
+        includingPositiveVelocityAndRC: Bool = true,
+        requireRecentPumpData: Bool = true
     ) throws -> [PredictedGlucoseValue] {
         dispatchPrecondition(condition: .onQueue(dataAccessQueue))
 
@@ -1254,8 +1255,10 @@ extension LoopDataManager {
             throw LoopError.invalidFutureGlucose(date: lastGlucoseDate)
         }
 
-        guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
-            throw LoopError.pumpDataTooOld(date: pumpStatusDate)
+        if requireRecentPumpData {
+            guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
+                throw LoopError.pumpDataTooOld(date: pumpStatusDate)
+            }
         }
 
         var momentum: [GlucoseEffect] = []
@@ -1487,8 +1490,16 @@ extension LoopDataManager {
 
         let pendingInsulin = try getPendingInsulin()
         let shouldIncludePendingInsulin = pendingInsulin > 0
-        let prediction = try predictGlucose(using: .all, potentialBolus: nil, potentialCarbEntry: potentialCarbEntry, replacingCarbEntry: replacedCarbEntry, includingPendingInsulin: shouldIncludePendingInsulin, includingPositiveVelocityAndRC: considerPositiveVelocityAndRC)
-        return try recommendBolusValidatingDataRecency(forPrediction: prediction, consideringPotentialCarbEntry: potentialCarbEntry)
+
+        var effectsToUse = PredictionInputEffect.all
+        var requireRecentPumpData = true // default to true to gate existing behavior on other pump types
+        if self.shouldModelAsNoDelivery {
+            // No active pod connected means no basal delivery — model it as suspension
+            effectsToUse.insert(.suspend)
+            requireRecentPumpData = false
+        }
+        let prediction = try predictGlucose(using: effectsToUse, potentialBolus: nil, potentialCarbEntry: potentialCarbEntry, replacingCarbEntry: replacedCarbEntry, includingPendingInsulin: shouldIncludePendingInsulin, includingPositiveVelocityAndRC: considerPositiveVelocityAndRC, requireRecentPumpData: requireRecentPumpData)
+        return try recommendBolusValidatingDataRecency(forPrediction: prediction, consideringPotentialCarbEntry: potentialCarbEntry, requireRecentPumpData: requireRecentPumpData)
     }
 
     /// - Throws:
@@ -1498,7 +1509,8 @@ extension LoopDataManager {
     ///     - LoopError.pumpDataTooOld
     ///     - LoopError.configurationError
     fileprivate func recommendBolusValidatingDataRecency<Sample: GlucoseValue>(forPrediction predictedGlucose: [Sample],
-                                                                               consideringPotentialCarbEntry potentialCarbEntry: NewCarbEntry?) throws -> ManualBolusRecommendation? {
+                                                                               consideringPotentialCarbEntry potentialCarbEntry: NewCarbEntry?,
+                                                                               requireRecentPumpData: Bool = true) throws -> ManualBolusRecommendation? {
         guard let glucose = glucoseStore.latestGlucose else {
             throw LoopError.missingDataError(.glucose)
         }
@@ -1513,9 +1525,10 @@ extension LoopDataManager {
         guard lastGlucoseDate.timeIntervalSince(now()) <= LoopCoreConstants.inputDataRecencyInterval else {
             throw LoopError.invalidFutureGlucose(date: lastGlucoseDate)
         }
-
-        guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
-            throw LoopError.pumpDataTooOld(date: pumpStatusDate)
+        if requireRecentPumpData {
+            guard now().timeIntervalSince(pumpStatusDate) <= LoopCoreConstants.inputDataRecencyInterval else {
+                throw LoopError.pumpDataTooOld(date: pumpStatusDate)
+            }
         }
 
         guard glucoseMomentumEffect != nil else {
@@ -1531,6 +1544,12 @@ extension LoopDataManager {
         }
 
         return try recommendManualBolus(forPrediction: predictedGlucose, consideringPotentialCarbEntry: potentialCarbEntry)
+    }
+    
+    private var shouldModelAsNoDelivery: Bool {
+        // Model as no delivery if the delegate or status is not present.
+        // If both are present, use the pumpManagerStatus field directly
+        return delegate?.pumpManagerStatus?.shouldModelAsNoDelivery ?? true
     }
     
     /// - Throws: LoopError.configurationError
@@ -1719,7 +1738,8 @@ extension LoopDataManager {
 
         let pumpStatusDate = doseStore.lastAddedPumpData
 
-        if startDate.timeIntervalSince(pumpStatusDate) > LoopCoreConstants.inputDataRecencyInterval {
+        let pumpDataTooOld = startDate.timeIntervalSince(pumpStatusDate) > LoopCoreConstants.inputDataRecencyInterval
+        if pumpDataTooOld {
             errors.append(.pumpDataTooOld(date: pumpStatusDate))
         }
 
@@ -1773,17 +1793,33 @@ extension LoopDataManager {
         }
 
         dosingDecision.appendErrors(errors)
-        if let error = errors.first {
+        let errorsExcludingPumpDataTooOld = errors.filter {
+            if case .pumpDataTooOld = $0 { return false }
+            return true
+        }
+        if let error = errorsExcludingPumpDataTooOld.first {
             logger.error("%{public}@", String(describing: error))
             return (dosingDecision, error)
         }
 
         var loopError: LoopError?
         do {
-            let predictedGlucose = try predictGlucose(using: settings.enabledEffects)
+            var effectsToUse = settings.enabledEffects
+            if self.shouldModelAsNoDelivery {
+                effectsToUse.insert(.suspend)  // no pump = no basal delivery, model it as suspension
+            }
+            let predictedGlucose = try predictGlucose(using: effectsToUse, requireRecentPumpData: false)
             self.predictedGlucose = predictedGlucose
-            let predictedGlucoseIncludingPendingInsulin = try predictGlucose(using: settings.enabledEffects, includingPendingInsulin: true)
+            // Prediction is shown regardless of pump state, while automated dosing still requires fresh pump data (below via pumpDataTooOld)
+            let predictedGlucoseIncludingPendingInsulin = try predictGlucose(using: effectsToUse, includingPendingInsulin: true, requireRecentPumpData: false)
             self.predictedGlucoseIncludingPendingInsulin = predictedGlucoseIncludingPendingInsulin
+
+            if pumpDataTooOld {
+                self.logger.debug("Skipping automatic dose recommendation due to stale pump data.")
+                recommendedAutomaticDose = nil
+                dosingDecision.automaticDoseRecommendation = nil
+                return (dosingDecision, .pumpDataTooOld(date: pumpStatusDate))
+            }
 
             dosingDecision.predictedGlucose = predictedGlucose
 
@@ -1944,6 +1980,17 @@ extension LoopDataManager {
             }
         }
     }
+    
+    
+}
+
+extension PumpManagerStatus {
+    var shouldModelAsNoDelivery: Bool {
+        // Treat a non-active (faulted or setup incomplete) pod just like no pod
+        // OmniBLE reports no active pod as .active(.distantPast)
+        // See both OmniBLEPumpManager.basalDeliveryState(for:) and OmnipodPumpManager.basalDeliveryState(for:)
+        return basalDeliveryState == .active(.distantPast)
+    }
 }
 
 /// Describes a view into the loop state
@@ -1985,9 +2032,10 @@ protocol LoopState {
     /// - Parameter replacedCarbEntry: An existing carb entry replaced by `potentialCarbEntry`
     /// - Parameter includingPendingInsulin: If `true`, the returned prediction will include the effects of scheduled but not yet delivered insulin
     /// - Parameter considerPositiveVelocityAndRC: Positive velocity and positive retrospective correction will not be used if this is false.
+    /// - Parameter requireRecentPumpData: Age of pump data will not be evaluated (and not throw LoopError.pumpDataTooOld) if this is `false`. Set to `false` for predicting insulin without a pump connected.
     /// - Returns: An timeline of predicted glucose values
     /// - Throws: LoopError.missingDataError if prediction cannot be computed
-    func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool) throws -> [PredictedGlucoseValue]
+    func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool, requireRecentPumpData: Bool) throws -> [PredictedGlucoseValue]
 
     /// Calculates a new prediction from a manual glucose entry in the context of a meal entry
     ///
@@ -2035,7 +2083,8 @@ extension LoopState {
     /// - Returns: An timeline of predicted glucose values
     /// - Throws: LoopError.missingDataError if prediction cannot be computed
     func predictGlucose(using inputs: PredictionInputEffect, includingPendingInsulin: Bool = false) throws -> [GlucoseValue] {
-        try predictGlucose(using: inputs, potentialBolus: nil, potentialCarbEntry: nil, replacingCarbEntry: nil, includingPendingInsulin: includingPendingInsulin, considerPositiveVelocityAndRC: true)
+        // `requireRecentPumpData` set to false as this method is for visualization purposes
+        try predictGlucose(using: inputs, potentialBolus: nil, potentialCarbEntry: nil, replacingCarbEntry: nil, includingPendingInsulin: includingPendingInsulin, considerPositiveVelocityAndRC: true, requireRecentPumpData: false)
     }
 }
 
@@ -2099,9 +2148,9 @@ extension LoopDataManager {
             return loopDataManager.retrospectiveCorrection.totalGlucoseCorrectionEffect
         }
 
-        func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool) throws -> [PredictedGlucoseValue] {
+        func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool, requireRecentPumpData: Bool) throws -> [PredictedGlucoseValue] {
             dispatchPrecondition(condition: .onQueue(loopDataManager.dataAccessQueue))
-            return try loopDataManager.predictGlucose(using: inputs, potentialBolus: potentialBolus, potentialCarbEntry: potentialCarbEntry, replacingCarbEntry: replacedCarbEntry, includingPendingInsulin: includingPendingInsulin, includingPositiveVelocityAndRC: considerPositiveVelocityAndRC)
+            return try loopDataManager.predictGlucose(using: inputs, potentialBolus: potentialBolus, potentialCarbEntry: potentialCarbEntry, replacingCarbEntry: replacedCarbEntry, includingPendingInsulin: includingPendingInsulin, includingPositiveVelocityAndRC: considerPositiveVelocityAndRC, requireRecentPumpData: requireRecentPumpData)
         }
 
         func predictGlucoseFromManualGlucose(

--- a/Loop/View Controllers/PredictionTableViewController.swift
+++ b/Loop/View Controllers/PredictionTableViewController.swift
@@ -29,6 +29,10 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         tableView.rowHeight = UITableView.automaticDimension
         tableView.cellLayoutMarginsFollowReadableWidth = true
 
+        // No pump connected means no basal delivery — default prediction to suspension effect
+        if self.defaultPredictionShouldIncludeNoDelivery {
+            self.selectedInputs.insert(.suspend)
+        }
         glucoseChart.glucoseDisplayRange = LoopConstants.glucoseChartDefaultDisplayRangeWide
 
         let notificationCenter = NotificationCenter.default
@@ -87,6 +91,19 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         }
     }
 
+    private func selectedEffectsMatchBasePrediction() -> Bool {
+        var baseEffects = PredictionInputEffect.all
+        if self.defaultPredictionShouldIncludeNoDelivery {
+            baseEffects.insert(.suspend)
+        }
+        return selectedInputs == baseEffects
+    }
+
+    private var defaultPredictionShouldIncludeNoDelivery: Bool {
+        guard let pumpManager = self.deviceManager.pumpManager else { return true }
+        return pumpManager.status.shouldModelAsNoDelivery
+    }
+
     let glucoseChart = PredictedGlucoseChart(yAxisStepSizeMGDLOverride: FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil)
 
     override func createChartsManager() -> ChartsManager {
@@ -135,14 +152,20 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
             self.glucoseChart.setPredictedGlucoseValues(state.predictedGlucoseIncludingPendingInsulin ?? [])
 
             do {
-                let glucose = try state.predictGlucose(using: self.selectedInputs, includingPendingInsulin: true)
-                self.glucoseChart.setAlternatePredictedGlucoseValues(glucose)
+                if self.selectedEffectsMatchBasePrediction() {
+                    self.glucoseChart.setAlternatePredictedGlucoseValues([])
+                } else {
+                    let glucose = try state.predictGlucose(using: self.selectedInputs, includingPendingInsulin: true)
+                    self.glucoseChart.setAlternatePredictedGlucoseValues(glucose)
+                }
             } catch {
                 self.refreshContext.update(with: .status)
                 self.glucoseChart.setAlternatePredictedGlucoseValues([])
             }
 
-            if let lastPoint = self.glucoseChart.alternatePredictedGlucosePoints?.last?.y {
+            if let lastPoint = (self.selectedEffectsMatchBasePrediction() ?
+                                self.glucoseChart.predictedGlucosePoints.last?.y :
+                                    self.glucoseChart.alternatePredictedGlucosePoints?.last?.y) {
                 self.eventualGlucoseDescription = String(describing: lastPoint)
             } else {
                 self.eventualGlucoseDescription = nil
@@ -233,6 +256,18 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         case .inputs:
             let cell = tableView.dequeueReusableCell(withIdentifier: PredictionInputEffectTableViewCell.className, for: indexPath) as! PredictionInputEffectTableViewCell
             self.tableView(tableView, updateTextFor: cell, at: indexPath)
+            let input = availableInputs[indexPath.row]
+            if input == .suspend && self.defaultPredictionShouldIncludeNoDelivery {
+                // When no pump connected, suspend effect is marked as active, so we show it as permanently selected and non-interactive
+                cell.contentView.alpha = 0.5
+                cell.selectionStyle = .none
+                let checkmark = UIImageView(image: UIImage(systemName: "checkmark"))
+                checkmark.tintColor = .systemGray
+                cell.accessoryView = checkmark
+            } else {
+                cell.contentView.alpha = 1.0
+                cell.selectionStyle = .default
+            }
             return cell
         }
     }
@@ -297,6 +332,10 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         
         }
 
+        if input == .suspend && self.defaultPredictionShouldIncludeNoDelivery {
+            subtitleText = NSLocalizedString("Always active when no pump is connected", comment: "Subtitle for suspend prediction input when no pump is connected")
+        }
+        
         cell.subtitleLabel?.text = subtitleText
     }
 
@@ -315,6 +354,13 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         guard Section(rawValue: indexPath.section) == .inputs else { return }
 
         let input = availableInputs[indexPath.row]
+        
+        // When no pump connected, suspend effect is permanently active — ignore taps
+        if input == .suspend && self.defaultPredictionShouldIncludeNoDelivery {
+            tableView.deselectRow(at: indexPath, animated: true)
+            return
+        }
+        
         let isSelected = selectedInputs.contains(input)
 
         if let cell = tableView.cellForRow(at: indexPath) {

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -45,6 +45,8 @@ protocol BolusEntryViewModelDelegate: AnyObject {
     
     var isPumpConfigured: Bool { get }
     
+    var shouldModelAsNoDelivery: Bool { get }
+    
     var pumpInsulinType: InsulinType? { get }
     
     var settings: LoopSettings { get }
@@ -78,6 +80,7 @@ final class BolusEntryViewModel: ObservableObject {
         case staleGlucoseData
         case futureGlucoseData
         case stalePumpData
+        case noPumpConnected
     }
 
     var authenticationHandler: (String) async -> Bool = { message in
@@ -580,13 +583,18 @@ final class BolusEntryViewModel: ObservableObject {
                     considerPositiveVelocityAndRC: true
                 )
             } else {
+                var effectsToUse = PredictionInputEffect.all
+                if delegate?.shouldModelAsNoDelivery ?? false {
+                    effectsToUse.insert(.suspend)  // no pump = no basal delivery, model it as suspension
+                }
                 predictedGlucoseValues = try state.predictGlucose(
-                    using: .all,
+                    using: effectsToUse,
                     potentialBolus: enteredBolusDose,
                     potentialCarbEntry: potentialCarbEntry,
                     replacingCarbEntry: originalCarbEntry,
                     includingPendingInsulin: true,
-                    considerPositiveVelocityAndRC: true
+                    considerPositiveVelocityAndRC: true,
+                    requireRecentPumpData: false // this is for visualization only
                 )
             }
         } catch {
@@ -657,7 +665,7 @@ final class BolusEntryViewModel: ObservableObject {
         let now = Date()
         var recommendation: ManualBolusRecommendation?
         let recommendedBolus: HKQuantity?
-        let notice: Notice?
+        var notice: Notice?
         do {
             recommendation = try computeBolusRecommendation(from: state)
 
@@ -695,6 +703,15 @@ final class BolusEntryViewModel: ObservableObject {
                 notice = .stalePumpData
             default:
                 notice = nil
+            }
+        }
+        
+        // Surface appropriate pump warning even when recommendation succeeded
+        if notice == nil || notice == .predictedGlucoseInRange {
+            if delegate.shouldModelAsNoDelivery {
+                notice = .noPumpConnected
+            } else if isPumpDataStale {
+                notice = .stalePumpData
             }
         }
 

--- a/Loop/View Models/ManualEntryDoseViewModel.swift
+++ b/Loop/View Models/ManualEntryDoseViewModel.swift
@@ -37,6 +37,8 @@ protocol ManualDoseViewModelDelegate: AnyObject {
     
     var isPumpConfigured: Bool { get }
     
+    var shouldModelAsNoDelivery: Bool { get }
+
     var preferredGlucoseUnit: HKUnit { get }
     
     var pumpInsulinType: InsulinType? { get }
@@ -261,13 +263,18 @@ final class ManualEntryDoseViewModel: ObservableObject {
 
         let predictedGlucoseValues: [PredictedGlucoseValue]
         do {
+            var effectsToUse = PredictionInputEffect.all
+            if delegate?.shouldModelAsNoDelivery ?? false {
+                effectsToUse.insert(.suspend)  // no pump means no basal delivery. model it as suspension
+            }
             predictedGlucoseValues = try state.predictGlucose(
-                using: .all,
+                using: effectsToUse,
                 potentialBolus: enteredBolusDose,
                 potentialCarbEntry: nil,
                 replacingCarbEntry: nil,
                 includingPendingInsulin: true,
-                considerPositiveVelocityAndRC: true
+                considerPositiveVelocityAndRC: true,
+                requireRecentPumpData: false // visualization only — prediction chart does not require fresh pump data
             )
         } catch {
             predictedGlucoseValues = []

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -326,8 +326,13 @@ struct BolusEntryView: View {
         case .stalePumpData:
             return WarningView(
                 title: Text("No Recent Pump Data", comment: "Title for bolus screen notice when pump data is missing or stale"),
-                caption: Text(String(format: NSLocalizedString("Your pump data is stale. %1$@ cannot recommend a bolus amount.", comment: "Caption for bolus screen notice when pump data is missing or stale"), appName)),
+                caption: Text(String(format: NSLocalizedString("Your pump data is stale. Bolus delivery may be unavailable.", comment: "Caption for bolus screen notice when pump data is stale"), appName)),
                 severity: .critical
+            )
+        case .noPumpConnected:
+            return WarningView(
+                title: Text("No Pump Connected", comment: "Title for bolus screen notice when no pump is connected"),
+                caption: Text(NSLocalizedString("No pump is connected. Bolus delivery is unavailable.", comment: "Caption for bolus screen notice when no pump is connected"))
             )
         case .predictedGlucoseInRange, .glucoseBelowTarget:
             return WarningView(

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -823,7 +823,7 @@ fileprivate class MockLoopState: LoopState {
     var totalRetrospectiveCorrection: HKQuantity?
     
     var predictGlucoseValueResult: [PredictedGlucoseValue] = []
-    func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool) throws -> [PredictedGlucoseValue] {
+    func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool, requireRecentPumpData: Bool) throws -> [PredictedGlucoseValue] {
         return predictGlucoseValueResult
     }
 
@@ -947,6 +947,8 @@ fileprivate class MockBolusEntryViewModelDelegate: BolusEntryViewModelDelegate {
     var mostRecentPumpDataDate: Date?
     
     var isPumpConfigured: Bool = true
+    
+    var shouldModelAsNoDelivery: Bool = false
     
     var preferredGlucoseUnit: HKUnit = .milligramsPerDeciliter
     


### PR DESCRIPTION
## Show predicted glucose and bolus recommendation when no active delivery device is paired

Closes #2445

### Overview

When no active pod is paired, for example during a pod change or after a pod fault, Loop suppresses both the predicted glucose curve and the bolus recommendation entirely. This happens because the pump data recency check throws an error when no pod is active, since `doseStore.lastAddedPumpData` returns `.distantPast`, which always exceeds `inputDataRecencyInterval`.

This PR decouples the visualization and bolus recommendation paths from the pump recency check when no active delivery device is detected, while preserving the original conservative behavior when a pod is paired but temporarily out of communication.

### Approach

A new computed property `shouldModelAsNoDelivery` is added as an extension on `PumpManagerStatus` in LoopKit. This property returns `true` when `basalDeliveryState == .active(.distantPast)`, which is the sentinel value used by both `OmniBLEPumpManager` and `OmnipodPumpManager` to indicate no active pod is paired. I chose this approach to keep the detection logic in one place, close to the data it depends on, and avoid scattering pump-specific logic across the codebase. This was the least disruptive way I found to introduce this change.

For pump types that do not use this sentinel (`.active(.distantPast)`) (e.g. Medtronic/RileyLink), `shouldModelAsNoDelivery` will never return `true` as long as those pumps have a `pumpManager` with any `pumpStatus`. When no pump manager is present at all, the property defaults to `true` which treats the state of an unconfigured pump as no delivery.

### Changes

**`PumpManagerStatus` extension**
- Adds `shouldModelAsNoDelivery: Bool` computed property based on `basalDeliveryState`

**Prediction curve**
- Adds `requireRecentPumpData` parameter (default `true`) to `predictGlucose` in `LoopDataManager`, preserving existing behavior for all other call sites. (Not sure if this was necessary but it felt safest).
- When `shouldModelAsNoDelivery` is `true`, the suspension of insulin delivery effect is automatically included in the prediction, since no basal is being delivered
- The main status chart, bolus entry chart, manual dose chart, and predicted glucose chart all reflect this updated prediction
- Automated dosing recommendations remain fully gated on pump data recency. `updatePredictedGlucoseAndRecommendedDose` returns early before computing a dose recommendation when pump data is stale

**Bolus recommendation**
- When `shouldModelAsNoDelivery` is `true`, the full prediction-based bolus recommendation algorithm runs using the suspension-adjusted prediction curve, bypassing the pump recency check
- When a pod is paired but data is stale (temporary communication gap), the original conservative behavior is preserved. The recommendation is blocked and the existing "No Recent Pump Data" warning is shown
- A new `noPumpConnected` notice is surfaced on the bolus screen, distinct from `stalePumpData`, to clearly communicate the context to the user

**Predicted Glucose chart**
- When `shouldModelAsNoDelivery` is `true`, the Suspension of Insulin Delivery row in the prediction modification selection picker is shown as active, grayed out, non-interactive, and checked, since it reflects reality rather than a hypothetical
- The subtitle message is updated on the row to explain why it is applied automatically
- The alternate prediction line is hidden when it would be identical to the base prediction to avoid rendering a redundant overlapping line

**Warning text**
- Updated the `stalePumpData` warning caption to no longer claim a recommendation cannot be made
- Added a new `noPumpConnected` warning case distinct from `stalePumpData`

### Affected files

- `Loop/Managers/LoopDataManager.swift`
- `Loop/View Models/BolusEntryViewModel.swift`
- `Loop/View Models/ManualEntryDoseViewModel.swift`
- `Loop/View Controllers/PredictionTableViewController.swift`
- `Loop/Views/BolusEntryView.swift`
- `Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift`
- `LoopTests/ViewModels/BolusEntryViewModelTests.swift`

### Testing

- Tested with no pod paired (between pod changes)
- Tested with pod faulted prior to expiry
- Tested with pod paired and data stale (temporary communication gap)
- Tested with pod paired and data fresh
- Existing automated dosing behavior verified unchanged in all states
- Only tested on Omnipod Dash. See RFC section below

### RFC / Acknowledgements

**Detection mechanism**

As mentioned above, the `shouldModelAsNoDelivery` property relies on the `.active(.distantPast)` sentinel value used by `OmniBLEPumpManager` and `OmnipodPumpManager` to signal no active pod. This is an implementation detail rather than a formally documented contract, and could theoretically change without warning. It is also specific to pod-based pump managers. Tube pumps that do not use this sentinel should be unaffected by this change.

A cleaner long-term solution would be to add `shouldModelAsNoDelivery` directly to the `PumpManager` protocol in LoopKit with a default implementation of `false`, allowing each pump manager to explicitly opt in based on its own internal state. This was considered but deferred to keep the scope of this PR contained to the Loop repo. Feedback on whether that approach is preferred is requested and more than welcome.

**Default behavior when no pump manager is present**

When `pumpManagerStatus` is `nil` (no pump configured at all), `shouldModelAsNoDelivery` defaults to `true`. This means the feature also activates in the fully unconfigured state, which I felt to be a more useful default, though I honestly can't envision users commonly using Loop without a configured pump/pumpManager. Therefore a user with no pump configured still benefits from seeing a prediction. If the reviewers prefer `false` in this case, I'm open to that, as it is a one-line modification to adjust the behavior on what *I think* is an edge-case, but please let me know!

**Non-Omnipod pump testing**

This change has only been tested live with Omnipod Dash. Contributions from users of other pump types, particularly those that might use or be aware of other causes of `.active(.distantPast)` in unexpected ways, are welcome, as the codebase only has 2 (now 3) references to that combination.

### Screenshots

**Note:** some of the below screenshots include 2 visual-only modifications to the prediction line color (signaling above/below ranges) and a thin red vertical bar that shows the current time across all charts. Those changes are from some of my very old personal features and they are not included in this PR.

dashboardActualStandardWithPodState 
<img width="603" height="1311" alt="dashboardActualStandardWithPodState" src="https://github.com/user-attachments/assets/e161c5fe-f39d-4bf4-bdcd-2258567f3d75" />
dashboardNoInsulinActual
(disregard hidden video marker)
<img width="603" height="1311" alt="dashboardNoInsulinActual" src="https://github.com/user-attachments/assets/6254723f-dc39-4022-8cb9-47b9232125b9" />
dashboardNoPodActual_predictionsReflectingUpdates
<img width="603" height="1311" alt="dashboardNoPodActual_predictionsReflectingUpdates" src="https://github.com/user-attachments/assets/52c56ab3-deaa-44b1-bd5b-66405af82c48" />
dashboardNoPodActual
<img width="603" height="1311" alt="dashboardNoPodActual" src="https://github.com/user-attachments/assets/4a7a71df-1a1d-465a-9f6e-ab4d8acdf7f0" />
dashboardPredictionLineSimulatorNoPumpConfigured
<img width="439" height="396" alt="dashboardPredictionLineSimulatorNoPumpConfigured" src="https://github.com/user-attachments/assets/9a4ebaac-15d6-4663-a1d9-89a479dcfb20" />
predictionsActual
<img width="603" height="1311" alt="predictionsActual" src="https://github.com/user-attachments/assets/94879f41-a772-437e-a888-6bb453d77151" />

