### PR TITLE
Fix Live Activity cooperative-pool starvation deadlock

### DIFF
--- a/Loop/Managers/Live Activity/LiveActivityManager.swift
+++ b/Loop/Managers/Live Activity/LiveActivityManager.swift
@@ -103,7 +103,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
             let statusContext = UserDefaults.appGroup?.statusExtensionContext
             let glucoseFormatter = NumberFormatter.glucoseFormatter(for: unit)
             
-            let glucoseSamples = self.getGlucoseSample(unit: unit)
+            let glucoseSamples = await self.getGlucoseSample(unit: unit)
             guard let currentGlucose = glucoseSamples.last else {
                 print("ERROR: No glucose sample found...")
                 return
@@ -118,7 +118,7 @@ class LiveActivityManager : LiveActivityManagerProxy {
                 delta = "\(deltaValue < 0 ? "-" : "+")\(glucoseFormatter.string(from: abs(deltaValue)) ?? "??")"
             }
             
-            let bottomRow = self.getBottomRow(
+            let bottomRow = await self.getBottomRow(
                 currentGlucose: current,
                 delta: delta,
                 statusContext: statusContext,
@@ -308,53 +308,43 @@ class LiveActivityManager : LiveActivityManagerProxy {
         }
     }
     
-    private func getInsulinOnBoard() -> String {
-        let updateGroup = DispatchGroup()
-        var iob = "??"
-        
-        updateGroup.enter()
-        self.doseStore.insulinOnBoard(at: Date.now) { result in
-            switch (result) {
-            case .failure:
-                break
-            case .success(let iobValue):
-                iob = self.iobFormatter.string(from: iobValue.value) ?? "??"
-                break
+    private func getInsulinOnBoard() async -> String {
+        // NOTE: Do NOT bridge async→sync with DispatchGroup.wait(.distantFuture) here.
+        // update() runs on a Swift Concurrency cooperative-pool thread; blocking that
+        // thread starves the (core-count-sized) pool and can deadlock the whole
+        // concurrency runtime under repeated Live Activity updates. Suspend instead.
+        return await withCheckedContinuation { continuation in
+            self.doseStore.insulinOnBoard(at: Date.now) { result in
+                switch (result) {
+                case .failure:
+                    continuation.resume(returning: "??")
+                case .success(let iobValue):
+                    continuation.resume(returning: self.iobFormatter.string(from: iobValue.value) ?? "??")
+                }
             }
-            
-            updateGroup.leave()
         }
-        
-        _ = updateGroup.wait(timeout: .distantFuture)
-        return iob
     }
-    
-    private func getGlucoseSample(unit: HKUnit) -> [StoredGlucoseSample] {
-        let updateGroup = DispatchGroup()
-        var samples: [StoredGlucoseSample] = []
-        
-        updateGroup.enter()
-        
+
+    private func getGlucoseSample(unit: HKUnit) async -> [StoredGlucoseSample] {
         // When in spacious mode, we want to show the predictive line
         // In compact mode, we only want to show the history
         let timeInterval: TimeInterval = self.settings.addPredictiveLine ? .hours(-2) : .hours(-6)
-        self.glucoseStore.getGlucoseSamples(
-            start: adjustedChartStart(Date.now.addingTimeInterval(timeInterval)),
-            end: Date.now
-        ) { result in
-            switch (result) {
-            case .failure:
-                break
-            case .success(let data):
-                samples = data
-                break
+
+        // NOTE: See getInsulinOnBoard() — never block the cooperative pool with a
+        // DispatchGroup.wait here; suspend the async task instead.
+        return await withCheckedContinuation { continuation in
+            self.glucoseStore.getGlucoseSamples(
+                start: adjustedChartStart(Date.now.addingTimeInterval(timeInterval)),
+                end: Date.now
+            ) { result in
+                switch (result) {
+                case .failure:
+                    continuation.resume(returning: [])
+                case .success(let data):
+                    continuation.resume(returning: data)
+                }
             }
-            
-            updateGroup.leave()
         }
-        
-        _ = updateGroup.wait(timeout: .distantFuture)
-        return samples
     }
     
     // If the chart start falls past the half-hour mark (HH:31–HH:59), pull it back to HH:30
@@ -490,43 +480,45 @@ class LiveActivityManager : LiveActivityManagerProxy {
         return glucoseRanges
     }
     
-    private func getBottomRow(currentGlucose: Double, delta: String, statusContext: StatusExtensionContext?, glucoseFormatter: NumberFormatter) -> [BottomRowItem] {
-        return self.settings.bottomRowConfiguration.map { type in
+    private func getBottomRow(currentGlucose: Double, delta: String, statusContext: StatusExtensionContext?, glucoseFormatter: NumberFormatter) async -> [BottomRowItem] {
+        var items: [BottomRowItem] = []
+        for type in self.settings.bottomRowConfiguration {
             switch(type) {
             case .iob:
-                return BottomRowItem.generic(label: type.name(), value: getInsulinOnBoard(), unit: "U")
-                
+                items.append(BottomRowItem.generic(label: type.name(), value: await getInsulinOnBoard(), unit: "U"))
+
             case .cob:
                 var cob: String = "0"
                 if let cobValue = statusContext?.carbsOnBoard {
                     cob = self.cobFormatter.string(from: cobValue) ?? "??"
                 }
-                return BottomRowItem.generic(label: type.name(), value: cob, unit: "g")
-                
+                items.append(BottomRowItem.generic(label: type.name(), value: cob, unit: "g"))
+
             case .basal:
                 guard let netBasalContext = statusContext?.netBasal else {
-                    return BottomRowItem.basal(rate: 0, percentage: 0)
+                    items.append(BottomRowItem.basal(rate: 0, percentage: 0))
+                    continue
                 }
+                items.append(BottomRowItem.basal(rate: netBasalContext.rate, percentage: netBasalContext.percentage))
 
-                return BottomRowItem.basal(rate: netBasalContext.rate, percentage: netBasalContext.percentage)
-                
             case .currentBg:
-                return BottomRowItem.currentBg(label: type.name(), value: "\(glucoseFormatter.string(from: currentGlucose) ?? "??")", trend: statusContext?.glucoseDisplay?.trendType)
-                
+                items.append(BottomRowItem.currentBg(label: type.name(), value: "\(glucoseFormatter.string(from: currentGlucose) ?? "??")", trend: statusContext?.glucoseDisplay?.trendType))
+
             case .eventualBg:
                 guard let eventual = statusContext?.predictedGlucose?.values.last else {
-                    return BottomRowItem.generic(label: type.name(), value: "??", unit: "")
+                    items.append(BottomRowItem.generic(label: type.name(), value: "??", unit: ""))
+                    continue
                 }
-                
-                return BottomRowItem.generic(label: type.name(), value: glucoseFormatter.string(from: eventual) ?? "??", unit: "")
-                
+                items.append(BottomRowItem.generic(label: type.name(), value: glucoseFormatter.string(from: eventual) ?? "??", unit: ""))
+
             case .deltaBg:
-                return BottomRowItem.generic(label: type.name(), value: delta, unit: "")
-                
+                items.append(BottomRowItem.generic(label: type.name(), value: delta, unit: ""))
+
             case .updatedAt:
-                return BottomRowItem.generic(label: type.name(), value: timeFormatter.string(from: Date.now), unit: "")
+                items.append(BottomRowItem.generic(label: type.name(), value: timeFormatter.string(from: Date.now), unit: ""))
             }
-       }
+        }
+        return items
     }
     
     private func initEmptyActivity(settings: LiveActivitySettings) {


### PR DESCRIPTION
## Problem

`LiveActivityManager.getGlucoseSample(unit:)` and `getInsulinOnBoard()` bridge async work to sync using `DispatchGroup.wait(timeout: .distantFuture)`. Both are called from `update()`, whose body runs inside a `Task { … }` — i.e. on a **Swift Concurrency cooperative-pool thread**.

Blocking a cooperative-pool thread violates the pool's forward-progress guarantee. The pool is sized to the CPU core count. Each `update()` that reaches one of these methods parks a pool thread on the `.distantFuture` wait, while the inner `Task { await … }` that would call `.leave()` needs a pool thread to run. As `update()` calls stack up, every cooperative thread ends up parked and no thread is left to complete the inner work — the entire concurrency runtime wedges and **Loop stops looping**.

Note the blocking call is a read of Loop’s **local glucose store** (`glucoseStore.getGlucoseSamples`, backed by Core Data), not a fetch from the CGM — so this is independent of CGM type and glucose-fetch latency.

`update()` is **fire-and-forget with no concurrency limit**: `LoopDataManager.updateDisplayState()` calls it without `await`, and it just spawns a detached `Task` on the cooperative pool. It is driven by store-change notifications (`glucoseSamplesDidChange`, `valuesDidChange`, `carbEntriesDidChange`, preferences), not a timer. The pool self-heals while any thread is free, so the wedge requires a **burst** of pool-width-many overlapping calls — e.g. several `glucoseSamplesDidChange` from a glucose backfill, or glucose+dose+carb changing around one loop cycle. That is not a high steady rate; it just has to reach the pool width once. (The captured report showed exactly 6 such threads, matching the device core count.)

### Evidence (captured on device)

A forced report off a hung install showed **all** cooperative-pool threads (`com.apple.root.utility-qos.cooperative`) stuck identically:

```
LiveActivityManager.getGlucoseSample(unit:)
  → DispatchGroup.wait
    → _dispatch_group_wait_slow → __ulock_wait
```

…with the five `RemoteDataServicesManager` Nightscout upload queues blocked on semaphores behind them (their async completions also needed the starved pool). The main thread was idle in its run loop — the freeze was the concurrency runtime, not the UI thread. (The affected device was running a local BLE Libre CGM at the time; the deadlock does not depend on the CGM in use.)

## Fix

- Make `getGlucoseSample` and `getInsulinOnBoard` `async` and suspend via `withCheckedContinuation` instead of blocking. A never-firing completion now merely suspends the task — it can no longer starve the pool.
- Make `getBottomRow` `async` and iterate (instead of `.map`) so the IOB query stays **lazy** — issued only for the `.iob` row, exactly as before.
- Update the two call sites in `update()` to `await`.

No behavior change other than not blocking the cooperative pool.