### PR TITLE
Wire pump BLE heartbeat to CGM reading schedule; preserve device state on plugin-load miss

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -851,7 +851,17 @@ extension DeviceDataManager {
     }
 
     func updatePumpManagerBLEHeartbeatPreference() {
-        pumpManager?.setMustProvideBLEHeartbeat(pumpManagerMustProvideBLEHeartbeat)
+        guard pumpManagerMustProvideBLEHeartbeat else {
+            pumpManager?.setBLEHeartbeatRequest(nil)
+            return
+        }
+        // Tell the pump when the last CGM reading landed and how often readings are expected, so it can
+        // schedule its next heartbeat to arrive just after the next reading is due (the pump adds its own
+        // buffer for the remote CGM value to be fetched and stored).
+        let request = PumpHeartbeatRequest(
+            lastCGMReadingDate: glucoseStore.latestGlucose?.startDate,
+            expectedCGMReadingInterval: cgmManager?.expectedGlucoseSampleInterval ?? .minutes(5))
+        pumpManager?.setBLEHeartbeatRequest(request)
     }
 }
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -310,26 +310,40 @@ final class DeviceDataManager {
 
     func instantiateDeviceManagers() {
         if let pumpManagerRawValue = rawPumpManager ?? UserDefaults.appGroup?.legacyPumpManagerRawValue {
-            pumpManager = pumpManagerFromRawValue(pumpManagerRawValue)
-            // Update lastPumpEventsReconciliation on DoseStore
-            if let lastSync = pumpManager?.lastSync {
-                Task {
-                    try? await doseStore.addPumpEvents([], lastReconciliation: lastSync)
+            if let restoredPumpManager = pumpManagerFromRawValue(pumpManagerRawValue) {
+                pumpManager = restoredPumpManager
+                // Update lastPumpEventsReconciliation on DoseStore
+                if let lastSync = pumpManager?.lastSync {
+                    Task {
+                        try? await doseStore.addPumpEvents([], lastReconciliation: lastSync)
+                    }
                 }
-            }
-            if let status = pumpManager?.status {
-                updatePumpIsAllowingAutomation(status: status)
+                if let status = pumpManager?.status {
+                    updatePumpIsAllowingAutomation(status: status)
+                }
+            } else {
+                // We have saved pump state, but its plugin couldn't be instantiated in this build (e.g.
+                // the app was built without that pump manager plugin). Do NOT assign pumpManager = nil —
+                // that fires the didSet, which writes rawPumpManager = nil and DELETES the persisted
+                // PumpManagerState, permanently losing the pod pairing/session keys. Leave the saved
+                // state on disk so a build that includes the plugin can restore it on a later launch.
+                log.error("Saved pump manager plugin unavailable; preserving persisted PumpManagerState for a future launch")
             }
         } else {
             pumpManager = nil
         }
 
         if let cgmManagerRawValue = rawCGMManager ?? UserDefaults.appGroup?.legacyCGMManagerRawValue {
-            cgmManager = cgmManagerFromRawValue(cgmManagerRawValue)
-
-            // Handle case of PumpManager providing CGM
-            if cgmManager == nil && pumpManagerTypeFromRawValue(cgmManagerRawValue) != nil {
+            if let restoredCGMManager = cgmManagerFromRawValue(cgmManagerRawValue) {
+                cgmManager = restoredCGMManager
+            } else if pumpManagerTypeFromRawValue(cgmManagerRawValue) != nil {
+                // Handle case of PumpManager providing CGM
                 cgmManager = pumpManager as? CGMManager
+            } else {
+                // Saved CGM state exists but its plugin couldn't be instantiated in this build. Don't
+                // assign cgmManager = nil — that would delete the persisted CGMManagerState (same
+                // footgun as the pump path above). Preserve it for a future launch with the plugin.
+                log.error("Saved CGM manager plugin unavailable; preserving persisted CGMManagerState for a future launch")
             }
         }
     }


### PR DESCRIPTION
## Summary

Two small `DeviceDataManager` changes that complete the reading-aligned pump heartbeat and harden device-manager restoration.

> **Depends on** LoopKit/LoopKit#596 (`PumpHeartbeatRequest` / `setBLEHeartbeatRequest`). Merge that into LoopKit `next-dev` first.

## Changes

**Wire pump BLE heartbeat to the CGM reading schedule** — `updatePumpManagerBLEHeartbeatPreference()` now builds a `PumpHeartbeatRequest` from the latest stored glucose date and the CGM's `expectedGlucoseSampleInterval`, and calls `setBLEHeartbeatRequest`. This lets a pump manager schedule its background heartbeat to land just after the next CGM reading is expected — giving a network CGM time to store its value before the pod wakes Loop — instead of firing on a blind fixed interval. Passes `nil` when no heartbeat is wanted. The call is refreshed on the same triggers as the existing heartbeat preference update.

**Preserve persisted pump/CGM state when a plugin can't be instantiated** — if a pump/CGM plugin fails to load at startup, `instantiateDeviceManagers()` now leaves the persisted `PumpManagerState` / `CGMManagerState` untouched and logs the error, instead of assigning `nil`. Previously a transient plugin-load miss would trigger the `didSet` that **deletes the state plist**, silently losing a configured pump/CGM (LTK, keys) with no recovery. State is only replaced when a manager is successfully restored.

Both commits touch only `Loop/Managers/DeviceDataManager.swift` (+37/-13).
