### PR TITLE
Fix race in testRescheduleMutedLoopNotLoopingAlerts

### DIFF
--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -315,9 +315,14 @@ class AlertManagerTests: XCTestCase {
         
         let lastLoopDate = Date()
         await alertManager.loopDidComplete(lastLoopDate)
-        alertManager.alertMuter.configuration.startTime = Date()
-        alertManager.alertMuter.configuration.duration = .hours(4)
-        
+
+        // Turn on muting, then reschedule the loop-not-running alerts as muted.
+        // In production this reschedule is driven asynchronously by the
+        // alertMuter.$configuration sink (RunLoop.main hop + a detached Task), so
+        // await it directly here rather than racing that pipeline.
+        alertManager.alertMuter.configuration = AlertMuter.Configuration(startTime: Date(), duration: .hours(4))
+        await alertManager.rescheduleLoopNotRunningNotifications(lastLoopDate)
+
         let loopNotRunningRequests = await UNUserNotificationCenter.current().pendingNotificationRequests().filter({
             $0.content.categoryIdentifier == LoopNotificationCategory.loopNotRunning.rawValue
         })


### PR DESCRIPTION
### Summary

`AlertManagerTests.testRescheduleMutedLoopNotLoopingAlerts` is intermittently failing (fails reliably on some machines).

The test mutates the alert muter configuration and then immediately reads the pending loop-not-running notifications, expecting them to be muted. But in production the reschedule that mutes those notifications is driven **asynchronously** by the `alertMuter.$configuration` sink — a `.receive(on: RunLoop.main)` hop followed by a fire-and-forget `Task` (`AlertManager.swift`). So the test reads the still-unmuted notifications before the reschedule lands, and the muted-sound assertion (`XCTAssertNil(...timeSensitive...sound)`) fails.

### Change

Test-only. Enable muting and then `await alertManager.rescheduleLoopNotRunningNotifications(lastLoopDate)` directly, so the assertions observe the muted state deterministically instead of racing the async pipeline. No production behavior change.

### Testing

`AlertManagerTests` — 20 tests, 0 failures (previously 1 failure). Verified on a fresh simulator boot; the target test passes at ~0.1s.