### PR TITLE
Wire pump BLE heartbeat to the CGM reading schedule (dev backport)

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -930,7 +930,17 @@ extension DeviceDataManager {
     }
 
     func updatePumpManagerBLEHeartbeatPreference() {
-        pumpManager?.setMustProvideBLEHeartbeat(pumpManagerMustProvideBLEHeartbeat)
+        guard pumpManagerMustProvideBLEHeartbeat else {
+            pumpManager?.setBLEHeartbeatRequest(nil)
+            return
+        }
+        // Tell the pump when the last CGM reading landed and how often readings are expected, so it can
+        // schedule its next heartbeat to arrive just after the next reading is due (the pump adds its own
+        // buffer for the remote CGM value to be fetched and stored).
+        let request = PumpHeartbeatRequest(
+            lastCGMReadingDate: glucoseStore.latestGlucose?.startDate,
+            expectedCGMReadingInterval: cgmManager?.expectedGlucoseSampleInterval ?? .minutes(5))
+        pumpManager?.setBLEHeartbeatRequest(request)
     }
 }
 


### PR DESCRIPTION
### Summary

Backports the Loop-side heartbeat wiring to the **dev** line (dev counterpart of #2469 on `next-dev`). When a pump must provide its own BLE heartbeat, Loop now sends it a `PumpHeartbeatRequest` — the last CGM reading date + expected reading interval — so the pump can schedule its next heartbeat to arrive just after the next reading is due. When the CGM can wake the app itself, it sends `nil`.

Single change in `updatePumpManagerBLEHeartbeatPreference()` (`DeviceDataManager.swift`), swapping the old `setMustProvideBLEHeartbeat(_:)` call for the new `setBLEHeartbeatRequest(_:)`. `processCGMReadingResult` already calls this method after every reading, so the pump's heartbeat cadence tracks the actual CGM schedule.

### Dependency

⚠️ Requires the LoopKit `setBLEHeartbeatRequest` / `PumpHeartbeatRequest` API on dev — **LoopKit/LoopKit#599** (dev backport of #596). This will not compile on stock dev until #599 merges.

### Testing

Built in a `LoopKit/LoopWorkspace@dev` workspace with LoopKit#599 applied and OmnipodKit on loopandlearn `ble-heartbeat` (LoopWorkspace scheme, iOS simulator): **BUILD SUCCEEDED, 0 errors**.