### PR TITLE
bump WATCHOS_DEPLOYMENT_TARGET to 9.0 to match LoopKit

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -4300,7 +4300,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wall";
-				WATCHOS_DEPLOYMENT_TARGET = 7.1;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -4412,7 +4412,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				WARNING_CFLAGS = "-Wall";
-				WATCHOS_DEPLOYMENT_TARGET = 7.1;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Purpose

Enable update_dev_to_3.14.4 to build after I failed to do one final test of the build before pushing

## Method

This PR makes the WATCHOS_DEPLOYMENT_TARGET match that of the current LoopKit dev branch.