### PR TITLE
Watch: give GlucoseStore its own Core Data stack

### DIFF
--- a/LoopCore/PersistenceController.swift
+++ b/LoopCore/PersistenceController.swift
@@ -21,13 +21,13 @@ extension PersistenceController {
         return self.init(directoryURL: directoryURL.appendingPathComponent("com.loopkit.LoopKit", isDirectory: true), isReadOnly: isReadOnly)
     }
 
-    public class func controllerInLocalDirectory() -> PersistenceController {
+    public class func controllerInLocalDirectory(named name: String = "com.loopkit.LoopKit") -> PersistenceController {
         guard let directoryURL = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true) else {
             fatalError("Could not access the document directory of the current process")
         }
 
         let isReadOnly = Bundle.main.isAppExtension
 
-        return self.init(directoryURL: directoryURL.appendingPathComponent("com.loopkit.LoopKit"), isReadOnly: isReadOnly)
+        return self.init(directoryURL: directoryURL.appendingPathComponent(name), isReadOnly: isReadOnly)
     }
 }

--- a/WatchApp Extension/Managers/LoopDataManager.swift
+++ b/WatchApp Extension/Managers/LoopDataManager.swift
@@ -111,10 +111,17 @@ class LoopDataManager {
             loopSettings: LoopSettings(),
             scheduleOverride: nil
         )
-        
+
+        // Give GlucoseStore its own Core Data stack rather than sharing `cacheStore` with
+        // CarbStore. GlucoseStore drives its context exclusively with the async
+        // `context.perform` API, while CarbStore uses `performAndWait`. Sharing one serial
+        // context between the two mixes those concurrency models and can race, producing a
+        // torn read of a freshly-inserted CachedGlucoseObject (a nil required attribute).
+        // A dedicated context removes that cross-store contention.
+        let glucoseCacheStore = PersistenceController.controllerInLocalDirectory(named: "com.loopkit.LoopKit.Glucose")
         Task {
             glucoseStore = await GlucoseStore(
-                cacheStore: cacheStore,
+                cacheStore: glucoseCacheStore,
                 cacheLength: .hours(4)
             )
         }


### PR DESCRIPTION
## Summary

On the watch, `CarbStore` and `GlucoseStore` are constructed with the **same** `PersistenceController` (one shared `NSManagedObjectContext`). But the two stores drive that context with **different concurrency models**:

- `GlucoseStore` → async `context.perform { }`
- `CarbStore` → `queue.async { context.performAndWait { } }`

Mixing the Swift-async `perform` with GCD-dispatched `performAndWait` on a single serial context lets the two overlap, which can produce a **torn read of a freshly-inserted `CachedGlucoseObject`** — a required attribute (`startDate`) reads `nil`, and the app crashes bridging it:

```
Foundation: Date._unconditionallyBridgeFromObjectiveC(NSDate?) -> Date   (brk 1)
  ← LoopKit: closure (CachedGlucoseObject) -> StoredGlucoseSample  @ GlucoseStore.swift:324
  ← CoreData: _developerSubmittedBlockToNSManagedObjectContextPerform  (await context.perform)
```

This was confirmed by two crash reports symbolicated end-to-end (system frames via matching watchOS DeviceSupport, LoopKit frames via the exact build dSYM). It matches the observed behavior: **intermittent, and it disappears under the Xcode debugger** (the debugger reschedules threads and closes the race window). It also explains the paradox that `create()` sets `startDate` and `save()` (which validates the required attribute) succeeds two lines before the nil read — only a *concurrent* mutation of the shared context can do that within one block.

## Fix

Give `GlucoseStore` its **own** Core Data stack on the watch so it never shares a context with `CarbStore`.

- `LoopCore/PersistenceController.swift`: `controllerInLocalDirectory(named:)` gains a defaulted `name` parameter (`"com.loopkit.LoopKit"`), so every existing caller is unchanged.
- `WatchApp Extension/Managers/LoopDataManager.swift`: the watch glucose store now uses `controllerInLocalDirectory(named: "com.loopkit.LoopKit.Glucose")`.

After this, the shared context has only `CarbStore` (all `performAndWait`), and glucose has a dedicated context driven only by async `perform` (the HealthKit `performAndWait` paths are dormant on the watch — no `hkSampleStore`). Neither context mixes concurrency models, so the cross-store race is gone.

## Caveat

Existing watch users' cached glucose lives in the shared `com.loopkit.LoopKit` store; after this change the glucose store reads from a new `com.loopkit.LoopKit.Glucose` directory and starts empty, re-backfilling from the phone on next launch. This is harmless — the watch glucose cache is ephemeral (4h) and re-populated via the existing backfill request.

## Notes / follow-ups (not in this PR)

- No defensive/guard code is included here by request — this is purely the structural change.
- Related hygiene worth a separate look: `NSManagedObjectContext.purgeObjects` combines a batch delete with `mergeChanges(fromRemoteContextSave:)` **and** `refreshAllObjects()` on the same context; and `GlucoseStore.saveSamplesToHealthKit` reads managed objects (`quantitySample`) outside their `perform` block (iOS-only path).

## Test plan

- Builds clean (Loop scheme).
- Watch app launches, receives WatchConnectivity context/backfill, renders glucose, and adds new samples without the intermittent `startDate` crash.
