### PR TITLE
Carb absorption review: use mid-absorption ISF to match the algorithm

### DIFF
--- a/Loop/Managers/LoopDataManager+CarbAbsorption.swift
+++ b/Loop/Managers/LoopDataManager+CarbAbsorption.swift
@@ -70,7 +70,13 @@ extension LoopDataManager {
         // Overlay basal history on basal doses, splitting doses to get amount delivered relative to basal
         let annotatedDoses = doses.annotated(with: basalWithOverrides)
 
-        let insulinEffects = annotatedDoses.glucoseEffects(
+        // Use the standard mid-absorption ISF model — matching LoopAlgorithm's
+        // prediction path (useMidAbsorptionISF) — so this review's carb
+        // absorption agrees with the home-screen COB. Dose-time `glucoseEffects`
+        // is kept only for backwards compatibility; when it and the algorithm
+        // disagreed, an ISF-changing override made the carb screen and the
+        // home screen show different COB.
+        let insulinEffects = annotatedDoses.glucoseEffectsMidAbsorptionISF(
             insulinSensitivityHistory: sensitivityWithOverrides,
             from: start.addingTimeInterval(-CarbMath.maximumAbsorptionTimeInterval).dateFlooredToTimeInterval(GlucoseMath.defaultDelta),
             to: nil)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1549,7 +1549,10 @@ extension LoopDataManager: FavoriteFoodInsightsViewModelDelegate {
             .annotated(with: basalWithOverrides)
             .sorted { $0.startDate < $1.startDate }
 
-        let insulinEffects = annotatedDoses.glucoseEffects(
+        // Standard mid-absorption ISF model, matching LoopAlgorithm's prediction
+        // path — keeps this review's carb absorption consistent with the
+        // algorithm (dose-time `glucoseEffects` is legacy backwards-compat).
+        let insulinEffects = annotatedDoses.glucoseEffectsMidAbsorptionISF(
             insulinSensitivityHistory: sensitivityWithOverrides,
             from: start.addingTimeInterval(-CarbMath.maximumAbsorptionTimeInterval).dateFlooredToTimeInterval(GlucoseMath.defaultDelta),
             to: nil)


### PR DESCRIPTION
## Problem

Reported on next-dev 3.15.1: after a carb entry + bolus and then activating an `insulinNeedsScaleFactor` preset (e.g. "Prevent Rollercoaster", scale 0.15), the **carb screen showed the meal still largely unabsorbed (~14 g of 50 g)** while the **home screen showed Active Carbs = 0** and a forecast driven purely by IOB.

## Cause

Two different insulin-effect models feed carb absorption:

- **Home screen COB / forecast** → `LoopAlgorithm.generatePrediction` with `useMidAbsorptionISF: true` → `glucoseEffectsMidAbsorptionISF` (ISF applied across the dose's absorption, `filterDateRange`).
- **Carb screen** (`fetchCarbAbsorptionReview` → `CarbAbsorptionViewController`) and **favorite-food insights** (`getHistoricalChartsData`) → legacy `glucoseEffects` (ISF fixed at `closestPrior(to: dose.startDate)`).

Both apply `sensitivityWithOverrides`, but only the algorithm's mid-absorption model lets an override's ISF change reshape the insulin effect of already-delivered insulin. With the 0.15 override, the effective ISF spikes (~57 → ~380 mg/dL/U) during the window, the algorithm's insulin counteraction inflates, and the dynamic carb absorption over-counts → COB collapses to 0. The review paths, still on dose-time ISF, don't see that and keep showing the carbs on board. Hence the screen-vs-home disagreement.

## Fix

Move both review paths onto the standard `glucoseEffectsMidAbsorptionISF` so carb absorption on the carb screen and favorite-food insights is computed the same way as `LoopAlgorithm`'s prediction. The screens now agree with home-screen COB. Dose-time `glucoseEffects` remains for backwards compatibility only.

## Scope

This is the **consistency** fix (the two views now match). It intentionally does **not** change the underlying mid-absorption behavior under an ISF-changing override — that's the standard model (an activity override legitimately re-weights delivered insulin). The separate design question — that `insulinNeedsScaleFactor` is dual-use (real sensitivity vs. dosing aggressiveness), so an extreme/`>1` scale factor with active carbs can mis-attribute absorption (and in the `>1` direction manufacture phantom COB → over-dose) — is noted for a follow-up discussion, not addressed here.

## Test plan

- Builds clean.
- With an ISF-changing override active during carb absorption, the carb screen / favorite-food insights and the home-screen COB now show the same absorption.
