### PR TITLE
Fix Last Bolus footer leaking onto Glucose/Carbs charts via cell reuse

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -888,8 +888,15 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
             if let indexPath = tableView.indexPath(for: cell) {
                 self.tableView(tableView, updateSubtitleFor: cell, at: indexPath)
-                if Section(rawValue: indexPath.section)! == .charts && ChartRow(rawValue: indexPath.row)! == .iob {
-                    cell.setFooterView(content: iobFooterViewContent)
+                if Section(rawValue: indexPath.section)! == .charts {
+                    // Only the Active Insulin (.iob) chart carries the "Last Bolus" footer. Clear it
+                    // on every other chart row so a recycled cell can't drag a stale footer onto the
+                    // Glucose/Carbs rows.
+                    if ChartRow(rawValue: indexPath.row)! == .iob {
+                        cell.setFooterView(content: iobFooterViewContent)
+                    } else {
+                        clearChartFooter(cell)
+                    }
                 }
             }
         }
@@ -1013,6 +1020,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 cell.setTitleLabelText(label: NSLocalizedString("Glucose", comment: "The title of the glucose and prediction graph"))
                 cell.setTitleTextColor(color: ChartColorPalette.primary.glucoseTint)
                 cell.doesNavigate = settingsManager.dosingEnabled || !FeatureFlags.simpleBolusCalculatorEnabled
+                clearChartFooter(cell)
             case .iob:
                 cell.setSupplementalChartGenerator(generator: { [weak self] (frame) in
                     return self?.statusCharts.doseChart(withFrame: frame)?.view
@@ -1030,6 +1038,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 })
                 cell.setTitleLabelText(label: NSLocalizedString("Active Carbohydrates", comment: "The title of the Carbs On-Board graph"))
                 cell.setTitleTextColor(color: ChartColorPalette.primary.carbTint)
+                clearChartFooter(cell)
             }
 
             self.tableView(tableView, updateSubtitleFor: cell, at: indexPath)
@@ -1159,6 +1168,14 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 .padding(.vertical)
                 .accessibilityIdentifier("text_ActiveInsulinFooter")
         }
+    }
+
+    /// Clears any footer from a (possibly recycled) chart cell. Uses the hide branch of
+    /// `setFooterView`, which keeps the hosting controller in place so the Active Insulin row
+    /// can still re-populate its "Last Bolus" footer — while preventing that footer from
+    /// leaking onto the Glucose/Carbs rows through cell reuse.
+    private func clearChartFooter(_ cell: ChartTableViewCell) {
+        cell.setFooterView(content: nil as (() -> EmptyView)?)
     }
 
     private func tableView(_ tableView: UITableView, updateSubtitleFor cell: ChartTableViewCell, at indexPath: IndexPath) {


### PR DESCRIPTION
## Problem

Users on next-dev see a "Last Bolus" line under **all three** home-screen charts (Glucose, Active Insulin, Active Carbs), each showing a *different* and often wrong value/time — including future-dated ones (e.g. a bolus "at 20:05" when it's 14:35, i.e. actually yesterday's).

The "Last Bolus" footer (last **manual** bolus, `loopManager.lastManualBolus`) is intended for the **Active Insulin** chart only — it's set exclusively on the `.iob` `ChartTableViewCell` (`accessibilityIdentifier "text_ActiveInsulinFooter"`). It appears on the other two charts because of **cell reuse**:

- The footer is only ever *added* to the `.iob` cell.
- The `.glucose` and `.cob` (carbs) configuration paths never clear it, and `ChartTableViewCell.prepareForReuse()` doesn't reset it either.
- So when a recycled `ChartTableViewCell` that previously served the Active Insulin row is dequeued for the Glucose or Carbs row, it drags its old footer along.

And because the footer is a **static SwiftUI `Text` snapshot** captured when that physical cell was last the `.iob` row, each pooled cell shows a *frozen* `lastManualBolus` from a different past moment — which is why the three lines show three different, stale bolus values.

## Fix

Clear the footer on every non-`.iob` chart-cell configuration path — the `.glucose` and `.cob` cases in `cellForRowAt`, and the in-place update in `redrawCharts()` — via a small `clearChartFooter(_:)` helper. It uses `setFooterView`'s existing hide branch (`content: nil`), which keeps the hosting controller in place so the Active Insulin row still populates its footer normally.

Result: "Last Bolus" shows **only** under Active Insulin, with the current value.

## Notes / alternatives

- Root cause is arguably in `LoopKit`'s `ChartTableViewCell.prepareForReuse()` (it should reset its own footer). I kept the fix in Loop since the footer is a Loop-owned feature and this leaves the shared cell untouched — happy to move it to a `prepareForReuse` guard in LoopKit instead if you'd prefer the framework-level fix.
- Separately/cosmetically: "Last Bolus:" renders in English within an otherwise-localized UI because that string's translations are empty in `Localizable.xcstrings` — not addressed here.

Compile-verified (Loop scheme, iPhone 17 sim, `** BUILD SUCCEEDED **`).
