### PR TITLE
Mark two removed pre-meal strings stale in the catalog

### DIFF
--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -40331,6 +40331,7 @@
     },
     "Until I enter carbs" : {
       "comment" : "The title of a target alert action specifying pre-meal targets duration for 1 hour or until the user enters carbs (whichever comes first).",
+      "extractionState" : "stale",
       "localizations" : {
         "da" : {
           "stringUnit" : {
@@ -40607,6 +40608,7 @@
     },
     "Use Pre-Meal Preset" : {
       "comment" : "The title of the alert controller used to select a duration for pre-meal targets",
+      "extractionState" : "stale",
       "localizations" : {
         "da" : {
           "stringUnit" : {


### PR DESCRIPTION
`"Until I enter carbs"` and `"Use Pre-Meal Preset"` are no longer referenced anywhere in source — `grep` across the tree finds nothing — so Xcode marks them stale on extraction. Their existing translations are left in place; only the marker is added.

Two lines. This is the whole of what a build currently leaves uncommitted in this repo, so taking it stops the catalog showing as dirty after every build.

Build-regenerated, no hand edits. Raised by @marionbarker while testing LoopKit/LoopWorkspace#485.